### PR TITLE
fix(alerts): debounce runner offline notifications

### DIFF
--- a/cmd/miabi/alerting.go
+++ b/cmd/miabi/alerting.go
@@ -115,38 +115,3 @@ func (n *platformAlerter) NodeStatus(nodeID uint, name string, online bool) {
 		Body: "The node's agent tunnel dropped; workloads scheduled on it are unreachable.",
 	})
 }
-
-// RunnerStatus emits runner_offline / runner_online signals. A shared runner is
-// platform-scoped (system workspace → super-admins); a workspace-owned runner
-// notifies its own members.
-func (n *platformAlerter) RunnerStatus(r *models.Runner, online bool) {
-	var wsID uint
-	platform := r.Scope == models.ScopeShared || r.WorkspaceID == nil
-	if platform {
-		wsID = n.systemWorkspace()
-	} else {
-		wsID = *r.WorkspaceID
-	}
-	if wsID == 0 {
-		return
-	}
-	ref := fmt.Sprintf("runner:%d", r.ID)
-	if online {
-		n.e.Emit(alerting.Signal{WorkspaceID: wsID, Kind: "runner_online", Resolve: true, SubjectRef: ref, Platform: platform})
-		return
-	}
-	name := r.DisplayName
-	if name == "" {
-		name = r.Name
-	}
-	link := fmt.Sprintf("/runners/%d", r.ID)
-	if platform {
-		link = "/admin/runners"
-	}
-	n.e.Emit(alerting.Signal{
-		WorkspaceID: wsID, Kind: "runner_offline", SubjectType: "runner", SubjectRef: ref,
-		SubjectLink: link, Severity: models.AlertWarning, Platform: platform,
-		Title: "Runner offline — " + name,
-		Body:  "The runner's tunnel dropped; queued CI/build jobs may wait for it.",
-	})
-}

--- a/cmd/miabi/server.go
+++ b/cmd/miabi/server.go
@@ -269,6 +269,12 @@ func runServer(cli *okapicli.CLI) {
 				ws: repositories.NewWorkspaceRepository(res.db),
 			}
 			nodeManager.SetOnStatusChange(palerter.NodeStatus)
+			// Runners are scanned rather than hooked: their tunnels re-form too often
+			// for the raw event to be worth notifying on, so the engine debounces it
+			// (offline ≥2m fires, back ≥2m clears). It needs the system workspace to
+			// scope shared runners to the super-admins.
+			alertEngine.SetSystemWorkspace(palerter.systemWorkspace)
+			alertEngine.SetRunnerLister(repositories.NewRunnerRepository(res.db))
 			// The quota scan + backup-outcome alerts are wired below, once the quota
 			// service and backup service exist (they depend on it).
 			webhookRepo := repositories.NewWebhookRepository(res.db)
@@ -506,9 +512,9 @@ func runServer(cli *okapicli.CLI) {
 			})
 
 			var runnerDispatcher *runners.Dispatcher
-			var runnerManager *runners.Manager
-			res.forward, runnerDispatcher, runnerManager = routes.InitRoutes(app, res.db, res.redis, cfg, res.producer, dockerClient, nodeService, nodeManager, nodeGateway, clusterService, bus, proxyMgr, res.cron, logStore)
-			runnerManager.SetOnStatusChange(palerter.RunnerStatus)
+			// The runner manager is discarded: runner alerts come from the engine's
+			// scan (see SetRunnerLister above), not from its connect/disconnect hook.
+			res.forward, runnerDispatcher, _ = routes.InitRoutes(app, res.db, res.redis, cfg, res.producer, dockerClient, nodeService, nodeManager, nodeGateway, clusterService, bus, proxyMgr, res.cron, logStore)
 
 			// This process holds the runner tunnels, so its worker is the one that
 			// dispatches builds to runners — for both pipelines and git-source app

--- a/internal/models/runner.go
+++ b/internal/models/runner.go
@@ -95,8 +95,13 @@ type Runner struct {
 	// Connected reflects a live tunnel (transient; set by the connection manager).
 	Connected bool `json:"connected" gorm:"-"`
 
-	LastSeenAt  *time.Time `json:"last_seen_at,omitempty"`
-	CreatedByID *uint      `json:"created_by_id,omitempty"`
+	LastSeenAt *time.Time `json:"last_seen_at,omitempty"`
+	// ConnectedSince is when the current unbroken connection began — reset on every
+	// reconnect, cleared on disconnect. LastSeenAt cannot answer "how long has this
+	// runner been up?" because the heartbeat refreshes it every 30s; the offline
+	// alert needs that to avoid clearing on a runner that is flapping.
+	ConnectedSince *time.Time `json:"connected_since,omitempty"`
+	CreatedByID    *uint      `json:"created_by_id,omitempty"`
 
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`

--- a/internal/runners/manager.go
+++ b/internal/runners/manager.go
@@ -40,20 +40,12 @@ type Manager struct {
 
 	mu       sync.Mutex
 	sessions map[uint]*yamux.Session
-	onStatus func(r *models.Runner, online bool)
 }
 
 // NewManager creates a runner connection manager backed by the runner service
 // (for status persistence).
 func NewManager(state connectionState) *Manager {
 	return &Manager{state: state, sessions: map[uint]*yamux.Session{}}
-}
-
-// SetOnStatusChange registers a hook fired when a runner comes online (tunnel
-// connected) or goes offline (tunnel dropped). Used by alerting to raise/resolve
-// a "runner offline" alert. Best-effort: run in a goroutine, must not block.
-func (m *Manager) SetOnStatusChange(fn func(r *models.Runner, online bool)) {
-	m.onStatus = fn
 }
 
 // Handle owns an authenticated runner WebSocket: it builds the tunnel, marks the
@@ -74,9 +66,6 @@ func (m *Manager) Handle(r *models.Runner, os, arch, version, remoteIP string, w
 	m.replace(id, sess)
 	m.state.MarkConnected(id, os, arch, version, remoteIP)
 	logger.Info("runner connected", "runner", id, "name", r.Name, "version", version, "ip", remoteIP)
-	if m.onStatus != nil {
-		go m.onStatus(r, true)
-	}
 
 	stop := make(chan struct{})
 	go m.heartbeat(id, os, arch, version, remoteIP, stop)
@@ -87,9 +76,6 @@ func (m *Manager) Handle(r *models.Runner, os, arch, version, remoteIP string, w
 	m.state.MarkDisconnected(id)
 	m.forget(id, sess)
 	logger.Info("runner disconnected", "runner", id, "name", r.Name)
-	if m.onStatus != nil {
-		go m.onStatus(r, false)
-	}
 }
 
 // Connected reports whether a runner currently has a live tunnel.

--- a/internal/services/alerting/engine.go
+++ b/internal/services/alerting/engine.go
@@ -73,6 +73,10 @@ type Engine struct {
 	certs   CertLister
 	volumes VolumeUsageLister
 	quota   QuotaLister
+	runners RunnerLister
+	// sysWorkspace resolves the built-in system workspace, which owns alerts whose
+	// subject belongs to the platform rather than to any one workspace.
+	sysWorkspace func() uint
 	// Platform-scoped alerts (category Node, …) are emitted on the system
 	// workspace and fan out to the platform super-admins instead of workspace
 	// members.

--- a/internal/services/alerting/scan.go
+++ b/internal/services/alerting/scan.go
@@ -15,7 +15,11 @@ import (
 
 // Scan cadence and TLS thresholds.
 const (
-	scanInterval       = 30 * time.Minute
+	scanInterval = 30 * time.Minute
+	// fastScanInterval drives the scans whose threshold is measured in minutes,
+	// where the 30-minute cadence would make "offline for 2 minutes" mean anything
+	// up to 32.
+	fastScanInterval   = time.Minute
 	certExpiryWarn     = 14 * 24 * time.Hour
 	certExpiryCritical = 3 * 24 * time.Hour
 )
@@ -38,14 +42,21 @@ func (e *Engine) ScanLoop(ctx context.Context) {
 	// A scan on start so a fresh control plane surfaces existing conditions
 	// immediately rather than after the first interval.
 	e.scan(ctx)
-	t := time.NewTicker(scanInterval)
-	defer t.Stop()
+	slow := time.NewTicker(scanInterval)
+	defer slow.Stop()
+	// The runner scan is deliberately NOT run on start: every runner is out of
+	// contact for the moment it takes them to redial a control plane that just
+	// booted, and firing on that would alert on our own restart.
+	fast := time.NewTicker(fastScanInterval)
+	defer fast.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-t.C:
+		case <-slow.C:
 			e.scan(ctx)
+		case <-fast.C:
+			e.fastScan(ctx)
 		}
 	}
 }
@@ -59,6 +70,13 @@ func (e *Engine) scan(ctx context.Context) {
 	}
 	if e.quota != nil {
 		e.scanQuotas(ctx)
+	}
+}
+
+// fastScan runs the minute-resolution scans.
+func (e *Engine) fastScan(ctx context.Context) {
+	if e.runners != nil {
+		e.scanRunners(ctx)
 	}
 }
 
@@ -123,7 +141,118 @@ func volName(v *models.Volume) string {
 	return v.Name
 }
 
-// --- Quotas -----------------------------------------------------------------
+// ==== Runners (CI) ==================
+
+const (
+	runnerOfflineAfter = 2 * time.Minute
+	runnerStableFor    = 2 * time.Minute
+)
+
+// RunnerLister is the scanner's view of runners (the runner repo).
+type RunnerLister interface {
+	ListAll() ([]models.Runner, error)
+}
+
+// SetRunnerLister enables the runner-reachability scan.
+func (e *Engine) SetRunnerLister(r RunnerLister) { e.runners = r }
+
+// SetSystemWorkspace supplies the built-in system workspace, which owns alerts
+// whose subject belongs to the platform rather than to one workspace.
+func (e *Engine) SetSystemWorkspace(fn func() uint) { e.sysWorkspace = fn }
+
+// scanRunners fires "runner offline" for runners out of contact for at least
+// runnerOfflineAfter, and clears it only once one is back and has stayed back for
+// runnerStableFor.
+//
+// Reachability is judged on LastSeenAt rather than Status. The heartbeat refreshes
+// last-seen every 30s, so a stale value means nothing is talking to us — which
+// remains true when a control plane killed mid-connection never ran
+// MarkDisconnected and left the row reading "online" indefinitely.
+//
+// Runners that are neither out of contact long enough nor stably back are *held*:
+// they keep whatever alert they already have without opening a new one. That is
+// what turns a flapping runner into one alert instead of a stream.
+func (e *Engine) scanRunners(ctx context.Context) {
+	all, err := e.runners.ListAll()
+	if err != nil {
+		logger.Warn("alerting: runner scan failed", "error", err)
+		return
+	}
+	now := e.now().UTC()
+	held := map[string]bool{}
+	for i := range all {
+		r := &all[i]
+		if r.Ephemeral || !r.Enabled {
+			continue
+		}
+		ws, platform := runnerAlertScope(r, e.systemWorkspace())
+		if ws == 0 {
+			// a shared runner with no system workspace to hang the alert on
+			continue
+		}
+		ref := fmt.Sprintf("runner:%d", r.ID)
+		key := signalDedup("runner_offline", ref)
+		if runnerStablyBack(r, now) {
+			continue
+		}
+		held[key] = true
+		if r.LastSeenAt == nil || now.Sub(r.LastSeenAt.UTC()) < runnerOfflineAfter {
+			continue
+		}
+		link := fmt.Sprintf("/runners/%d", r.ID)
+		if platform {
+			link = "/admin/runners"
+		}
+		e.doFire(ctx, ws, intent{
+			kind: fire, ruleKey: "runner_offline", dedupKey: key,
+			category: models.CategoryCI, severity: models.AlertWarning,
+			subjectType: "runner", subjectRef: ref, subjectLink: link,
+			minRole: models.WorkspaceRoleDeveloper, platform: platform,
+			title: "Runner offline — " + runnerName(r),
+			body:  "The runner has been out of contact for over 2 minutes; queued CI/build jobs may wait for it.",
+		})
+	}
+	e.resolveStale(ctx, models.CategoryCI, "runner_offline:", held)
+}
+
+// runnerAlertScope resolves who hears about a runner: a shared runner is
+// platform-scoped (system workspace → super-admins), a workspace-owned one
+// notifies its own members.
+func runnerAlertScope(r *models.Runner, sysWs uint) (workspaceID uint, platform bool) {
+	if r.Scope == models.ScopeShared || r.WorkspaceID == nil {
+		return sysWs, true
+	}
+	return *r.WorkspaceID, false
+}
+
+// runnerStablyBack reports whether a runner is connected now and has been for
+// runnerStableFor — the bar for clearing its alert.
+func runnerStablyBack(r *models.Runner, now time.Time) bool {
+	if r.Status == models.RunnerStatusOffline || r.ConnectedSince == nil {
+		return false
+	}
+	// The row claims a connection; the heartbeat has to agree.
+	if r.LastSeenAt == nil || now.Sub(r.LastSeenAt.UTC()) >= runnerOfflineAfter {
+		return false
+	}
+	return now.Sub(r.ConnectedSince.UTC()) >= runnerStableFor
+}
+
+func runnerName(r *models.Runner) string {
+	if r.DisplayName != "" {
+		return r.DisplayName
+	}
+	return r.Name
+}
+
+func (e *Engine) systemWorkspace() uint {
+	if e.sysWorkspace == nil {
+		return 0
+	}
+	return e.sysWorkspace()
+}
+
+// =========== Quotas
 
 // QuotaBreach is one workspace resource at/over the near-limit threshold.
 type QuotaBreach struct {

--- a/internal/services/alerting/signal_test.go
+++ b/internal/services/alerting/signal_test.go
@@ -131,6 +131,120 @@ func TestRunnerAlertScopes(t *testing.T) {
 	}
 }
 
+type runnerLister struct{ r []models.Runner }
+
+func (f *runnerLister) ListAll() ([]models.Runner, error) { return f.r, nil }
+
+func ago(d time.Duration) *time.Time { t := time.Now().UTC().Add(-d); return &t }
+
+// TestRunnerScanDebounce is the whole point of the runner scan: a runner that
+// drops and comes back inside the window must never reach anyone's inbox, and one
+// that flaps must not produce a resolve/re-fire pair per cycle.
+func TestRunnerScanDebounce(t *testing.T) {
+	eng, alerts, inbox, _ := newEngineDB(t)
+	ws := uint(1)
+	rl := &runnerLister{r: []models.Runner{{
+		ID: 5, Name: "build-1", WorkspaceID: &ws, Scope: models.ScopeWorkspace,
+		Enabled: true, Status: models.RunnerStatusOffline, LastSeenAt: ago(30 * time.Second),
+	}}}
+	eng.SetRunnerLister(rl)
+	run := func() { eng.scanRunners(context.Background()) }
+	active := func() int { a, _ := alerts.ListByWorkspace(1, true, 0); return len(a) }
+
+	// Offline for 30s — a restart, not an outage. Nothing said.
+	run()
+	if active() != 0 {
+		t.Fatalf("a 30s blip must not alert, %d active", active())
+	}
+
+	// Past the threshold: one alert, one notification.
+	rl.r[0].LastSeenAt = ago(3 * time.Minute)
+	run()
+	if active() != 1 {
+		t.Fatalf("want 1 alert after 3 minutes offline, got %d", active())
+	}
+	if c, _ := inbox.UnreadCount(7); c != 1 {
+		t.Fatalf("developer should have 1 notification, got %d", c)
+	}
+
+	// Back, but only just: the alert is HELD, not resolved — this is what stops a
+	// flapping runner emitting a recovered/offline pair every cycle.
+	rl.r[0].Status = models.RunnerStatusOnline
+	rl.r[0].LastSeenAt = ago(time.Second)
+	rl.r[0].ConnectedSince = ago(30 * time.Second)
+	run()
+	if active() != 1 {
+		t.Fatalf("alert must hold while the runner is only briefly back, got %d active", active())
+	}
+
+	// Stably back: resolved.
+	rl.r[0].ConnectedSince = ago(3 * time.Minute)
+	run()
+	if active() != 0 {
+		t.Fatalf("alert should clear once the runner is stably back, %d active", active())
+	}
+}
+
+// TestRunnerScanSkipsExpectedAbsence: ephemeral runners are torn down by design
+// and disabled ones were switched off on purpose — neither is news.
+func TestRunnerScanSkipsExpectedAbsence(t *testing.T) {
+	eng, alerts, _, _ := newEngineDB(t)
+	ws := uint(1)
+	long := ago(time.Hour)
+	eng.SetRunnerLister(&runnerLister{r: []models.Runner{
+		{ID: 1, Name: "ephemeral", WorkspaceID: &ws, Scope: models.ScopeWorkspace,
+			Enabled: true, Ephemeral: true, Status: models.RunnerStatusOffline, LastSeenAt: long},
+		{ID: 2, Name: "disabled", WorkspaceID: &ws, Scope: models.ScopeWorkspace,
+			Enabled: false, Status: models.RunnerStatusOffline, LastSeenAt: long},
+		{ID: 3, Name: "never-started", WorkspaceID: &ws, Scope: models.ScopeWorkspace,
+			Enabled: true, Status: models.RunnerStatusOffline}, // no LastSeenAt
+	}})
+
+	eng.scanRunners(context.Background())
+	if a, _ := alerts.ListByWorkspace(1, true, 0); len(a) != 0 {
+		t.Fatalf("expected absences must not alert, got %+v", a)
+	}
+}
+
+// TestRunnerScanSharedGoesToAdmins: a shared runner belongs to the platform, so
+// its alert lands on the system workspace and reaches super-admins.
+func TestRunnerScanSharedGoesToAdmins(t *testing.T) {
+	eng, alerts, inbox, _ := newEngineDB(t)
+	eng.SetSystemAdmins(fakeAdmins{ids: []uint{100}})
+	eng.SetSystemWorkspace(func() uint { return 999 })
+	eng.SetRunnerLister(&runnerLister{r: []models.Runner{{
+		ID: 9, Name: "shared-1", Scope: models.ScopeShared, // WorkspaceID nil
+		Enabled: true, Status: models.RunnerStatusOffline, LastSeenAt: ago(5 * time.Minute),
+	}}})
+
+	eng.scanRunners(context.Background())
+	act, _ := alerts.ListByWorkspace(999, true, 0)
+	if len(act) != 1 || act[0].DedupKey != "runner_offline:runner:9" {
+		t.Fatalf("want 1 platform runner alert, got %+v", act)
+	}
+	if c, _ := inbox.UnreadCount(100); c != 1 {
+		t.Fatalf("admin should be notified, got %d", c)
+	}
+	if c, _ := inbox.UnreadCount(7); c != 0 {
+		t.Fatalf("workspace member must not receive a shared-runner alert, got %d", c)
+	}
+}
+
+// A shared runner with no system workspace resolved has nowhere to hang its
+// alert; it must be skipped rather than written to workspace 0.
+func TestRunnerScanSkipsSharedWithoutSystemWorkspace(t *testing.T) {
+	eng, alerts, _, _ := newEngineDB(t)
+	eng.SetRunnerLister(&runnerLister{r: []models.Runner{{
+		ID: 9, Name: "shared-1", Scope: models.ScopeShared,
+		Enabled: true, Status: models.RunnerStatusOffline, LastSeenAt: ago(5 * time.Minute),
+	}}})
+
+	eng.scanRunners(context.Background())
+	if a, _ := alerts.ListByWorkspace(0, true, 0); len(a) != 0 {
+		t.Fatalf("must not alert without a system workspace, got %+v", a)
+	}
+}
+
 // TestDiskScanFireAndResolve: a volume ≥95% full fires a critical disk alert;
 // once usage drops below the warning threshold it auto-resolves.
 func TestDiskScanFireAndResolve(t *testing.T) {

--- a/internal/services/runner/service.go
+++ b/internal/services/runner/service.go
@@ -39,6 +39,10 @@ var (
 // join-token prefix "mbn_" so the two token scopes never collide).
 const tokenPrefix = "mbr_"
 
+// contactLostAfter is the gap in a runner's heartbeat (30s) that counts as the
+// connection having broken, rather than one late beat. Two missed beats.
+const contactLostAfter = 90 * time.Second
+
 // Input is the mutable set of fields a create/update accepts. Scope-specific
 // fields (WorkspaceID, Scope) are set by the caller, not bound from the request.
 type Input struct {
@@ -299,6 +303,22 @@ func (s *Service) regenToken(m *models.Runner) (string, error) {
 	return token, nil
 }
 
+// connectionBroke reports whether a runner's stored state shows the previous
+// connection genuinely ended, rather than this being another heartbeat on a
+// connection that never dropped. It decides when ConnectedSince — the "how long
+// has this been up" the offline alert debounces on — restarts.
+//
+// A stale last-seen counts as a break even when the row still says "online",
+// because a control plane killed mid-connection never runs MarkDisconnected:
+// Status alone would then claim an unbroken connection that ended hours ago, and
+// a runner returning from a real outage would clear its alert instantly.
+func connectionBroke(m *models.Runner, now time.Time) bool {
+	return m.ConnectedSince == nil ||
+		m.Status == models.RunnerStatusOffline ||
+		m.LastSeenAt == nil ||
+		now.Sub(*m.LastSeenAt) > contactLostAfter
+}
+
 // MarkConnected records that a runner's tunnel is live: online status, a fresh
 // last-seen, and its self-reported platform facts. Best-effort (a missing runner
 // is ignored) so the connection manager can call it on connect and on each
@@ -312,8 +332,11 @@ func (s *Service) MarkConnected(id uint, os, arch, version, remoteIP string) {
 	if remoteIP != "" {
 		m.RemoteIP = remoteIP
 	}
-	// A cordoned runner stays cordoned (an operator hold); otherwise it goes
-	// online. Draining is a terminal-for-this-connection state set elsewhere.
+
+	if connectionBroke(m, now) {
+		m.ConnectedSince = &now
+	}
+
 	if m.Status != models.RunnerStatusDraining {
 		m.Status = models.RunnerStatusOnline
 	}
@@ -337,6 +360,7 @@ func (s *Service) MarkDisconnected(id uint) {
 		return
 	}
 	m.Status = models.RunnerStatusOffline
+	m.ConnectedSince = nil // uptime ends here; the next connection starts a new one
 	_ = s.repo.Update(m)
 }
 
@@ -402,8 +426,6 @@ func normalizeConcurrency(n int) int {
 func generateToken() string {
 	b := make([]byte, 32)
 	if _, err := rand.Read(b); err != nil {
-		// crypto/rand failing is fatal for a security token; surface loudly rather
-		// than mint a weak one.
 		logger.Error("runner token generation failed", "error", err)
 	}
 	return tokenPrefix + hex.EncodeToString(b)

--- a/internal/services/runner/service_test.go
+++ b/internal/services/runner/service_test.go
@@ -7,7 +7,51 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/miabi-io/miabi/internal/models"
 )
+
+// TestConnectionBroke pins down when a runner's uptime clock restarts — the input
+// the offline alert debounces its resolve on. Getting this wrong in either
+// direction is a bug you only notice in production: reset too eagerly and an alert
+// never clears, too rarely and a flapping runner clears it instantly.
+func TestConnectionBroke(t *testing.T) {
+	now := time.Now()
+	at := func(d time.Duration) *time.Time { t := now.Add(-d); return &t }
+
+	cases := []struct {
+		name string
+		r    models.Runner
+		want bool
+	}{
+		{"heartbeat on a live connection", models.Runner{
+			Status: models.RunnerStatusOnline, ConnectedSince: at(time.Hour), LastSeenAt: at(20 * time.Second),
+		}, false},
+		{"draining still counts as connected", models.Runner{
+			Status: models.RunnerStatusDraining, ConnectedSince: at(time.Hour), LastSeenAt: at(20 * time.Second),
+		}, false},
+		{"reconnect after a clean disconnect", models.Runner{
+			Status: models.RunnerStatusOffline, ConnectedSince: nil, LastSeenAt: at(5 * time.Minute),
+		}, true},
+		{"first ever connection", models.Runner{
+			Status: models.RunnerStatusOffline,
+		}, true},
+		{"row says online but heartbeats stopped (control plane was killed)", models.Runner{
+			Status: models.RunnerStatusOnline, ConnectedSince: at(time.Hour), LastSeenAt: at(10 * time.Minute),
+		}, true},
+		{"one late heartbeat is not a break", models.Runner{
+			Status: models.RunnerStatusOnline, ConnectedSince: at(time.Hour), LastSeenAt: at(45 * time.Second),
+		}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := connectionBroke(&c.r, now); got != c.want {
+				t.Fatalf("connectionBroke = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
 
 func TestNormalizeLabels(t *testing.T) {
 	got := normalizeLabels([]string{"  buildkit ", "arch=amd64", "buildkit", "", "  "})

--- a/internal/storage/repositories/runner_repo.go
+++ b/internal/storage/repositories/runner_repo.go
@@ -74,6 +74,14 @@ func (r *RunnerRepository) ListShared() ([]models.Runner, error) {
 	return out, err
 }
 
+// ListAll returns every runner across all scopes — the alert scanner's view,
+// which has to reason about reachability platform-wide rather than per workspace.
+func (r *RunnerRepository) ListAll() ([]models.Runner, error) {
+	var out []models.Runner
+	err := r.db.Order("id DESC").Find(&out).Error
+	return out, err
+}
+
 // ListSchedulable returns the runners a workspace's jobs may run on: its own
 // runners plus (when includeShared) the platform-shared pool. Used by the
 // scheduler and the "waiting for a runner" surface.


### PR DESCRIPTION
Runner alerts were emitted straight from the connection manager's connect/disconnect hook, so every runner restart, redeploy and network blip produced an offline notification followed by an online one