### PR TITLE
feat(installer): docker run only — install.sh no longer sets up Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,47 +224,6 @@ MySQL, Redis, and MongoDB.
 
 ---
 
-## Feature Comparison
-
-| Feature                          |    Miabi    |  Coolify  | Dokploy  | CapRover |
-| -------------------------------- | :---------: | :-------: | :------: | :------: |
-| Self-hosted                      |     ✅      |    ✅     |    ✅    |    ✅    |
-| Open Source                      | ✅  |    ✅     |    ✅    |    ✅    |
-| Web UI                           |     ✅      |    ✅     |    ✅    |    ✅    |
-| Shared hosting                   |     ✅      |    ❌     |    ❌    |    ❌    |
-| CLI                              |     ✅      |    ❌     |    ❌    |    ❌    |
-| REST API                         |     ✅      |    ✅     | Partial  | Limited  |
-| OpenAPI Documentation            |     ✅      |    ❌     |    ❌    |    ❌    |
-| Multi-tenancy                    |     ✅      |    ❌     |    ❌    |    ❌    |
-| Workspace Isolation              |     ✅      |    ❌     |    ❌    |    ❌    |
-| Organizations & Teams            |     ✅      |  Limited  |    ❌    |    ❌    |
-| RBAC                             |     ✅      |  Limited  |    ❌    |    ❌    |
-| Deploy from Git                  |     ✅      |    ✅     |    ✅    |    ✅    |
-| Deploy Docker Images             |     ✅      |    ✅     |    ✅    |    ✅    |
-| Marketplace / Templates          |     ✅      |    ✅     |    ✅    | Limited  |
-| Buildpacks (No Dockerfile)       |     ✅      |    ✅     |    ❌    |    ❌    |
-| Built-in Container Registry      |     ✅      |    ❌     |    ❌    |    ❌    |
-| Managed Databases                |     ✅      |    ✅     |    ✅    | Limited  |
-| Automatic HTTPS (Let's Encrypt)  |     ✅      |    ✅     |    ✅    |    ✅    |
-| Canary Deployments               |     ✅      |    ❌     |    ❌    |    ❌    |
-| Zero-downtime Deployments        |     ✅      |  Limited  | Limited  | Limited  |
-| Rollbacks                        |     ✅      |    ✅     | Limited  | Limited  |
-| CI/CD Pipelines                  |     ✅      |    ❌     |    ❌    |    ❌    |
-| GitOps                           |     ✅      |    ❌     |    ❌    |    ❌    |
-| Multi-node Deployments           |     ✅      |  Partial  | Partial  | Partial  |
-| Docker Swarm Support             |     ✅      |    ✅     |    ✅    |    ❌    |
-| Docker Import                    |     ✅      |    ❌     |    ❌    |    ❌    |
-| Secrets Management               |     ✅      |  Partial  | Partial  | Limited  |
-| Monitoring                       | ✅ Built-in |   Basic   |  Basic   |  Basic   |
-| Scheduled Backups                |     ✅      |  Partial  | Partial  |    ❌    |
-| Audit Logs                       |     ✅      |    ❌     |    ❌    |    ❌    |
-| API Tokens                       |     ✅      |    ✅     |    ✅    |    ❌    |
-| OAuth / OIDC                     |     ✅      |  Partial  |    ❌    |    ❌    |
-| SAML / LDAP (Enterprise)         |     ✅      |    ❌     |    ❌    |    ❌    |
-| Terraform Provider               |     ✅      |    ❌     |    ❌    |    ❌    |
-
----
-
 ## Architecture
 
 ```
@@ -306,52 +265,44 @@ proxy that needs only an outbound connection and the local Docker socket.
 ## Quick Start
 
 Miabi runs as four containers — the control plane, PostgreSQL, Redis and the Goma
-gateway. You can have **Docker Compose** create them, or let **Miabi** create them
-itself. Both are supported; they differ in who owns the containers, and that decides
-whether Miabi can update itself.
+gateway. **The installer builds them itself**, straight against the Docker API; it does
+not use Docker Compose.
 
-| | Compose (default) | Stack |
-|---|---|---|
-| Containers created by | Docker Compose, from `/opt/miabi/compose.yaml` | Miabi, against the Docker API |
-| Desired state in | `compose.yaml` + `.env` | `/etc/miabi/stack.yaml` |
-| Upgrades | re-run the installer → `docker compose up -d` | `miabi update` — replaces Miabi's **own** container, rolling back if it fails |
+Compose owns what Compose created: a container Miabi recreated out-of-band would be
+silently reverted by the next `docker compose up -d`, so a Compose-managed Miabi could
+never truthfully update itself. Miabi owns these containers
+(`io.miabi.managed-by=miabi`), which is what makes `miabi update` — replacing even its
+own container, with rollback — possible.
 
-Compose owns what Compose created: if Miabi recreated one of its own containers, the
-next `docker compose up -d` would silently revert it. That is why self-update needs
-stack mode.
-
-### One-line install (production, Compose)
-
-Installs Docker if needed, fetches the production compose + config into
-`/opt/miabi`, generates secrets, and brings the stack up:
+### One-line install (production)
 
 ```bash
-curl -fsSL https://get.miabi.io | sudo bash
+curl -fsSL https://get.miabi.io | sudo MIABI_DOMAIN=miabi.example.com \
+  MIABI_ACME_EMAIL=you@example.com bash
 ```
 
-Prompts for your domain and ACME email (pass `MIABI_DOMAIN=` / `MIABI_ACME_EMAIL=`
-to skip the prompts — answering over a pipe is unreliable). Open your domain and sign
-in with the seeded platform admin.
-
-### Stack install (Miabi manages itself)
-
-```bash
-curl -fsSL https://get.miabi.io | sudo MIABI_INSTALL_MODE=stack \
-  MIABI_DOMAIN=miabi.example.com MIABI_ACME_EMAIL=you@example.com bash
-```
-
-Afterwards, manage it with the `miabi-stack` wrapper the installer drops:
+Installs Docker if missing, brings the stack up, writes `/etc/miabi/stack.yaml`, and
+prints the admin password. Then manage it with the `miabi-stack` wrapper it leaves
+behind:
 
 ```bash
 miabi-stack status                     # what is running, and its health
+miabi-stack restart                    # restart the stack, or one component
 MIABI_TAG=1.5.0 miabi-stack update     # roll forward (rolls back if it fails)
 miabi-stack uninstall                  # keeps your data; add --volumes to destroy it
 ```
 
+> [!NOTE]
+> The installer refuses to run on a host that already runs Miabi under Compose: the two
+> do not share volumes (`miabi_pgdata` vs `mb-platform-pgdata`), so it would create an
+> empty database beside your real one. Stay on Compose with
+> `docker compose pull && docker compose up -d`, or back up, `docker compose down`, and
+> re-run with `MIABI_FORCE_STACK=1`.
+
 ### `docker run` (no script)
 
 There is **no binary to install** — the Miabi image *is* the installer, since its
-entrypoint is the `miabi` binary. A stack install is one command:
+entrypoint is the `miabi` binary. A full install is one command:
 
 ```bash
 docker run --rm -it \
@@ -361,16 +312,15 @@ docker run --rm -it \
 ```
 
 The tag you invoke is the version you get: the image asks Docker for its own image
-reference, so a private registry works exactly like Docker Hub. `update`, `status` and
-`uninstall` are the same command with a different verb — and because the installer is
-an *ephemeral* container, it can replace the control plane without killing itself.
+reference, so a private registry works exactly like Docker Hub. `update`, `restart`,
+`status` and `uninstall` are the same command with a different verb — and because the
+installer is an *ephemeral* container, it can replace the control plane without killing
+itself.
 
 > [!WARNING]
-> Do not omit `-v /etc/miabi:/etc/miabi`. Without it the manifest — the only copy of
-> your database password and encryption key — is written inside the throwaway
-> container and lost when it exits. The install still reports success and the stack
-> comes up healthy, but you can never manage or upgrade it, and a re-install cannot
-> reopen the database.
+> Do not omit `-v /etc/miabi:/etc/miabi`. Miabi refuses to install without it: the
+> manifest — the only copy of your database password and encryption key — would be
+> written inside the throwaway container and lost when it exits.
 
 Docker must already be installed for this path; the installer script is what installs
 it for you.
@@ -492,7 +442,46 @@ backups, monitoring, marketplace, teams, and the admin platform.
 </table>
 
 ---
+## Feature Comparison
 
+| Feature                          |    Miabi    |  Coolify  | Dokploy  | CapRover |
+| -------------------------------- | :---------: | :-------: | :------: | :------: |
+| Self-hosted                      |     ✅      |    ✅     |    ✅    |    ✅    |
+| Open Source                      | ✅  |    ✅     |    ✅    |    ✅    |
+| Web UI                           |     ✅      |    ✅     |    ✅    |    ✅    |
+| Shared hosting                   |     ✅      |    ❌     |    ❌    |    ❌    |
+| CLI                              |     ✅      |    ❌     |    ❌    |    ❌    |
+| REST API                         |     ✅      |    ✅     | Partial  | Limited  |
+| OpenAPI Documentation            |     ✅      |    ❌     |    ❌    |    ❌    |
+| Multi-tenancy                    |     ✅      |    ❌     |    ❌    |    ❌    |
+| Workspace Isolation              |     ✅      |    ❌     |    ❌    |    ❌    |
+| Organizations & Teams            |     ✅      |  Limited  |    ❌    |    ❌    |
+| RBAC                             |     ✅      |  Limited  |    ❌    |    ❌    |
+| Deploy from Git                  |     ✅      |    ✅     |    ✅    |    ✅    |
+| Deploy Docker Images             |     ✅      |    ✅     |    ✅    |    ✅    |
+| Marketplace / Templates          |     ✅      |    ✅     |    ✅    | Limited  |
+| Buildpacks (No Dockerfile)       |     ✅      |    ✅     |    ❌    |    ❌    |
+| Built-in Container Registry      |     ✅      |    ❌     |    ❌    |    ❌    |
+| Managed Databases                |     ✅      |    ✅     |    ✅    | Limited  |
+| Automatic HTTPS (Let's Encrypt)  |     ✅      |    ✅     |    ✅    |    ✅    |
+| Canary Deployments               |     ✅      |    ❌     |    ❌    |    ❌    |
+| Zero-downtime Deployments        |     ✅      |  Limited  | Limited  | Limited  |
+| Rollbacks                        |     ✅      |    ✅     | Limited  | Limited  |
+| CI/CD Pipelines                  |     ✅      |    ❌     |    ❌    |    ❌    |
+| GitOps                           |     ✅      |    ❌     |    ❌    |    ❌    |
+| Multi-node Deployments           |     ✅      |  Partial  | Partial  | Partial  |
+| Docker Swarm Support             |     ✅      |    ✅     |    ✅    |    ❌    |
+| Docker Import                    |     ✅      |    ❌     |    ❌    |    ❌    |
+| Secrets Management               |     ✅      |  Partial  | Partial  | Limited  |
+| Monitoring                       | ✅ Built-in |   Basic   |  Basic   |  Basic   |
+| Scheduled Backups                |     ✅      |  Partial  | Partial  |    ❌    |
+| Audit Logs                       |     ✅      |    ❌     |    ❌    |    ❌    |
+| API Tokens                       |     ✅      |    ✅     |    ✅    |    ❌    |
+| OAuth / OIDC                     |     ✅      |  Partial  |    ❌    |    ❌    |
+| SAML / LDAP (Enterprise)         |     ✅      |    ❌     |    ❌    |    ❌    |
+| Terraform Provider               |     ✅      |    ❌     |    ❌    |    ❌    |
+
+---
 ## Ecosystem
 
 Miabi is part of a family of self-hosting tools by the same author:

--- a/cmd/miabi/stack.go
+++ b/cmd/miabi/stack.go
@@ -37,6 +37,7 @@ func registerStackCommands(cli *okapicli.CLI) {
 		String("control-url", "", "", "URL remote nodes and agents dial back on (default: the panel's own URL)").
 		String("image", "", "", "Control-plane image (default: the image this installer itself runs from)").
 		String("gateway-image", "", "", "Goma Gateway image").
+		String("runner-image", "", "", "CI runner image (shown in the runner enrollment command)").
 		String("goma-config", "", "", "Gateway config file, relative to the manifest's directory (default goma.yml)").
 		Bool("registry", "", false, "Enable the built-in container registry").
 		Bool("no-host-proc", "", false, "Do not bind the host's /proc into the control plane (for hosts that refuse the bind; host metrics fall back to the container's /proc)").
@@ -162,6 +163,11 @@ func runInstall(cmd *okapicli.Command) error {
 	if v := cmd.GetString("goma-config"); v != "" {
 		m.Gateway.Config = v
 	}
+	// install.sh pins every image in one place and CI bumps them there; without this the
+	// runner would silently fall back to the Go default and drift from that pin.
+	if v := cmd.GetString("runner-image"); v != "" {
+		m.Images.Runner = v
+	}
 	if v := cmd.GetString("subnet"); v != "" {
 		m.Network.Subnet = v
 	}
@@ -184,10 +190,6 @@ func runInstall(cmd *okapicli.Command) error {
 	if m.Images.Miabi == "" {
 		return errors.New("cannot determine which image to install: this build carries no version, and it is not running as a container it could inspect — pass --image <repo>:<tag>")
 	}
-	if m.Secrets.AdminEmail == "" || m.Secrets.AdminEmail == "admin@example.com" {
-		m.Secrets.AdminEmail = "admin@" + m.Domain
-	}
-
 	// Normalize before showing the plan, so what is printed is what will run —
 	// including the generated secrets, which must be persisted even if converge later
 	// fails. A stack whose containers exist but whose password was never written down

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -3,60 +3,57 @@
 # Miabi one-line installer.
 #   curl -fsSL https://get.miabi.io | sudo bash
 #
-# Installs Docker if missing, then brings up the Miabi stack. Two modes:
+# Installs Docker if missing, then hands off to Miabi, which builds its own stack —
+# network, volumes, PostgreSQL, Redis, the Goma gateway and the control plane —
+# straight against the Docker API.
 #
-#   compose (default)  Fetches compose.yaml + goma.yml into /opt/miabi, generates
-#                      secrets into .env, and runs `docker compose up -d`.
-#                      Re-running is safe: an existing .env is kept (only blank
-#                      secrets are filled) and the stack is updated in place.
+# There is NO BINARY TO INSTALL. The installer IS the Miabi image, whose entrypoint is
+# the miabi binary, so all this script really does is:
 #
-#   stack              MIABI_INSTALL_MODE=stack. Miabi installs itself, straight
-#                      against the Docker API — no compose file, no /opt/miabi.
-#                      The point: Compose owns what Compose created, so a
-#                      compose-managed Miabi can never truthfully update itself
-#                      (the next `docker compose up -d` reverts it). A
-#                      stack-managed one can, including replacing its OWN
-#                      container, with an automatic rollback if the new image does
-#                      not come up. Adds `miabi-stack` to manage it afterwards.
+#   docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
+#     -v /etc/miabi:/etc/miabi miabi/miabi:<tag> install --domain ...
 #
-# Both are supported; every container is labeled io.miabi.managed-by so Miabi
-# always knows which world it is in and never acts on a stack it does not own.
+# Why not Docker Compose (which this script used to set up)? Compose owns what Compose
+# created: a container Miabi recreated out-of-band would be silently reverted by the
+# next `docker compose up -d`. So a Compose-managed Miabi could never truthfully update
+# itself. Miabi owns these containers (io.miabi.managed-by=miabi), which is what makes
+# `miabi update` — including replacing its own container, with rollback — possible.
 #
-# Run it from a checkout (deploy/install.sh) and it copies the local files
-# instead of downloading them.
+# Compose is still supported for anyone who wants to drive it themselves:
+# deploy/compose.yaml is unchanged. This script simply no longer does it for you, and
+# it refuses to install alongside an existing Compose stack (they do not share volumes).
+#
+# It leaves behind a `miabi-stack` wrapper:
+#
+#   miabi-stack status | restart | update | uninstall
 #
 # Environment overrides:
-#   MIABI_INSTALL_MODE          compose (default) | stack
-#   MIABI_DIR                   install directory              (default /opt/miabi)
-#   MIABI_ETC                   stack-mode manifest dir        (default /etc/miabi)
+#   MIABI_DOMAIN                panel domain; required (prompts on a tty)
+#   MIABI_ACME_EMAIL            Let's Encrypt contact
+#   MIABI_ADMIN_EMAIL           first admin's login (default: MIABI_ACME_EMAIL)
 #   MIABI_CONTROL_URL           URL remote nodes/agents dial back on (default: the
-#                               panel's own URL). Stack mode only.
+#                               panel's own URL)
 #   MIABI_REGISTRY_ENABLED      enable the built-in registry   (skips the prompt)
 #   MIABI_REGISTRY_HOST         its hostname                   (default registry.<domain>)
 #   MIABI_NO_HOST_PROC          1 = do not bind the host's /proc into Miabi. Set it
 #                               where the bind is refused (a rootless daemon, a
 #                               hardened host, a socket proxy that forbids host binds);
 #                               host metrics then fall back to the container's /proc,
-#                               which already reflects host CPU/memory. Stack mode only.
+#                               which already reflects host CPU/memory.
+#   MIABI_ETC                   manifest directory             (default /etc/miabi)
 #   MIABI_VERSION               Miabi release to install       (default: pinned below)
 #   GOMA_VERSION                Goma Gateway release           (default: pinned below)
 #   RUNNER_VERSION              miabi/runner release           (default: pinned below)
-#   MIABI_RAW                   base URL for remote file fetch (default: the tag)
-#   MIABI_NO_START              set to 1 to configure but not `up -d`
-#   MIABI_SKIP_DOCKER_INSTALL   set to 1 to never touch the host's packages;
-#                               Docker + Compose v2 must already be present
-#   MIABI_DOMAIN                panel domain; skips the prompt
-#   MIABI_ACME_EMAIL            Let's Encrypt email; skips the prompt
-#   MIABI_ADMIN_EMAIL           first admin's login (default: MIABI_ACME_EMAIL)
-#   MIABI_ADMIN_PASSWORD        first admin's password (default: generated)
-#   ASSUME_YES                  set to 1 to skip interactive prompts (placeholders)
+#   MIABI_SKIP_DOCKER_INSTALL   1 = never touch the host's packages; Docker must exist
+#   MIABI_FORCE_STACK           1 = install even though a Compose stack is present
+#   ASSUME_YES                  1 = never prompt
 #
-# Answering the prompts over a pipe is unreliable, so prefer passing the values:
-#   curl -fsSL .../install.sh | sudo MIABI_DOMAIN=miabi.example.com \
+# Answering prompts over a pipe is unreliable, so prefer passing the values:
+#   curl -fsSL https://get.miabi.io | sudo MIABI_DOMAIN=miabi.example.com \
 #     MIABI_ACME_EMAIL=you@example.com bash
 #
-# Install or downgrade to a specific release:
-#   curl -fsSL .../install.sh | sudo MIABI_VERSION=v1.1.0 bash
+# Install or pin a specific release:
+#   curl -fsSL https://get.miabi.io | sudo MIABI_VERSION=v1.4.0 bash
 
 # This script is bash (pipefail, ERR traps, BASH_SOURCE, local). Invoked as
 # `sh install.sh` the shebang is ignored: under dash that is `set: Illegal option
@@ -73,16 +70,14 @@ fi
 
 set -euo pipefail
 
-INSTALL_DIR="${MIABI_DIR:-/opt/miabi}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
-START_STACK="${MIABI_NO_START:-0}"
 SKIP_DOCKER_INSTALL="${MIABI_SKIP_DOCKER_INSTALL:-0}"
 
 # ── versions ─────────────────────────────────────────────────────────────────
 #
-# Bump order matters: change these, commit, then tag THAT commit. The stack files
-# are fetched from the tag below, so a version bumped but not yet tagged points
-# at a tag that does not exist.
+# The single place every image is pinned. CI bumps these on release (see
+# .github/workflows/release.yml) and they are passed straight to `miabi install`, so
+# the manifest it writes records exactly what this release was tested against.
 MIABI_VERSION="${MIABI_VERSION:-v1.3.0}"
 GOMA_VERSION="${GOMA_VERSION:-v0.11.0}"
 RUNNER_VERSION="${RUNNER_VERSION:-v0.0.7}"
@@ -98,15 +93,6 @@ MIABI_IMAGE_TAG="${MIABI_VERSION#v}";   MIABI_IMAGE_TAG="${MIABI_IMAGE_TAG:-late
 GOMA_IMAGE_TAG="${GOMA_VERSION#v}";     GOMA_IMAGE_TAG="${GOMA_IMAGE_TAG:-latest}"
 RUNNER_IMAGE_TAG="${RUNNER_VERSION#v}"; RUNNER_IMAGE_TAG="${RUNNER_IMAGE_TAG:-latest}"
 
-# Fetch the stack files from the SAME release as the images, so compose.yaml and
-# the image it references can never disagree. A caller who blanks MIABI_VERSION
-# falls back to main.
-if [ -n "$MIABI_VERSION" ]; then
-  DEFAULT_RAW="https://raw.githubusercontent.com/miabi-io/miabi/refs/tags/${MIABI_VERSION}/deploy"
-else
-  DEFAULT_RAW="https://raw.githubusercontent.com/miabi-io/miabi/main/deploy"
-fi
-REPO_RAW="${MIABI_RAW:-$DEFAULT_RAW}"
 
 # How to re-run for an update: a local path when run from a checkout, otherwise
 # the canonical one-liner (a piped `curl | bash` has no re-runnable path).
@@ -137,9 +123,8 @@ die()  { printf "${C_DIM}%s${C_RESET} ${C_RED}✗${C_RESET}   %s\n" "$(_ts)" "$1
 on_error() {
   local code=$?
   printf "\n${C_RED}Installation failed${C_RESET} (exit %s) at line %s.\n" "$code" "${1:-?}" >&2
-  # Only suggest compose logs once there is a stack to read them from.
-  if command -v docker >/dev/null 2>&1 && [ -f "${INSTALL_DIR}/compose.yaml" ]; then
-    printf "  • Inspect logs:   cd %s && docker compose logs\n" "$INSTALL_DIR" >&2
+  if command -v docker >/dev/null 2>&1; then
+    printf "  • Inspect logs:   docker logs miabi\n" >&2
   fi
   printf "  • Re-run safely:  %s\n" "$UPDATE_HINT" >&2
   exit "$code"
@@ -394,55 +379,72 @@ prompt_yn() { # <env-var> <question>
   case "$ans" in y|Y|yes|YES) return 0 ;; *) return 1 ;; esac
 }
 
-# ── install mode ─────────────────────────────────────────────────────────────
+# ── an existing Compose install ──────────────────────────────────────────────
 #
-# Two supported ways to run Miabi, distinguished forever after by the
-# io.miabi.managed-by label on every container:
+# This installer builds the Miabi-managed stack (`miabi install`, straight against
+# the Docker API). It no longer sets up Docker Compose.
 #
-#   compose (default)  Docker Compose owns the stack. Battle-tested. Miabi may
-#                      LOOK at its own components but must never recreate them:
-#                      the next `docker compose up -d` would silently revert it.
+# That matters for a host that ALREADY runs Miabi under Compose, because the two do
+# not share volumes:
 #
-#   stack              Miabi owns the stack. `miabi install` talks to the Docker
-#                      API directly, so Miabi can update its own components —
-#                      including its own container — and roll back a bad image.
+#   compose:  miabi_pgdata          (project-prefixed by Compose)
+#   stack:    mb-platform-pgdata
 #
-# The stack mode needs no binary on this host. The installer IS the Miabi image,
-# whose entrypoint is the miabi binary:
-#
-#   docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
-#     -v /etc/miabi:/etc/miabi miabi/miabi:<tag> install --domain ...
-#
-# An ephemeral container is all the isolation the update needs: it is a DIFFERENT
-# container from the control plane, so it can stop and replace it without killing
-# the process doing the work. And the image's own version is the version it
-# installs, so `miabi/miabi:1.5.0 update` moves the stack to 1.5.0 — the tag you
-# invoke is the tag you get. Nothing to download, nothing to keep in sync.
-#
-# Default is compose because it is what every existing install runs and what has
-# been proven in the field; stack mode is new. Opt in with MIABI_INSTALL_MODE=stack.
-INSTALL_MODE="${MIABI_INSTALL_MODE:-compose}"
-
-# Where the stack manifest lives. Overridable so the installer can be exercised
-# without writing to /etc, and so a non-root or multi-stack host can put it
-# elsewhere. The path must resolve to the SAME directory for this script and for
-# the Docker daemon — it is bind-mounted into the installer container.
+# So installing the stack here would not adopt the existing database — it would
+# create an empty one beside it, and the operator would think their data had
+# vanished. Refuse, and say what to do instead.
 STACK_ETC="${MIABI_ETC:-/etc/miabi}"
+
+compose_miabi_present() {
+  command -v docker >/dev/null 2>&1 || return 1
+  # The label is authoritative and survives a custom project name; the volume is the
+  # fallback for a stack that predates the labels.
+  [ -n "$(docker ps -aq --filter label=io.miabi.managed-by=compose 2>/dev/null)" ] && return 0
+  docker volume inspect miabi_pgdata >/dev/null 2>&1 && return 0
+  return 1
+}
+
+if compose_miabi_present && [ "${MIABI_FORCE_STACK:-0}" != "1" ]; then
+  warn "this host already runs Miabi under Docker Compose."
+  cat >&2 <<'EOM'
+
+  This installer now builds the Miabi-managed stack, which uses DIFFERENT volumes —
+  your database would not come with it, and you would get an empty one instead.
+
+  To keep your Compose install (nothing changes):
+
+      cd /opt/miabi && docker compose pull && docker compose up -d
+
+  To move to the Miabi-managed stack, migrate the data deliberately:
+
+      1. Back up:  https://miabi.io/docs/storage/backups
+      2. cd /opt/miabi && docker compose down
+      3. Re-run this installer with MIABI_FORCE_STACK=1
+      4. Restore the backup into the new stack
+
+EOM
+  die "refusing to install alongside a Compose stack (set MIABI_FORCE_STACK=1 to proceed anyway)."
+fi
 
 install_stack() {
   local domain acme admin image
   domain="$(prompt MIABI_DOMAIN 'Panel domain (e.g. miabi.example.com)' '')"
-  [ -n "$domain" ] || die "MIABI_DOMAIN is required in stack mode: MIABI_INSTALL_MODE=stack MIABI_DOMAIN=miabi.example.com"
+  [ -n "$domain" ] || die "MIABI_DOMAIN is required: pass it as MIABI_DOMAIN=miabi.example.com (answering a prompt over a pipe is unreliable)."
   acme="$(prompt MIABI_ACME_EMAIL "Let's Encrypt contact email" "admin@${domain}")"
-  admin="$(prompt MIABI_ADMIN_EMAIL "First admin's login" "$acme")"
+  # Only pass --admin-email when the operator actually set one. The two addresses fall
+  # back to each other inside `miabi install`, so defaulting admin to acme HERE would
+  # duplicate that rule in shell — and the two copies would drift.
+  admin="${MIABI_ADMIN_EMAIL:-}"
   image="miabi/miabi:${MIABI_IMAGE_TAG}"
 
   # Optional flags, built as an array so an unset one contributes nothing (an empty
   # string would arrive as a stray "" argument).
   local extra=()
+  [ -n "$admin" ] && extra+=(--admin-email "$admin")
 
-  # Built-in registry. Declining leaves the keys out of the manifest entirely, which
-  # is what keeps the registry a UI-managed setting — see the compose branch below.
+  # Built-in registry. Declining leaves the keys out of the manifest entirely — any
+  # non-empty MIABI_REGISTRY_* is a one-way override that pins the setting out of the
+  # admin UI's reach, so "absent" is the only way to say "the UI decides".
   if prompt_yn MIABI_REGISTRY_ENABLED 'Enable the built-in container registry?'; then
     local registry_host
     registry_host="$(prompt MIABI_REGISTRY_HOST 'Registry host' "registry.${domain}")"
@@ -489,8 +491,8 @@ install_stack() {
     "$image" install \
       --domain "$domain" \
       --acme-email "$acme" \
-      --admin-email "$admin" \
       --gateway-image "jkaninda/goma-gateway:${GOMA_IMAGE_TAG}" \
+      --runner-image "miabi/runner:${RUNNER_IMAGE_TAG}" \
       ${extra[@]+"${extra[@]}"} \
       $assume || die "miabi install failed"
       # ${extra[@]+"..."}, not a bare "${extra[@]}": under `set -u`, expanding an EMPTY
@@ -532,270 +534,4 @@ WRAPPER
   exit 0
 }
 
-if [ "$INSTALL_MODE" = "stack" ] || [ "$INSTALL_MODE" = "cli" ]; then
-  install_stack
-fi
-
-# ── install dir + files ──────────────────────────────────────────────────────
-log "Setting up ${INSTALL_DIR}"
-mkdir -p "${INSTALL_DIR}/goma"
-
-# Fetch a file from the local checkout when available, otherwise from the repo.
-fetch() { # <relative-path> <dest>
-  if [ -f "${SCRIPT_DIR}/$1" ]; then
-    cp "${SCRIPT_DIR}/$1" "$2"
-  else
-    curl -fsSL "${REPO_RAW}/$1" -o "$2" || die "failed to download $1 from ${REPO_RAW}"
-  fi
-}
-
-cd "${INSTALL_DIR}"
-fetch "compose.yaml"  "compose.yaml"
-fetch "goma/goma.yml" "goma/goma.yml"
-fetch ".env.example"  ".env.example"
-ok "Stack files in place"
-
-# Generate a 32-byte hex secret; prefer openssl, fall back to /dev/urandom.
-rand() {
-  if command -v openssl >/dev/null 2>&1; then
-    openssl rand -hex 32
-  else
-    LC_ALL=C tr -dc 'a-f0-9' </dev/urandom | head -c 64
-  fi
-}
-
-# .env helpers.
-#
-# get_kv MUST NOT fail when the key is absent — an unset key is a normal state,
-# not an error. Optional settings ship COMMENTED OUT in .env.example (e.g.
-# MIABI_NETWORK_CIDR), so grep finds nothing and exits 1; under `set -euo
-# pipefail` that failure propagates out of the command substitution and trips the
-# ERR trap, killing the install. The trailing `|| true` makes "absent" mean
-# "empty string", which is what every caller already assumes via `${x:-default}`.
-get_kv() { grep -E "^$1=" .env 2>/dev/null | head -n1 | cut -d= -f2- || true; }
-set_kv() { sed -i "s|^$1=.*|$1=$2|" .env; }
-# Fill a key only when its current value is empty (idempotent self-heal).
-fill_if_blank() { [ -z "$(get_kv "$1")" ] && set_kv "$1" "$2" || true; }
-
-# Resolve the host's docker group GID so the non-root container can read the
-# Docker socket.
-docker_gid() {
-  local gid
-  gid="$(stat -c '%g' /var/run/docker.sock 2>/dev/null || true)"
-  [ -n "$gid" ] || gid="$(getent group docker 2>/dev/null | cut -d: -f3)"
-  printf '%s' "${gid:-999}"
-}
-
-# Set a key, appending when .env only carries it as a comment (as .env.example
-# does for every optional setting) — a sed rewrite would silently match nothing.
-set_or_append() { # <key> <value>
-  if grep -qE "^$1=" .env; then set_kv "$1" "$2"; else printf '%s=%s\n' "$1" "$2" >> .env; fi
-}
-
-fresh=0
-registry_host=""
-if [ ! -f .env ]; then
-  fresh=1
-  log "Generating .env with fresh secrets"
-  cp .env.example .env
-  chmod 600 .env
-
-  domain="$(prompt MIABI_DOMAIN 'Panel domain' 'miabi.example.com')"
-  email="$(prompt MIABI_ACME_EMAIL "Let's Encrypt email" 'admin@example.com')"
-  set_kv MIABI_DOMAIN  "$domain"
-  set_kv MIABI_WEB_URL "https://$domain"
-  set_kv MIABI_ACME_EMAIL "$email"
-
-  # The admin is seeded on first boot and Miabi refuses to start outside dev on
-  # an empty or default password, so it must always be set. Default the login to
-  # the ACME email rather than leaving the example address in place.
-  set_kv MIABI_ADMIN_EMAIL "${MIABI_ADMIN_EMAIL:-$email}"
-
-  # Built-in OCI registry. Only written when enabled: any non-empty registry var
-  # is a one-way override that pins the setting out of the UI's reach. Declining
-  # leaves the keys absent, so the registry stays UI-managed.
-  if prompt_yn MIABI_REGISTRY_ENABLED 'Enable the built-in container registry?'; then
-    # Validate: this host gets a public DNS record and its own TLS certificate, so
-    # a bad value (notably a stray "y" carried over from the previous y/N prompt)
-    # would have the gateway request a certificate for a nonsense name. Re-ask on
-    # a tty; fall back to the default when there is nobody to ask.
-    registry_host=""
-    for _ in 1 2 3; do
-      registry_host="$(prompt MIABI_REGISTRY_HOST 'Registry host' "registry.${domain}")"
-      case "$registry_host" in
-        *.*.*|*.*) case "$registry_host" in
-                     *[!a-zA-Z0-9.-]*|-*|.*|*.) ;;   # illegal chars / bad edges
-                     *) break ;;                     # looks like a hostname
-                   esac ;;
-      esac
-      warn "'${registry_host}' is not a valid hostname (expected something like registry.${domain})"
-      unset MIABI_REGISTRY_HOST                      # so prompt() asks again
-      [ -r /dev/tty ] && [ "${ASSUME_YES:-0}" != "1" ] || { registry_host="registry.${domain}"; break; }
-      registry_host=""
-    done
-    [ -n "$registry_host" ] || registry_host="registry.${domain}"
-
-    set_or_append MIABI_REGISTRY_ENABLED true
-    set_or_append MIABI_REGISTRY_HOST "$registry_host"
-    ok "Registry enabled (host: ${registry_host})"
-  fi
-
-  set_kv DOCKER_GID "$(docker_gid)"
-  ok "Created .env (domain: $(get_kv MIABI_DOMAIN))"
-else
-  log "Existing .env found — keeping it (filling only blank secrets)"
-fi
-
-# Always ensure the required secrets and docker GID are populated, even on an
-# upgrade from an older .env that pre-dates a setting.
-for k in MIABI_DB_PASSWORD MIABI_REDIS_PASSWORD MIABI_JWT_SECRET MIABI_ENCRYPTION_KEY; do
-  if [ -z "$(get_kv "$k")" ]; then
-    fill_if_blank "$k" "$(rand)"
-    [ "$fresh" -eq 1 ] || warn "filled previously-empty ${k} with a new secret"
-  fi
-done
-
-# An .env written before the admin keys existed has neither line to rewrite;
-# append rather than sed, or compose fails interpolation on MIABI_ADMIN_PASSWORD.
-grep -qE '^MIABI_ADMIN_EMAIL=' .env || printf 'MIABI_ADMIN_EMAIL=%s\n' "${MIABI_ADMIN_EMAIL:-$(get_kv MIABI_ACME_EMAIL)}" >> .env
-grep -qE '^MIABI_ADMIN_PASSWORD=' .env || printf 'MIABI_ADMIN_PASSWORD=\n' >> .env
-
-admin_generated=0
-if [ -z "$(get_kv MIABI_ADMIN_PASSWORD)" ]; then
-  if [ -n "${MIABI_ADMIN_PASSWORD:-}" ]; then
-    set_kv MIABI_ADMIN_PASSWORD "$MIABI_ADMIN_PASSWORD"
-  else
-    # 32 hex chars: comfortably past the default-password check, still pasteable.
-    set_kv MIABI_ADMIN_PASSWORD "$(rand | cut -c1-32)"
-    admin_generated=1
-  fi
-  [ "$fresh" -eq 1 ] || warn "filled previously-empty MIABI_ADMIN_PASSWORD"
-fi
-
-if [ -z "$(get_kv DOCKER_GID)" ]; then set_kv DOCKER_GID "$(docker_gid)"; fi
-ok "Secrets ready"
-
-# ── image pins ───────────────────────────────────────────────────────────────
-# Re-running the installer is how you upgrade, so the pins must move with it.
-# A value pointing at some other repository is a deliberate override (a private
-# mirror, a locally built image) and is never rewritten.
-pin_image() { # <key> <repo> <tag>
-  local cur; cur="$(get_kv "$1")"
-  case "$cur" in
-    ""|"$2":*) set_or_append "$1" "$2:$3" ;;
-    *) warn "$1 points at a custom image ($cur) — leaving it untouched" ;;
-  esac
-}
-pin_image MIABI_IMAGE  miabi/miabi            "$MIABI_IMAGE_TAG"
-pin_image GOMA_IMAGE   jkaninda/goma-gateway  "$GOMA_IMAGE_TAG"
-pin_image RUNNER_IMAGE miabi/runner           "$RUNNER_IMAGE_TAG"
-
-if [ "$MIABI_IMAGE_TAG" = latest ]; then
-  warn "unstamped installer — pinning images to :latest (a release build pins exact versions)."
-else
-  ok "Pinned miabi/miabi:${MIABI_IMAGE_TAG}, jkaninda/goma-gateway:${GOMA_IMAGE_TAG}, miabi/runner:${RUNNER_IMAGE_TAG}"
-fi
-
-# ── shared app network ───────────────────────────────────────────────────────
-# Goma and every routed app/database container share the `miabi` bridge. Create
-# it up front as an EXTERNAL network with a roomy, controllable CIDR (compose
-# references it as external), so it survives `compose down` and never falls back
-# to Docker's small default address pool — which caps a plain network's IP space
-# and how many networks a host can have. Per-workspace/db/stack networks use a
-# separate managed pool (MIABI_NETWORK_POOL_CIDR, default 10.64.0.0/12).
-ensure_app_network() {
-  local cidr; cidr="$(get_kv MIABI_NETWORK_CIDR)"; cidr="${cidr:-10.63.0.0/16}"
-  # Platform labels mark this as Miabi's own shared network, so it is never offered
-  # in the "Import from Docker" list. (The network is declared `external:` in
-  # compose.yaml — created here, once — so compose cannot label it for us.)
-  local lbl=(
-    --label io.miabi.part-of=miabi
-    --label io.miabi.role=control-plane
-    --label io.miabi.managed-by=compose
-  )
-  if docker network inspect miabi >/dev/null 2>&1; then
-    ok "Docker network 'miabi' already exists (leaving its CIDR unchanged)"
-  elif docker network create --driver bridge --subnet "$cidr" "${lbl[@]}" miabi >/dev/null 2>&1; then
-    ok "Created Docker network 'miabi' (${cidr})"
-  else
-    warn "could not create 'miabi' with subnet ${cidr} (in use? overlaps a route?); creating with Docker defaults"
-    docker network create "${lbl[@]}" miabi >/dev/null 2>&1 || die "failed to create the 'miabi' network"
-  fi
-}
-ensure_app_network
-
-# ── start ────────────────────────────────────────────────────────────────────
-if [ "${START_STACK}" = "1" ]; then
-  log "MIABI_NO_START set — skipping startup."
-  ok "Configured ${INSTALL_DIR}. Start with: cd ${INSTALL_DIR} && docker compose up -d"
-  exit 0
-fi
-
-log "Pulling images (this can take a minute)…"
-docker compose pull >/dev/null 2>&1 && ok "Images pulled" \
-  || warn "image pull reported a problem; continuing (compose will pull on up)"
-
-log "Starting Miabi…"
-docker compose up -d
-
-# Wait for the main container to come up so we can report a real status.
-log "Waiting for the panel to come up…"
-healthy=0
-for _ in $(seq 1 60); do
-  cid="$(docker compose ps -q miabi 2>/dev/null || true)"
-  if [ -n "$cid" ]; then
-    state="$(docker inspect -f '{{.State.Status}}' "$cid" 2>/dev/null || echo '')"
-    health="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$cid" 2>/dev/null || echo 'none')"
-    case "$state" in
-      running) if [ "$health" = healthy ] || [ "$health" = none ]; then healthy=1; break; fi ;;
-      exited|dead) break ;;
-    esac
-  fi
-  sleep 2
-done
-
-echo
-if [ "$healthy" -eq 1 ]; then
-  ok "Miabi is up and running."
-else
-  warn "Miabi did not report healthy yet — it may still be starting."
-  warn "Check status with: cd ${INSTALL_DIR} && docker compose ps && docker compose logs miabi"
-fi
-
-docker compose ps 2>/dev/null || true
-echo
-
-# ── domain reminder ──────────────────────────────────────────────────────────
-cur_domain="$(get_kv MIABI_DOMAIN)"
-cur_email="$(get_kv MIABI_ACME_EMAIL)"
-if [ "$cur_domain" = "miabi.example.com" ] || [ "$cur_email" = "admin@example.com" ]; then
-  warn "MIABI_DOMAIN / MIABI_ACME_EMAIL are still placeholders."
-  printf "      Edit %s/.env, set real values, then: docker compose up -d\n" "${INSTALL_DIR}"
-fi
-
-# ── summary ──────────────────────────────────────────────────────────────────
-printf "${C_GREEN}%s${C_RESET}\n" "──────────────────────────────────────────────────────────"
-if [ "$fresh" -eq 1 ]; then
-  printf "  ${C_GREEN}Miabi installed${C_RESET}\n\n"
-  printf "  Open ${C_CYAN}https://%s${C_RESET} once DNS points here and sign in as\n" "$cur_domain"
-  printf "  the platform admin seeded on first boot:\n\n"
-  printf "      email:    %s\n" "$(get_kv MIABI_ADMIN_EMAIL)"
-  if [ "$admin_generated" -eq 1 ]; then
-    printf "      password: ${C_CYAN}%s${C_RESET}\n\n" "$(get_kv MIABI_ADMIN_PASSWORD)"
-    printf "  ${C_YELLOW}This password is shown once.${C_RESET} It is stored in %s/.env —\n" "${INSTALL_DIR}"
-    printf "  change it from the UI after your first sign-in.\n\n"
-  else
-    printf "      password: (the MIABI_ADMIN_PASSWORD you supplied)\n\n"
-  fi
-else
-  printf "  ${C_GREEN}Miabi updated and running${C_RESET}\n\n"
-fi
-if [ -n "$registry_host" ]; then
-  printf "  Registry: ${C_CYAN}%s${C_RESET} — point an A record at this host so\n" "$registry_host"
-  printf "            Goma can issue its certificate, then docker login there.\n\n"
-fi
-printf "  Config:   %s/.env\n" "${INSTALL_DIR}"
-printf "  Logs:     cd %s && docker compose logs -f miabi\n" "${INSTALL_DIR}"
-printf "  Restart:  cd %s && docker compose restart\n" "${INSTALL_DIR}"
-printf "  Update:   %s\n" "$UPDATE_HINT"
-printf "${C_GREEN}%s${C_RESET}\n" "──────────────────────────────────────────────────────────"
+install_stack

--- a/internal/services/platformstack/manifest.go
+++ b/internal/services/platformstack/manifest.go
@@ -165,8 +165,9 @@ type Images struct {
 	Redis    string `yaml:"redis"`
 	Gateway  string `yaml:"gateway"`
 	// Runner is not run by the stack; it is the image shown in the runner enrollment
-	// command, so it belongs to the install's identity even though nothing here
-	// starts it.
+	// command, so it belongs to the install's identity even though nothing here starts
+	// it. It is therefore the one image whose default floats on :latest — see
+	// DefaultRunnerImage. install.sh still pins it to the tested version.
 	Runner string `yaml:"runner"`
 }
 

--- a/internal/services/platformstack/platformstack_test.go
+++ b/internal/services/platformstack/platformstack_test.go
@@ -1101,3 +1101,75 @@ func TestRestartWalksComponentsInDependencyOrder(t *testing.T) {
 		}
 	}
 }
+
+// acme_email and admin_email are different things — the Let's Encrypt contact, and the
+// login of the seeded platform admin — but in practice one person is both. An operator
+// who supplies either has told us who to use for the other, so each falls back to it.
+// Only when NEITHER is given do we invent admin@<domain>, which is a guess.
+func TestAcmeAndAdminEmailFallBackToEachOther(t *testing.T) {
+	cases := []struct {
+		name, acme, admin   string
+		wantAcme, wantAdmin string
+	}{
+		{
+			"only acme given → it becomes the admin login",
+			"ops@example.com", "",
+			"ops@example.com", "ops@example.com",
+		},
+		{
+			"only admin given → it becomes the ACME contact",
+			"", "boss@example.com",
+			"boss@example.com", "boss@example.com",
+		},
+		{
+			"both given → both kept",
+			"ops@example.com", "boss@example.com",
+			"ops@example.com", "boss@example.com",
+		},
+		{
+			"neither given → derived from the domain (the only guess)",
+			"", "",
+			"admin@miabi.example.com", "admin@miabi.example.com",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := Defaults("miabi/miabi:1.4.0")
+			m.Domain = "miabi.example.com"
+			m.ACMEEmail, m.Secrets.AdminEmail = c.acme, c.admin
+
+			if err := m.Normalize(); err != nil {
+				t.Fatal(err)
+			}
+			if m.ACMEEmail != c.wantAcme {
+				t.Errorf("acme_email = %q, want %q", m.ACMEEmail, c.wantAcme)
+			}
+			if m.Secrets.AdminEmail != c.wantAdmin {
+				t.Errorf("admin_email = %q, want %q", m.Secrets.AdminEmail, c.wantAdmin)
+			}
+
+			// Both must actually reach the containers that need them.
+			spec := controlPlaneSpec(m, ContainerControlPlane, m.Images.Miabi)
+			if !envHas(spec, "MIABI_ADMIN_EMAIL="+c.wantAdmin) {
+				t.Error("the admin login never reached the control plane")
+			}
+			if !envHas(gatewaySpec(m, ContainerGateway, m.Images.Gateway), "MIABI_ACME_EMAIL="+c.wantAcme) {
+				t.Error("the ACME contact never reached the gateway")
+			}
+		})
+	}
+}
+
+// A typo fails far from the mistake: the panel comes up fine, and only later does
+// Let's Encrypt refuse the contact — an ACME error that looks nothing like a typo.
+func TestBadEmailsAreRejected(t *testing.T) {
+	for _, bad := range []string{"not-an-email", "@example.com", "ops@localhost", "a@b@c.com", "ops @example.com"} {
+		m := Defaults("miabi/miabi:1.4.0")
+		m.Domain = "miabi.example.com"
+		m.ACMEEmail = bad
+		if err := m.Normalize(); err == nil {
+			t.Errorf("accepted %q as an email address", bad)
+		}
+	}
+}

--- a/internal/services/platformstack/stack.go
+++ b/internal/services/platformstack/stack.go
@@ -90,9 +90,16 @@ const (
 	DefaultPostgresImage = "postgres:17-alpine"
 	DefaultRedisImage    = "redis:7-alpine"
 	DefaultGatewayImage  = "jkaninda/goma-gateway:0.11.0"
-	DefaultRunnerImage   = "miabi/runner:0.0.7"
-	DefaultNetwork       = "miabi"
-	DefaultSubnet        = "10.63.0.0/16"
+	// DefaultRunnerImage floats on :latest, unlike every other default here — and that
+	// is deliberate. The runner is the one image the stack does not RUN: it only names
+	// what a CI runner should be enrolled with. So it carries none of the
+	// reproducibility weight the others do, and it releases on its own cadence (0.0.x
+	// while the panel is 1.x). A hard pin here would simply go stale — install.sh
+	// passes --runner-image with the version this release was tested against, and this
+	// default is only the fallback for a bare `docker run … install`.
+	DefaultRunnerImage = "miabi/runner:latest"
+	DefaultNetwork     = "miabi"
+	DefaultSubnet      = "10.63.0.0/16"
 )
 
 // Service installs and updates the stack.
@@ -125,7 +132,6 @@ func Defaults(miabiImage string) *Manifest {
 			Gateway:  DefaultGatewayImage,
 			Runner:   DefaultRunnerImage,
 		},
-		Secrets: Secrets{AdminEmail: "admin@example.com"},
 	}
 }
 
@@ -140,8 +146,8 @@ func (m *Manifest) Normalize() error {
 	if m.WebURL == "" {
 		m.WebURL = "https://" + m.Domain
 	}
-	if m.ACMEEmail == "" {
-		m.ACMEEmail = "admin@" + m.Domain
+	if err := m.normalizeEmails(); err != nil {
+		return err
 	}
 	if err := m.normalizeControlURL(); err != nil {
 		return err
@@ -389,6 +395,52 @@ func validEnvName(k string) bool {
 		}
 	}
 	return true
+}
+
+// normalizeEmails resolves the two addresses an install needs, letting each stand in
+// for the other.
+//
+//	acme_email   the contact Let's Encrypt is given for the certificates
+//	admin_email  the login of the platform admin seeded on first boot
+//
+// They are different things, but in practice one person is both, and an operator who
+// supplies one has told us who to use for the other. So each falls back to the other,
+// and only when NEITHER is given do we invent admin@<domain> — which is a guess, and
+// worth avoiding whenever the operator has said something real.
+//
+// Note admin_email is only consumed on FIRST boot, when the admin is seeded. Changing
+// it later renames nothing; it just recreates the control plane with a new env value.
+func (m *Manifest) normalizeEmails() error {
+	acme := strings.TrimSpace(m.ACMEEmail)
+	admin := strings.TrimSpace(m.Secrets.AdminEmail)
+
+	switch {
+	case acme == "" && admin == "":
+		acme = "admin@" + m.Domain
+		admin = acme
+	case acme == "":
+		acme = admin
+	case admin == "":
+		admin = acme
+	}
+
+	for label, addr := range map[string]string{"acme_email": acme, "admin_email": admin} {
+		if !validEmail(addr) {
+			return fmt.Errorf("%s %q is not an email address", label, addr)
+		}
+	}
+	m.ACMEEmail, m.Secrets.AdminEmail = acme, admin
+	return nil
+}
+
+// validEmail is deliberately shallow: exactly one @, something either side, and a dot
+// in the domain. Anything stricter rejects addresses that are perfectly valid, and the
+// real check is that Let's Encrypt accepts it — which happens far from here, so a
+// typo caught now saves an ACME failure that looks nothing like a typo.
+func validEmail(s string) bool {
+	local, domain, ok := strings.Cut(s, "@")
+	return ok && local != "" && strings.Contains(domain, ".") &&
+		!strings.Contains(domain, "@") && !strings.ContainsAny(s, " \t")
 }
 
 // normalizeControlURL defaults the control URL to the panel's public URL and checks


### PR DESCRIPTION
get.miabi.io now hands off to miabi install, which builds the stack straight against the Docker API