### PR TITLE
feat(pipelines): adopt .miabi/pipeline.yaml when creating an app from Git

### DIFF
--- a/examples/pipeline/README.md
+++ b/examples/pipeline/README.md
@@ -31,8 +31,8 @@ from [pipeline.yaml](pipeline.yaml).
 
 ## Keep the spec in your repo: `.miabi/pipeline.yaml`
 
-Version your pipeline-as-code next to the app it deploys — the conventional home
-is **`.miabi/pipeline.yaml`** in the application's repository:
+Version your pipeline-as-code next to the app it deploys — the home Miabi looks
+in is **`.miabi/pipeline.yaml`** in the application's repository:
 
 ```
 your-app/
@@ -42,7 +42,38 @@ your-app/
 └── src/…
 ```
 
-Register it as the pipeline — its contents become the pipeline's stored spec
+### The easy way: let Miabi adopt it
+
+When you create an application from a Git repository, Miabi reads the repository
+and offers to use the pipeline it finds. Accept, and it creates a **repo-owned**
+pipeline bound to the app — no API calls, no copy-pasting.
+
+A repo-owned pipeline is different from one you author in Miabi:
+
+- **The file is the source of truth.** Before every run, Miabi re-reads
+  `.miabi/pipeline.yaml` at the ref being built and runs what it finds. Edit the
+  file and push; there is nothing to re-apply.
+- **It can't be edited in Miabi.** The spec, the name, and the app binding are
+  all derived — from the file and from the app it was adopted for — so a `PATCH`
+  that changes any of them is rejected with `409`. The UI shows the definition
+  read-only behind a *managed by repository* badge. The one exception is
+  `enabled`: disabling a repo-owned pipeline is the kill switch that puts its app
+  back on direct builds without deleting anything.
+- **Deploying the app runs the pipeline.** The app has no separate build of its
+  own, so its build-method settings no longer apply and a deploy returns a
+  pipeline run instead of a deployment. This is the point: a deploy can't skip
+  the test and scan steps the repository declares.
+
+Miabi also accepts `.miabi/pipeline.yml`, `.miabi/pipelines.yaml`, and
+`.miabi/pipelines.yml`; the first that exists wins.
+
+An operator can turn adoption off fleet-wide with the `repo_pipelines_enabled`
+platform setting — git apps then always build and deploy directly.
+
+### The manual way: register the spec yourself
+
+Use this when you want a pipeline Miabi owns (editable in the UI, unaffected by
+what the repo carries). Its contents become the pipeline's stored spec
 (`$APP` = the Git-backed app's id):
 
 ```bash
@@ -66,11 +97,13 @@ curl -X PATCH "$BASE/api/v1/workspaces/$WS/pipelines/$PIPELINE" \
         < .miabi/pipeline.yaml)"
 ```
 
-> **Miabi runs the _stored_ spec, not the repo file.** `.miabi/pipeline.yaml` is
-> your version-controlled source of truth; the calls above copy it into the
-> pipeline record, and that record is what executes at run time. A matching
-> `git push` triggers a run (section 1) but does **not** re-read the file —
-> re-apply after you change it.
+> **A manually registered pipeline runs the _stored_ spec, not the repo file.**
+> The calls above copy `.miabi/pipeline.yaml` into the pipeline record, and that
+> record is what executes at run time. A matching `git push` triggers a run
+> (section 1) but does **not** re-read the file — re-apply after you change it.
+>
+> A **repo-owned** pipeline (adopted at app creation, above) does re-read the
+> file at every run, which is what makes re-applying unnecessary there.
 
 ---
 

--- a/internal/handlers/application_handler.go
+++ b/internal/handlers/application_handler.go
@@ -85,25 +85,31 @@ type CreateAppRequest struct {
 		// Build config (git source). BuildMethod: auto (default) | dockerfile |
 		// buildpack. Builder optionally overrides the buildpack builder image;
 		// Buildpacks/BuildEnv tune a buildpack build. Rejected for image apps.
-		BuildMethod     string            `json:"build_method" enum:"auto,dockerfile,buildpack"`
-		Builder         string            `json:"builder"`
-		Buildpacks      []string          `json:"buildpacks"`
-		BuildEnv        map[string]string `json:"build_env"`
-		RegistryID      *uint             `json:"registry_id"`
-		GitRepositoryID *uint             `json:"git_repository_id"`
-		StackID         *uint             `json:"stack_id"`
-		NetworkIDs      []uint            `json:"network_ids"`
-		Ports           []PortSpecBody    `json:"ports"`
-		Command         []string          `json:"command"`
-		Port            int               `json:"port"`
-		MemoryBytes     int64             `json:"memory_bytes" min:"0"`
-		NanoCPUs        int64             `json:"nano_cpus" min:"0"`
+		BuildMethod string            `json:"build_method" enum:"auto,dockerfile,buildpack"`
+		Builder     string            `json:"builder"`
+		Buildpacks  []string          `json:"buildpacks"`
+		BuildEnv    map[string]string `json:"build_env"`
+		// UsePipeline adopts the pipeline-as-code the repository carries at
+		// .miabi/pipeline.yaml (git source only), so deploys run through it instead
+		// of building directly. Check with POST /git/inspect first to see whether
+		// the repository has one; a repository that turns out to carry none still
+		// creates the app, which then builds directly.
+		UsePipeline     bool           `json:"use_pipeline"`
+		RegistryID      *uint          `json:"registry_id"`
+		GitRepositoryID *uint          `json:"git_repository_id"`
+		StackID         *uint          `json:"stack_id"`
+		NetworkIDs      []uint         `json:"network_ids"`
+		Ports           []PortSpecBody `json:"ports"`
+		Command         []string       `json:"command"`
+		Port            int            `json:"port"`
+		MemoryBytes     int64          `json:"memory_bytes" min:"0"`
+		NanoCPUs        int64          `json:"nano_cpus" min:"0"`
 		// GPUCount requests whole GPU devices (0 = none); GPUKind narrows to a
 		// vendor/model. Gated by the AllowGPU plan capability.
-		GPUCount        int               `json:"gpu_count" min:"0"`
-		GPUKind         string            `json:"gpu_kind"`
-		RestartPolicy   string            `json:"restart_policy" enum:"no,always,unless-stopped,on-failure"`
-		ImagePullPolicy string            `json:"image_pull_policy" enum:"always,if-not-present,never"`
+		GPUCount        int    `json:"gpu_count" min:"0"`
+		GPUKind         string `json:"gpu_kind"`
+		RestartPolicy   string `json:"restart_policy" enum:"no,always,unless-stopped,on-failure"`
+		ImagePullPolicy string `json:"image_pull_policy" enum:"always,if-not-present,never"`
 		// Cluster runtime (cluster mode). runtime_kind defaults to container;
 		// "service" runs the app as a replicated Swarm service.
 		RuntimeKind          string                   `json:"runtime_kind" enum:"container,service"`
@@ -150,10 +156,10 @@ type UpdateAppRequest struct {
 		NanoCPUs        int64          `json:"nano_cpus" min:"0"`
 		// GPUCount requests whole GPU devices (0 = none); GPUKind narrows to a
 		// vendor/model. Gated by the AllowGPU plan capability.
-		GPUCount        int            `json:"gpu_count" min:"0"`
-		GPUKind         string         `json:"gpu_kind"`
-		RestartPolicy   string         `json:"restart_policy" enum:"no,always,unless-stopped,on-failure"`
-		ImagePullPolicy string         `json:"image_pull_policy" enum:"always,if-not-present,never"`
+		GPUCount        int    `json:"gpu_count" min:"0"`
+		GPUKind         string `json:"gpu_kind"`
+		RestartPolicy   string `json:"restart_policy" enum:"no,always,unless-stopped,on-failure"`
+		ImagePullPolicy string `json:"image_pull_policy" enum:"always,if-not-present,never"`
 		// Cluster runtime. Empty runtime_kind leaves the stored kind unchanged;
 		// replicas <= 0 leaves it unchanged.
 		RuntimeKind          string                   `json:"runtime_kind" enum:"container,service"`
@@ -260,6 +266,7 @@ func (h *ApplicationHandler) Create(c *okapi.Context, req *CreateAppRequest) err
 		BuildMethod: models.AppBuildMethod(req.Body.BuildMethod), Builder: req.Body.Builder,
 		Buildpacks: req.Body.Buildpacks, BuildEnv: req.Body.BuildEnv,
 		RegistryID: req.Body.RegistryID, GitRepositoryID: req.Body.GitRepositoryID,
+		UsePipeline: req.Body.UsePipeline, UserID: userIDPtr(c),
 		StackID:    req.Body.StackID,
 		NetworkIDs: req.Body.NetworkIDs, Ports: toPortSpecs(req.Body.Ports),
 		Command: req.Body.Command, Port: req.Body.Port,
@@ -713,12 +720,26 @@ func (h *ApplicationHandler) Deploy(c *okapi.Context, req *DeployRequest) error 
 	if err != nil {
 		return c.AbortNotFound("application not found")
 	}
-	dep, err := h.svc.Deploy(app, req.Body.RegistryID, req.Body.Tag, models.DeployStrategy(req.Body.Strategy))
+	res, err := h.svc.RequestDeploy(app, req.Body.RegistryID, req.Body.Tag, models.DeployStrategy(req.Body.Strategy), userIDPtr(c))
 	if err != nil {
 		return h.mapErr(c, err)
 	}
 	h.record(c, app.WorkspaceID, "app.deploy", app.ID)
-	return created(c, dep)
+	// An app whose repository owns a pipeline deploys by running it: return the
+	// run so the client follows its logs instead of a deployment's. Only an app
+	// with an adopted pipeline can reach this branch — a direct deploy still
+	// returns the bare Deployment, so existing clients see no change.
+	if res.Run != nil {
+		return created(c, PipelineRunAccepted{Kind: "pipeline_run", Run: res.Run})
+	}
+	return created(c, res.Deployment)
+}
+
+// PipelineRunAccepted is the deploy response for an app whose repository owns a
+// pipeline. Kind discriminates it from the Deployment a direct deploy returns.
+type PipelineRunAccepted struct {
+	Kind string              `json:"kind"` // always "pipeline_run"
+	Run  *models.PipelineRun `json:"run"`
 }
 
 // Start / Stop / Restart act on the app's active release container.

--- a/internal/handlers/git_inspect_handler.go
+++ b/internal/handlers/git_inspect_handler.go
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package handlers
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/jkaninda/okapi"
+	"github.com/miabi-io/miabi/internal/middlewares"
+	"github.com/miabi-io/miabi/internal/services/gitrepo"
+	"github.com/miabi-io/miabi/internal/services/pipeline"
+)
+
+// inspectTimeout bounds the probe clone. The create-app modal blocks on this
+// call, so it has to fail fast on an unreachable or oversized repository.
+const inspectTimeout = 20 * time.Second
+
+// GitInspectHandler answers "what is in this repository?" for the create-app
+// flow: whether it builds from a Dockerfile, and whether it carries a
+// pipeline-as-code document Miabi should adopt.
+type GitInspectHandler struct {
+	gitRepos *gitrepo.Service
+}
+
+func NewGitInspectHandler(gitRepos *gitrepo.Service) *GitInspectHandler {
+	return &GitInspectHandler{gitRepos: gitRepos}
+}
+
+type InspectGitRequest struct {
+	Body struct {
+		// GitRepo is the repository URL. It may be omitted when GitRepositoryID
+		// names a stored credential that carries its own URL.
+		GitRepo string `json:"git_repo"`
+		// GitRef is the branch, tag or commit to inspect (blank = default branch).
+		GitRef string `json:"git_ref"`
+		// GitRepositoryID selects a stored credential for a private repository.
+		GitRepositoryID *uint `json:"git_repository_id"`
+	} `json:"body"`
+}
+
+// InspectGitStep is one step of a discovered pipeline, flattened for preview.
+type InspectGitStep struct {
+	Name            string `json:"name"`
+	Uses            string `json:"uses,omitempty"`
+	Image           string `json:"image,omitempty"`
+	ContinueOnError bool   `json:"continue_on_error,omitempty"`
+}
+
+// InspectGitResponse describes what the probe found. HasPipeline is the field the
+// create-app modal keys its "use the repository's pipeline" toggle off.
+type InspectGitResponse struct {
+	Ref           string `json:"ref"`
+	Commit        string `json:"commit"`
+	HasDockerfile bool   `json:"has_dockerfile"`
+	HasPipeline   bool   `json:"has_pipeline"`
+	PipelinePath  string `json:"pipeline_path,omitempty"`
+	PipelineName  string `json:"pipeline_name,omitempty"`
+	// PipelineError is set when a pipeline file was found but failed to parse.
+	// HasPipeline is false in that case — the file is reported so the user can fix
+	// it rather than silently getting a plain build.
+	PipelineError string           `json:"pipeline_error,omitempty"`
+	Steps         []InspectGitStep `json:"steps,omitempty"`
+	PushBranches  []string         `json:"push_branches,omitempty"`
+	TriggersPush  bool             `json:"triggers_push,omitempty"`
+	Manual        bool             `json:"manual,omitempty"`
+	Schedule      string           `json:"schedule,omitempty"`
+	// Spec is the document verbatim, for the preview pane.
+	Spec string `json:"spec,omitempty"`
+}
+
+// Inspect probes a repository. It is a read, but it makes the control plane
+// clone a caller-supplied URL, so it is gated at Developer — the same role that
+// can already point an app or a GitOps source at an arbitrary repository.
+func (h *GitInspectHandler) Inspect(c *okapi.Context, req *InspectGitRequest) error {
+	wsID := middlewares.WorkspaceID(c)
+	url, auth, err := h.gitRepos.CloneURLAuth(wsID, req.Body.GitRepo, req.Body.GitRepositoryID)
+	if err != nil {
+		switch {
+		case errors.Is(err, gitrepo.ErrNotFound):
+			return c.AbortNotFound("git repository credential not found")
+		case errors.Is(err, gitrepo.ErrURLRequired):
+			return c.AbortBadRequest("a repository URL or a stored git credential is required")
+		default:
+			return c.AbortInternalServerError("failed to resolve git credentials", err)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request().Context(), inspectTimeout)
+	defer cancel()
+
+	found, err := pipeline.Discover(ctx, url, strings.TrimSpace(req.Body.GitRef), auth)
+	if err != nil {
+		// A clone failure here is nearly always the user's input — a bad URL, a
+		// missing branch, or a credential that can't read the repo.
+		return c.AbortWithError(400, err)
+	}
+
+	resp := InspectGitResponse{
+		Ref:           found.Ref,
+		Commit:        found.Commit,
+		HasDockerfile: found.HasDockerfile,
+		HasPipeline:   found.HasPipeline(),
+		PipelinePath:  found.Path,
+		PipelineError: found.SpecError,
+		Spec:          found.Raw,
+	}
+	if s := found.Spec; s != nil {
+		resp.PipelineName = s.Metadata.Name
+		resp.Manual = s.On.Manual
+		resp.Schedule = s.On.Schedule
+		if s.On.Push != nil {
+			resp.TriggersPush = true
+			resp.PushBranches = s.On.Push.Branches
+		}
+		resp.Steps = make([]InspectGitStep, 0, len(s.Steps))
+		for _, st := range s.Steps {
+			resp.Steps = append(resp.Steps, InspectGitStep{
+				Name: st.Name, Uses: st.Uses, Image: st.Image, ContinueOnError: st.ContinueOnError,
+			})
+		}
+	}
+	return ok(c, resp)
+}

--- a/internal/handlers/helper.go
+++ b/internal/handlers/helper.go
@@ -37,6 +37,17 @@ func message(c *okapi.Context, msg string) error {
 	return ok(c, dto.MessageData{Message: msg})
 }
 
+// userIDPtr returns the request's actor as a pointer, or nil when there is no
+// authenticated user (an API-key call). Services take *uint so a run or record
+// can be left unattributed rather than attributed to user 0.
+func userIDPtr(c *okapi.Context) *uint {
+	id := middlewares.UserID(c)
+	if id == 0 {
+		return nil
+	}
+	return &id
+}
+
 // quotaAbort maps a plan quota / capability error to a 403 response. Returns nil
 // when err is not a quota error, so callers fall through to their own mapping.
 func quotaAbort(c *okapi.Context, err error) error {

--- a/internal/handlers/pipeline_handler.go
+++ b/internal/handlers/pipeline_handler.go
@@ -62,6 +62,10 @@ type UpdatePipelineRequest struct {
 
 type TriggerPipelineRequest struct {
 	Body struct {
+		// Branch selects the ref to build. Blank uses the pipeline's tracked ref
+		// (a repo-owned pipeline's source_ref); it also selects the ref a repo-owned
+		// pipeline re-reads its spec from.
+		Branch        string `json:"branch"`
 		Commit        string `json:"commit"`
 		CommitMessage string `json:"commit_message"`
 	} `json:"body"`
@@ -146,7 +150,8 @@ func (h *PipelineHandler) Trigger(c *okapi.Context, req *TriggerPipelineRequest)
 	wsID := middlewares.WorkspaceID(c)
 	actor := middlewares.UserID(c)
 	run, err := h.svc.Trigger(wsID, id, pipeline.TriggerInput{
-		Trigger: "manual", Commit: req.Body.Commit, CommitMessage: req.Body.CommitMessage, UserID: &actor,
+		Trigger: "manual", Branch: req.Body.Branch, Commit: req.Body.Commit,
+		CommitMessage: req.Body.CommitMessage, UserID: &actor,
 	})
 	if err != nil {
 		return h.mapErr(c, err)
@@ -354,6 +359,12 @@ func (h *PipelineHandler) mapErr(c *okapi.Context, err error) error {
 		return c.AbortNotFound("pipeline not found")
 	case errors.Is(err, pipeline.ErrNameTaken):
 		return c.AbortWithError(409, err)
+	case errors.Is(err, pipeline.ErrRepoOwned):
+		// 409: the request is well-formed, but this pipeline's spec lives in git.
+		return c.AbortWithError(409, err)
+	case errors.Is(err, pipeline.ErrNoPipelineInRepo), errors.Is(err, pipeline.ErrNotGitApp),
+		errors.Is(err, pipeline.ErrAdoptionUnavailable):
+		return c.AbortBadRequest(err.Error())
 	case errors.Is(err, pipeline.ErrInvalidSpec), errors.Is(err, pipeline.ErrNameRequired), errors.Is(err, pipeline.ErrDisabled):
 		return c.AbortBadRequest(err.Error())
 	default:

--- a/internal/models/app_event.go
+++ b/internal/models/app_event.go
@@ -27,6 +27,9 @@ const (
 	EventSettingsUpdated  AppEventType = "settings.updated"
 	EventAppCreated       AppEventType = "app.created"
 	EventAppDeleted       AppEventType = "app.deleted"
+	// EventPipelineAdopted records the outcome of reading a git app's repository
+	// for pipeline-as-code: adopted, or why it fell back to a direct build.
+	EventPipelineAdopted AppEventType = "pipeline.adopted"
 )
 
 // AppEventSeverity colors an event in the UI.

--- a/internal/models/pipeline.go
+++ b/internal/models/pipeline.go
@@ -5,6 +5,18 @@ package models
 
 import "time"
 
+// PipelineSource records who owns a definition's spec.
+type PipelineSource string
+
+const (
+	// PipelineSourceManual is a spec authored in Miabi: the UI and API own it.
+	PipelineSourceManual PipelineSource = "manual"
+	// PipelineSourceRepo is a spec adopted from the repository's pipeline-as-code
+	// file. The repo is the source of truth — the spec is re-read at each run's
+	// commit, and Miabi refuses to edit it in place.
+	PipelineSourceRepo PipelineSource = "repo"
+)
+
 // PipelineDefinition is a versioned, pipeline-as-code definition
 // (kind: Pipeline). The raw YAML spec is stored so the runner reads the same
 // document the repo carries at .miabi/pipeline.yaml.
@@ -25,6 +37,19 @@ type PipelineDefinition struct {
 	// pipeline. Generated on create; never serialized.
 	WebhookSecret string `json:"-" gorm:"not null;default:''"`
 
+	// Source records who owns Spec. An empty value reads as manual, so pipelines
+	// created before repository adoption existed keep behaving exactly as before.
+	Source PipelineSource `json:"source,omitempty" gorm:"not null;default:manual"`
+	// SourcePath is the repo-relative path Spec was read from (repo source only),
+	// e.g. ".miabi/pipeline.yaml".
+	SourcePath string `json:"source_path,omitempty"`
+	// SourceRef is the branch or ref the spec is read from (repo source only).
+	// It is the app's tracked ref at adoption time.
+	SourceRef string `json:"source_ref,omitempty"`
+	// SourceCommit is the commit Spec was last read at (repo source only) — what
+	// the UI shows as "synced from <commit>".
+	SourceCommit string `json:"source_commit,omitempty"`
+
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 
@@ -33,6 +58,10 @@ type PipelineDefinition struct {
 	// the pipeline has never run.
 	LastRun *PipelineRunSummary `json:"last_run,omitempty" gorm:"-"`
 }
+
+// IsRepoOwned reports whether the repository owns this pipeline's spec, which
+// makes it read-only in Miabi and re-read on every run.
+func (p *PipelineDefinition) IsRepoOwned() bool { return p.Source == PipelineSourceRepo }
 
 // PipelineRunSummary is a lightweight view of a run for list contexts — enough
 // to render a status badge and "ran 2h ago" without shipping steps or logs.
@@ -87,7 +116,10 @@ type PipelineRun struct {
 	Number int               `json:"number" gorm:"not null"`
 	Status PipelineRunStatus `json:"status" gorm:"not null;default:pending"`
 	// Trigger records how the run started: push | manual | schedule | upstream.
-	Trigger       string `json:"trigger"`
+	Trigger string `json:"trigger"`
+	// Branch is the ref the run built, surfaced to steps as $MIABI_BRANCH. Set
+	// from the pushed ref, or from the app's tracked ref for a manual run.
+	Branch        string `json:"branch,omitempty"`
 	Commit        string `json:"commit,omitempty"`
 	CommitMessage string `json:"commit_message,omitempty" gorm:"type:text"`
 	// TriggeredByKeyID / TriggeredByUserID attribute the run (mirrors Deployment).

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -141,6 +141,7 @@ type routerHandlers struct {
 	marketplace    *handlers.MarketplaceHandler
 	registry       *handlers.RegistryHandler
 	gitRepo        *handlers.GitRepositoryHandler
+	gitInspect     *handlers.GitInspectHandler
 	apply          *handlers.ApplyHandler
 	gitops         *handlers.GitOpsHandler
 	pipeline       *handlers.PipelineHandler
@@ -781,6 +782,14 @@ func InitRoutes(app *okapi.Okapi, db *gorm.DB, redisClient *redis.Client, cfg *c
 	gitopsService := gitops.NewService(repositories.NewGitSourceRepository(db), gitRepoRepo, applyService)
 	// CI/CD pipelines: definitions + runs on the internal runner (worker).
 	pipelineService := pipeline.NewService(repositories.NewPipelineRepository(db), producer)
+	// Repository-owned pipelines: adopting a repo's .miabi/pipeline.yaml and
+	// re-reading it before each run needs the app's clone URL and credential.
+	pipelineService.SetGitRepos(gitRepoService)
+	pipelineService.SetApps(appRepo)
+	// …and the app service routes a deploy through that pipeline when one exists.
+	// Wired here rather than at construction because the two services are mutually
+	// dependent: pipelines resolve apps, apps trigger pipelines.
+	appService.SetPipelines(pipelineService)
 	// Built-image catalog: provenance written by pipeline builds; list + GC here.
 	imageService := image.NewService(repositories.NewImageRepository(db), releaseRepo)
 	// Runner job dispatch: sends a build to a runner over its tunnel, mints the
@@ -904,6 +913,7 @@ func InitRoutes(app *okapi.Okapi, db *gorm.DB, redisClient *redis.Client, cfg *c
 			marketplace:    handlers.NewMarketplaceHandler(marketplaceService, auditLogger),
 			registry:       handlers.NewRegistryHandler(registryService, auditLogger),
 			gitRepo:        handlers.NewGitRepositoryHandler(gitRepoService, auditLogger),
+			gitInspect:     handlers.NewGitInspectHandler(gitRepoService),
 			apply:          handlers.NewApplyHandler(applyService, auditLogger),
 			gitops:         handlers.NewGitOpsHandler(gitopsService, auditLogger),
 			pipeline:       handlers.NewPipelineHandler(pipelineService, bus, auditLogger),

--- a/internal/routes/source_routes.go
+++ b/internal/routes/source_routes.go
@@ -133,5 +133,16 @@ func (r *Router) gitRepositoryRoutes() []okapi.RouteDefinition {
 			Handler:     r.h.gitRepo.Delete,
 			Summary:     "Delete a git repository credential",
 		},
+		{
+			// Not credential CRUD, but the same domain: what a repository holds,
+			// asked before an app exists to hang the question off.
+			Method:      http.MethodPost,
+			Path:        "/{workspace}/git/inspect",
+			Group:       g,
+			Middlewares: scoped(models.WorkspaceRoleDeveloper),
+			Handler:     okapi.H(r.h.gitInspect.Inspect),
+			Summary:     "Inspect a repository for a Dockerfile and pipeline-as-code",
+			Request:     &handlers.InspectGitRequest{},
+		},
 	}
 }

--- a/internal/services/application/application.go
+++ b/internal/services/application/application.go
@@ -116,6 +116,15 @@ type CreateInput struct {
 	// (Traefik &c.). Reserved keys (io.miabi.*, com.docker.*) are sanitized on
 	// create regardless of caller.
 	ContainerLabels map[string]string
+	// UsePipeline asks Miabi to adopt the pipeline-as-code document the repository
+	// carries (git source only). The caller has normally already confirmed one
+	// exists via the inspect endpoint; adoption re-reads the repository regardless,
+	// and a repository that turns out to carry none is not an error — the app is
+	// created and builds directly.
+	UsePipeline bool
+	// UserID attributes the adopted pipeline's first run. nil for non-interactive
+	// callers (GitOps, marketplace).
+	UserID *uint
 }
 
 type Service struct {
@@ -141,10 +150,32 @@ type Service struct {
 	quota        *quota.Service
 	cluster      ClusterCap
 	netEnsurer   NetworkEnsurer
+	pipelines    Pipelines
 }
 
 // SetQuota wires the plan/quota enforcer (nil-safe; nil skips checks).
 func (s *Service) SetQuota(q *quota.Service) { s.quota = q }
+
+// Pipelines adopts, finds, and triggers the pipeline a repository carries at
+// .miabi/pipeline.yaml. Implemented by pipeline.Service; an interface so this
+// package doesn't depend on the pipeline service (and its git machinery) just to
+// ask whether an app has one.
+type Pipelines interface {
+	// AdoptForApp probes the app's repository and, on finding pipeline-as-code,
+	// creates a repo-owned pipeline bound to the app. Reports
+	// pipeline.ErrNoPipelineInRepo when the repository carries none.
+	AdoptForApp(ctx context.Context, app *models.Application, userID *uint) (*models.PipelineDefinition, error)
+	// RepoPipelineForApp returns the app's enabled repo-owned pipeline, or nil.
+	RepoPipelineForApp(appID uint) (*models.PipelineDefinition, error)
+	// TriggerForApp starts a run of that pipeline.
+	TriggerForApp(app *models.Application, trigger string, userID *uint) (*models.PipelineRun, error)
+	// DeleteForApp drops the app's repo-owned pipelines and unbinds the rest.
+	DeleteForApp(workspaceID, appID uint) error
+}
+
+// SetPipelines wires repository pipeline adoption (nil-safe). Without it, a git
+// app always builds and deploys directly, exactly as before this existed.
+func (s *Service) SetPipelines(p Pipelines) { s.pipelines = p }
 
 // NetworkEnsurer resolves — creating if necessary — a workspace's default,
 // platform-managed Docker network, so every app is guaranteed to join it even
@@ -673,12 +704,18 @@ func deriveLiveStatus(state, health string, restarting, intentionallyStopped boo
 
 // emit records an app event (best-effort; recorder may be nil).
 func (s *Service) emit(app *models.Application, t models.AppEventType, message string) {
+	s.emitSeverity(app, t, models.SeverityInfo, message)
+}
+
+// emitSeverity records an app event at an explicit severity, for outcomes the
+// user should notice but that aren't failures of the operation they asked for.
+func (s *Service) emitSeverity(app *models.Application, t models.AppEventType, sev models.AppEventSeverity, message string) {
 	if s.events == nil {
 		return
 	}
 	s.events.Record(&models.AppEvent{
 		WorkspaceID: app.WorkspaceID, ApplicationID: app.ID,
-		Type: t, Severity: models.SeverityInfo, Message: message,
+		Type: t, Severity: sev, Message: message,
 	})
 }
 
@@ -779,7 +816,7 @@ func (s *Service) Create(workspaceID uint, in CreateInput) (*models.Application,
 		Command: in.Command, Port: in.Port,
 		MemoryBytes: in.MemoryBytes, NanoCPUs: in.NanoCPUs,
 		GPUCount: in.GPUCount, GPUKind: strings.TrimSpace(in.GPUKind),
-		RestartPolicy: normalizeRestartPolicy(in.RestartPolicy),
+		RestartPolicy:        normalizeRestartPolicy(in.RestartPolicy),
 		ImagePullPolicy:      normalizeImagePullPolicy(in.ImagePullPolicy),
 		RuntimeKind:          in.RuntimeKind,
 		Replicas:             in.Replicas,
@@ -835,7 +872,66 @@ func (s *Service) Create(workspaceID uint, in CreateInput) (*models.Application,
 		return nil, err
 	}
 	s.emit(app, models.EventAppCreated, "Application created")
+	s.adoptRepoPipeline(app, in)
 	return app, nil
+}
+
+// adoptRepoPipeline adopts the repository's pipeline-as-code for a newly created
+// git app, when the caller asked for it and the platform allows it.
+//
+// Every failure here is reported and swallowed. The app already exists and is
+// deployable; refusing to return it because a probe clone timed out, or because
+// the repository's pipeline has a typo in it, would be a far worse outcome than
+// falling back to the plain build the user would have got anyway. The reason
+// lands on the app's event feed so it is discoverable rather than silent.
+func (s *Service) adoptRepoPipeline(app *models.Application, in CreateInput) {
+	if !in.UsePipeline || app.SourceType != models.AppSourceGit || s.pipelines == nil {
+		return
+	}
+	if !s.repoPipelinesEnabled() {
+		s.emitSeverity(app, models.EventPipelineAdopted, models.SeverityWarning,
+			"Repository pipelines are disabled on this platform — building directly")
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), repoPipelineAdoptTimeout)
+	defer cancel()
+	def, err := s.pipelines.AdoptForApp(ctx, app, in.UserID)
+	switch {
+	case err != nil:
+		logger.Warn("could not adopt the repository's pipeline; the app will build directly",
+			"app", app.Name, "workspace", app.WorkspaceID, "error", err)
+		s.emitSeverity(app, models.EventPipelineAdopted, models.SeverityWarning,
+			"Could not use the repository's pipeline ("+err.Error()+") — building directly")
+	case def != nil:
+		s.emitSeverity(app, models.EventPipelineAdopted, models.SeverityInfo,
+			"Using the pipeline from "+def.SourcePath+" — deploys run through it")
+	}
+}
+
+// repoPipelineAdoptTimeout bounds adoption's probe clone. Generous: it runs
+// after the app is already created, so overshooting costs a slow create, not a
+// failed one.
+const repoPipelineAdoptTimeout = 90 * time.Second
+
+// repoPipelinesEnabled reports the platform kill-switch for adopting pipelines
+// out of repositories. Adoption lets a repository choose the step images and
+// shell commands that run on a runner, so an operator can turn the whole
+// capability off fleet-wide. Default on; an unset provider means on.
+func (s *Service) repoPipelinesEnabled() bool {
+	if s.settings == nil {
+		return true
+	}
+	return s.settings.Bool(settings.KeyRepoPipelinesEnabled, true)
+}
+
+// RepoPipelineForApp returns the repo-owned pipeline that owns this app's
+// deploys, or nil when it deploys directly. Handlers use it to explain the app's
+// build path in the UI.
+func (s *Service) RepoPipelineForApp(appID uint) (*models.PipelineDefinition, error) {
+	if s.pipelines == nil {
+		return nil, nil
+	}
+	return s.pipelines.RepoPipelineForApp(appID)
 }
 
 // SetNetworks attaches the given workspace networks to the app, always including the
@@ -1442,6 +1538,14 @@ func (s *Service) Delete(ctx context.Context, app *models.Application) error {
 	if s.portBindings != nil {
 		_ = s.portBindings.DeleteByApp(app.ID)
 	}
+	// Drop the pipelines the app's repository owned (they exist only to deploy it)
+	// and unbind any hand-written ones, so no definition is left pointing at an
+	// app that no longer exists.
+	if s.pipelines != nil {
+		if err := s.pipelines.DeleteForApp(app.WorkspaceID, app.ID); err != nil {
+			logger.Warn("could not clean up the app's pipelines", "app", app.Name, "error", err)
+		}
+	}
 	return s.apps.Delete(app.ID)
 }
 
@@ -1693,6 +1797,45 @@ func (s *Service) Deploy(app *models.Application, registryOverride *uint, tagOve
 		image = app.ImageRef(tagOverride)
 	}
 	return s.enqueue(app.ID, app.ServerID, image, "manual", regID, s.resolveStrategy(app, strategy))
+}
+
+// DeployResult is what a deploy request produced: a Deployment for an app that
+// builds directly, or the PipelineRun that will build and deploy an app whose
+// repository carries pipeline-as-code. Exactly one is set.
+type DeployResult struct {
+	Deployment *models.Deployment
+	Run        *models.PipelineRun
+}
+
+// RequestDeploy is the user-facing deploy entry point. When the app's repository
+// owns a pipeline, the request starts a pipeline run instead of a direct build,
+// so a deploy can never skip the test and scan steps the repository declares —
+// there is one path to production, not two.
+//
+// Internal redeploys (Start, Restart, rollback, GitOps reconcile) deliberately do
+// not come through here: they re-apply an existing configuration and must not
+// re-run CI.
+func (s *Service) RequestDeploy(app *models.Application, registryOverride *uint, tagOverride string, strategy models.DeployStrategy, userID *uint) (*DeployResult, error) {
+	// Fail rather than guess: if we can't tell whether a pipeline governs this
+	// app, deploying directly would silently skip the steps its repository
+	// declares — exactly the outcome routing through the pipeline exists to
+	// prevent.
+	def, err := s.RepoPipelineForApp(app.ID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve the app's pipeline: %w", err)
+	}
+	if def != nil {
+		run, err := s.pipelines.TriggerForApp(app, "manual", userID)
+		if err != nil {
+			return nil, err
+		}
+		return &DeployResult{Run: run}, nil
+	}
+	dep, err := s.Deploy(app, registryOverride, tagOverride, strategy)
+	if err != nil {
+		return nil, err
+	}
+	return &DeployResult{Deployment: dep}, nil
 }
 
 // resolveStrategy picks the effective rollout method: an explicit choice, else

--- a/internal/services/gitrepo/gitrepo.go
+++ b/internal/services/gitrepo/gitrepo.go
@@ -180,6 +180,38 @@ func (s *Service) TestConnection(ctx context.Context, workspaceID, id uint) erro
 	return nil
 }
 
+// CloneURLAuth resolves an explicit repository URL plus an optional stored
+// credential into the (normalized) clone URL and a go-git auth method, for
+// clones that run in-process on the control plane. Either argument may carry the
+// URL: an empty rawURL falls back to the credential's own URL, matching how the
+// deploy worker resolves an app's git source.
+//
+// Unlike CredentialURL (which embeds the secret in the URL because a remote
+// runner has no other way to receive it), the secret here stays in the auth
+// method and never lands in the URL — so the URL is safe to log or echo back in
+// an error. SSH-key credentials work on this path.
+func (s *Service) CloneURLAuth(workspaceID uint, rawURL string, credentialID *uint) (string, transport.AuthMethod, error) {
+	var g *models.GitRepository
+	if credentialID != nil && *credentialID > 0 {
+		found, err := s.repo.FindInWorkspace(workspaceID, *credentialID)
+		if err != nil {
+			return "", nil, ErrNotFound
+		}
+		g = found
+		if strings.TrimSpace(rawURL) == "" {
+			rawURL = g.URL
+		}
+	}
+	if strings.TrimSpace(rawURL) == "" {
+		return "", nil, ErrURLRequired
+	}
+	auth, err := AuthFor(g)
+	if err != nil {
+		return "", nil, err
+	}
+	return normalizeGitURL(rawURL), auth, nil
+}
+
 // Checkout clones url into dir and checks out ref, returning the resolved commit
 // hash. When ref is empty the cloned HEAD is used. log receives progress lines
 // (nil is allowed). It is the shared clone+checkout path used by both the deploy

--- a/internal/services/pipeline/adopt.go
+++ b/internal/services/pipeline/adopt.go
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jkaninda/logger"
+	"github.com/miabi-io/miabi/internal/models"
+	"github.com/miabi-io/miabi/internal/services/gitrepo"
+	"github.com/miabi-io/miabi/internal/slug"
+	"github.com/miabi-io/miabi/internal/storage/repositories"
+)
+
+// adoptTimeout bounds the probe clone made while adopting or re-syncing. It is
+// generous relative to the interactive inspect endpoint because these calls sit
+// on a background path (app creation, a run about to start), but it still has to
+// end — a hung clone must not wedge a deploy.
+const adoptTimeout = 60 * time.Second
+
+// SetGitRepos wires git credential resolution, which repository adoption and
+// per-run re-sync both need to clone. Left unset (tests, deployments with
+// adoption disabled), AdoptForApp reports ErrAdoptionUnavailable and re-sync is
+// skipped in favor of the stored spec.
+func (s *Service) SetGitRepos(g *gitrepo.Service) { s.gitRepos = g }
+
+// SetApps wires app lookup, which re-sync needs to resolve a repo-owned
+// pipeline's clone source from the app it is bound to.
+func (s *Service) SetApps(a *repositories.ApplicationRepository) { s.apps = a }
+
+// AdoptForApp probes an app's repository for a pipeline-as-code document and,
+// when it finds one, creates a repo-owned pipeline bound to that app.
+//
+// The definition is named after the app rather than the document's
+// metadata.name: pipeline names are unique per workspace, and two apps built
+// from forks of the same repo would otherwise collide on adoption. The
+// document's own name becomes the display label.
+func (s *Service) AdoptForApp(ctx context.Context, app *models.Application, userID *uint) (*models.PipelineDefinition, error) {
+	if s.gitRepos == nil {
+		return nil, ErrAdoptionUnavailable
+	}
+	if app.SourceType != models.AppSourceGit {
+		return nil, ErrNotGitApp
+	}
+	found, err := s.discoverForApp(ctx, app, "")
+	if err != nil {
+		return nil, err
+	}
+	if found.SpecError != "" {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidSpec, found.SpecError)
+	}
+	if !found.HasPipeline() {
+		return nil, ErrNoPipelineInRepo
+	}
+	enabled := true
+	return s.Create(app.WorkspaceID, Input{
+		Name:          s.uniqueName(app.WorkspaceID, app.Name),
+		DisplayName:   found.Spec.Metadata.Name,
+		ApplicationID: &app.ID,
+		Spec:          found.Raw,
+		Enabled:       &enabled,
+		Source:        models.PipelineSourceRepo,
+		SourcePath:    found.Path,
+		SourceRef:     app.GitRef,
+		SourceCommit:  found.Commit,
+	})
+}
+
+// RepoPipelineForApp returns the enabled, repo-owned pipeline bound to an app,
+// or nil when the app has none. It is what makes a deploy of a pipeline-carrying
+// app route through CI instead of building directly.
+//
+// An app may be bound to several pipelines; only a repo-owned one claims the
+// deploy path, and the oldest wins so the answer is stable.
+func (s *Service) RepoPipelineForApp(appID uint) (*models.PipelineDefinition, error) {
+	defs, err := s.repo.ListEnabledByApp(appID)
+	if err != nil {
+		return nil, err
+	}
+	return pickRepoOwned(defs), nil
+}
+
+// pickRepoOwned returns the oldest repo-owned definition in defs, or nil. Oldest
+// rather than newest so the app's deploy path can't change under it when a
+// second pipeline is bound later.
+func pickRepoOwned(defs []models.PipelineDefinition) *models.PipelineDefinition {
+	var best *models.PipelineDefinition
+	for i := range defs {
+		if !defs[i].IsRepoOwned() {
+			continue
+		}
+		if best == nil || defs[i].ID < best.ID {
+			best = &defs[i]
+		}
+	}
+	return best
+}
+
+// TriggerForApp starts a run of an app's repo-owned pipeline on the app's
+// tracked ref. The commit is left unset: the runner resolves the ref's current
+// head, which is what a user asking to deploy means by "the latest".
+func (s *Service) TriggerForApp(app *models.Application, trigger string, userID *uint) (*models.PipelineRun, error) {
+	def, err := s.RepoPipelineForApp(app.ID)
+	if err != nil {
+		return nil, err
+	}
+	if def == nil {
+		return nil, ErrNotFound
+	}
+	return s.Trigger(app.WorkspaceID, def.ID, TriggerInput{
+		Trigger: trigger, Branch: app.GitRef, UserID: userID,
+	})
+}
+
+// DeleteForApp removes every repo-owned pipeline bound to an app. Called when
+// the app is deleted: a repo-owned pipeline exists only to serve its app, and
+// left behind it would be an un-runnable definition with a dangling binding.
+// Manual pipelines bound to the app are unbound instead — a user authored those,
+// so they outlive the app.
+func (s *Service) DeleteForApp(workspaceID, appID uint) error {
+	defs, err := s.repo.ListByApp(appID)
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for i := range defs {
+		d := &defs[i]
+		if d.IsRepoOwned() {
+			if err := s.Delete(workspaceID, d.ID); err != nil {
+				errs = append(errs, err)
+			}
+			continue
+		}
+		d.ApplicationID = nil
+		if err := s.repo.Update(d); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// SyncFromRepo re-reads a repo-owned pipeline's spec from its repository at ref
+// and stores it, so a run always executes the document the commit actually
+// carries. It reports whether the spec changed.
+//
+// A repository that can't be reached is not fatal: the pipeline keeps its last
+// known-good spec and the run proceeds on that, which is far better than
+// failing a deploy because git was briefly unavailable. The stale read is
+// logged. A spec that is reachable but no longer parses IS fatal — running a
+// document the user has since broken would deploy something they didn't write.
+func (s *Service) SyncFromRepo(ctx context.Context, p *models.PipelineDefinition, ref string) (bool, error) {
+	if !p.IsRepoOwned() || s.gitRepos == nil || p.ApplicationID == nil || s.apps == nil {
+		return false, nil
+	}
+	app, err := s.apps.FindByID(*p.ApplicationID)
+	if err != nil {
+		logger.Warn("pipeline re-sync skipped: bound app not found",
+			"pipeline", p.Name, "app", *p.ApplicationID, "error", err)
+		return false, nil
+	}
+	if ref == "" {
+		ref = p.SourceRef
+	}
+	found, err := s.discoverForApp(ctx, app, ref)
+	if err != nil {
+		logger.Warn("pipeline re-sync could not read the repository; running the last known spec",
+			"pipeline", p.Name, "ref", ref, "error", err)
+		return false, nil
+	}
+	if found.SpecError != "" {
+		return false, fmt.Errorf("%w: %s", ErrInvalidSpec, found.SpecError)
+	}
+	if !found.HasPipeline() {
+		return false, fmt.Errorf("%w at %s", ErrNoPipelineInRepo, refLabel(ref))
+	}
+	changed := found.Raw != p.Spec
+	p.Spec = found.Raw
+	p.SourcePath = found.Path
+	p.SourceCommit = found.Commit
+	if ref != "" {
+		p.SourceRef = ref
+	}
+	if err := s.repo.Update(p); err != nil {
+		return false, err
+	}
+	s.applySchedule(p) // an edited `on.schedule` takes effect from this run on
+	return changed, nil
+}
+
+// discoverForApp resolves an app's clone URL + credential and probes it. ref
+// overrides the app's tracked ref (a push webhook supplies the pushed commit).
+func (s *Service) discoverForApp(ctx context.Context, app *models.Application, ref string) (*Found, error) {
+	url, auth, err := s.gitRepos.CloneURLAuth(app.WorkspaceID, app.GitRepo, app.GitRepositoryID)
+	if err != nil {
+		return nil, err
+	}
+	if ref == "" {
+		ref = app.GitRef
+	}
+	ctx, cancel := context.WithTimeout(ctx, adoptTimeout)
+	defer cancel()
+	return Discover(ctx, url, strings.TrimSpace(ref), auth)
+}
+
+// uniqueName returns base, or the first free base-2, base-3, … suffix. Adoption
+// must not fail because the workspace already has a pipeline by that name, and a
+// numeric suffix reads better in the UI than a random token.
+func (s *Service) uniqueName(workspaceID uint, base string) string {
+	name := slug.Make(base, "")
+	if name == "" {
+		name = "pipeline"
+	}
+	candidate := name
+	for i := 2; i < 100; i++ {
+		if taken, err := s.repo.ExistsByName(workspaceID, candidate); err != nil || !taken {
+			return candidate
+		}
+		candidate = name + "-" + strconv.Itoa(i)
+	}
+	return name + "-" + slug.Token(6)
+}
+
+// refLabel renders a ref for a message, naming the default branch when empty.
+func refLabel(ref string) string {
+	if strings.TrimSpace(ref) == "" {
+		return "the default branch"
+	}
+	return ref
+}

--- a/internal/services/pipeline/adopt_test.go
+++ b/internal/services/pipeline/adopt_test.go
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/miabi-io/miabi/internal/models"
+)
+
+func TestPickRepoOwnedIgnoresManualPipelines(t *testing.T) {
+	defs := []models.PipelineDefinition{
+		{ID: 3, Name: "hand-written", Source: models.PipelineSourceManual},
+		{ID: 5, Name: "from-repo", Source: models.PipelineSourceRepo},
+	}
+	got := pickRepoOwned(defs)
+	if got == nil || got.ID != 5 {
+		t.Fatalf("want the repo-owned pipeline, got %+v", got)
+	}
+}
+
+func TestPickRepoOwnedPrefersOldest(t *testing.T) {
+	// Binding a second repo-owned pipeline to the app must not move the deploy
+	// path onto it.
+	defs := []models.PipelineDefinition{
+		{ID: 9, Source: models.PipelineSourceRepo},
+		{ID: 4, Source: models.PipelineSourceRepo},
+		{ID: 7, Source: models.PipelineSourceRepo},
+	}
+	if got := pickRepoOwned(defs); got == nil || got.ID != 4 {
+		t.Fatalf("want id 4, got %+v", got)
+	}
+}
+
+func TestPickRepoOwnedNoneMeansDirectBuild(t *testing.T) {
+	// An empty Source is how every pipeline created before adoption existed reads,
+	// and it must never claim an app's deploys.
+	defs := []models.PipelineDefinition{
+		{ID: 1, Source: models.PipelineSourceManual},
+		{ID: 2, Source: ""},
+	}
+	if got := pickRepoOwned(defs); got != nil {
+		t.Fatalf("want nil, got %+v", got)
+	}
+	if got := pickRepoOwned(nil); got != nil {
+		t.Fatalf("want nil for no pipelines, got %+v", got)
+	}
+}
+
+func TestIsRepoOwned(t *testing.T) {
+	for _, tc := range []struct {
+		src  models.PipelineSource
+		want bool
+	}{
+		{models.PipelineSourceRepo, true},
+		{models.PipelineSourceManual, false},
+		{"", false}, // legacy rows
+	} {
+		p := &models.PipelineDefinition{Source: tc.src}
+		if got := p.IsRepoOwned(); got != tc.want {
+			t.Errorf("Source=%q: IsRepoOwned() = %v, want %v", tc.src, got, tc.want)
+		}
+	}
+}
+
+// A repo-owned pipeline derives everything but its enabled flag, so an update
+// that changes anything else must be refused rather than silently reverted by
+// the next run's re-sync.
+func TestRepoOwnedEditRequested(t *testing.T) {
+	appID := uint(7)
+	other := uint(8)
+	stored := &models.PipelineDefinition{
+		Name: "guestbook", DisplayName: "Guestbook", Spec: guestbookPipeline, ApplicationID: &appID,
+	}
+	enabled := true
+
+	for _, tc := range []struct {
+		name string
+		in   Input
+		want bool
+	}{
+		{"no change", Input{}, false},
+		{"enabled only", Input{Enabled: &enabled}, false},
+		{"same values round-tripped", Input{
+			Name: "guestbook", DisplayName: "Guestbook", Spec: guestbookPipeline,
+			SetApplicationID: true, ApplicationID: &appID, Enabled: &enabled,
+		}, false},
+		{"spec edited", Input{Spec: "apiVersion: miabi.io/v1\nkind: Pipeline\n"}, true},
+		{"renamed", Input{Name: "something-else"}, true},
+		{"display name changed", Input{DisplayName: "Renamed"}, true},
+		{"rebound to another app", Input{SetApplicationID: true, ApplicationID: &other}, true},
+		{"unbound", Input{SetApplicationID: true, ApplicationID: nil}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := repoOwnedEditRequested(stored, tc.in); got != tc.want {
+				t.Errorf("repoOwnedEditRequested() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSameAppID(t *testing.T) {
+	a, b := uint(1), uint(1)
+	c := uint(2)
+	if !sameAppID(nil, nil) {
+		t.Error("nil == nil")
+	}
+	if sameAppID(&a, nil) || sameAppID(nil, &a) {
+		t.Error("nil must differ from a bound app")
+	}
+	if !sameAppID(&a, &b) {
+		t.Error("equal values must compare equal")
+	}
+	if sameAppID(&a, &c) {
+		t.Error("different values must compare unequal")
+	}
+}
+
+func TestRefLabel(t *testing.T) {
+	if got := refLabel(""); got != "the default branch" {
+		t.Errorf("refLabel(\"\") = %q", got)
+	}
+	if got := refLabel("dev"); got != "dev" {
+		t.Errorf("refLabel(\"dev\") = %q", got)
+	}
+}

--- a/internal/services/pipeline/discover.go
+++ b/internal/services/pipeline/discover.go
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/miabi-io/miabi/internal/services/gitrepo"
+)
+
+// SourcePaths lists, in priority order, the repository paths Miabi reads a
+// pipeline-as-code document from. The first one that exists wins — a repo
+// carrying several is not an error, it just has one that counts.
+var SourcePaths = []string{
+	".miabi/pipeline.yaml",
+	".miabi/pipeline.yml",
+	".miabi/pipelines.yaml",
+	".miabi/pipelines.yml",
+}
+
+// probeDirPrefix names the temp worktrees Discover creates, so a leaked one is
+// identifiable.
+const probeDirPrefix = "mb-pipeline-probe-"
+
+// Found is the result of probing a repository for pipeline-as-code. A repo with
+// no pipeline is not an error: Path is empty and Spec is nil, and the caller
+// falls back to plain build-and-deploy.
+type Found struct {
+	// Ref is the ref that was probed, Commit the concrete SHA it resolved to.
+	Ref    string
+	Commit string
+	// HasDockerfile reports a Dockerfile at the repository root — what the "auto"
+	// build method keys off, so the caller can explain what happens when the repo
+	// carries no pipeline.
+	HasDockerfile bool
+	// Path is the repo-relative path the document was read from ("" = none found).
+	Path string
+	// Raw is the document verbatim — this is what gets stored as the definition's
+	// spec, so the stored copy is byte-identical to the file in the repo.
+	Raw string
+	// Spec is the parsed document, nil when none was found or it failed to parse.
+	Spec *Spec
+	// SpecError describes why a document that *was* found failed to parse. It is
+	// carried rather than returned so a broken file degrades to "build normally,
+	// tell the user why" instead of blocking app creation.
+	SpecError string
+}
+
+// HasPipeline reports whether a usable pipeline document was found.
+func (f *Found) HasPipeline() bool { return f != nil && f.Spec != nil }
+
+// DiscoverFS reads a pipeline-as-code document out of an already-checked-out
+// tree, returning the path it came from, its bytes, and the parsed spec. A tree
+// with no such document returns all-zero values and a nil error. A document that
+// exists but doesn't parse returns its path and bytes alongside the error, so
+// callers can report which file is broken.
+//
+// It takes an fs.FS rather than cloning so callers that already hold a worktree
+// (a pipeline run re-reading its spec, a build workspace) don't pay for a second
+// clone.
+func DiscoverFS(fsys fs.FS) (string, []byte, *Spec, error) {
+	for _, p := range SourcePaths {
+		raw, err := fs.ReadFile(fsys, p)
+		if errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return "", nil, nil, fmt.Errorf("read %s: %w", p, err)
+		}
+		spec, err := ParseSpec(raw)
+		if err != nil {
+			return p, raw, nil, fmt.Errorf("%s: %w", p, err)
+		}
+		return p, raw, spec, nil
+	}
+	return "", nil, nil, nil
+}
+
+// Discover clones url at ref into a throwaway worktree and reads its
+// pipeline-as-code document. The error return covers only infrastructure
+// failures (clone, IO) — a repo with no pipeline, or one whose pipeline is
+// malformed, comes back as a Found describing that.
+//
+// auth is a go-git auth method (see gitrepo.CloneURLAuth), so the credential
+// never enters the URL and can't leak through a returned error.
+func Discover(ctx context.Context, url, ref string, auth transport.AuthMethod) (*Found, error) {
+	dir, commit, cleanup, err := cloneWorktree(ctx, url, ref, auth)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+
+	f := &Found{Ref: ref, Commit: commit}
+	fsys := os.DirFS(dir)
+	if st, err := fs.Stat(fsys, "Dockerfile"); err == nil && !st.IsDir() {
+		f.HasDockerfile = true
+	}
+
+	path, raw, spec, err := DiscoverFS(fsys)
+	f.Path, f.Raw, f.Spec = path, string(raw), spec
+	if err != nil {
+		f.SpecError = err.Error()
+	}
+	return f, nil
+}
+
+// cloneWorktree clones url at ref into a fresh temp dir, returning the dir, the
+// resolved commit, and a cleanup func the caller must always run.
+//
+// It tries a depth-1 single-branch clone first — the fast path, and the only one
+// that keeps a probe cheap on a large repo. That clone can only name a branch,
+// so when ref is a tag or a commit SHA it falls back to a full clone plus
+// revision resolve (gitrepo.Checkout), the same resolution the deploy worker
+// uses.
+func cloneWorktree(ctx context.Context, url, ref string, auth transport.AuthMethod) (string, string, func(), error) {
+	dir, err := os.MkdirTemp("", probeDirPrefix)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("create probe dir: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(dir) }
+
+	opts := &gogit.CloneOptions{URL: url, Auth: auth, Depth: 1, SingleBranch: true, Tags: gogit.NoTags}
+	if ref != "" {
+		opts.ReferenceName = plumbing.NewBranchReferenceName(ref)
+	}
+	repo, cloneErr := gogit.PlainCloneContext(ctx, dir, false, opts)
+	if cloneErr == nil {
+		head, err := repo.Head()
+		if err != nil {
+			cleanup()
+			return "", "", nil, fmt.Errorf("resolve HEAD: %w", err)
+		}
+		return dir, head.Hash().String(), cleanup, nil
+	}
+	cleanup()
+	// A shallow clone of HEAD failing, or the caller giving up, is terminal —
+	// only an unresolvable ref is worth a second, more expensive attempt.
+	if ref == "" || ctx.Err() != nil {
+		return "", "", nil, fmt.Errorf("git clone: %w", cloneErr)
+	}
+
+	dir, err = os.MkdirTemp("", probeDirPrefix)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("create probe dir: %w", err)
+	}
+	cleanup = func() { _ = os.RemoveAll(dir) }
+	commit, err := gitrepo.Checkout(ctx, dir, url, ref, auth, nil)
+	if err != nil {
+		cleanup()
+		return "", "", nil, err
+	}
+	return dir, commit, cleanup, nil
+}

--- a/internal/services/pipeline/discover_clone_test.go
+++ b/internal/services/pipeline/discover_clone_test.go
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package pipeline
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+// newTestRepo builds a real git repository on disk carrying a Dockerfile and a
+// pipeline document on branch main, plus a v1 tag on the same commit. Discover
+// clones it over go-git's local transport, so this exercises the actual clone
+// path — not just the fs read.
+func newTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	repo, err := gogit.PlainInitWithOptions(dir, &gogit.PlainInitOptions{
+		InitOptions: gogit.InitOptions{DefaultBranch: plumbing.Main},
+	})
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".miabi"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	write := func(rel, body string) {
+		if err := os.WriteFile(filepath.Join(dir, rel), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	write("Dockerfile", "FROM scratch\n")
+	write(".miabi/pipeline.yaml", guestbookPipeline)
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+	if err := wt.AddGlob("."); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	hash, err := wt.Commit("initial", &gogit.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "test@example.com", When: time.Unix(1700000000, 0)},
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if _, err := repo.CreateTag("v1", hash, nil); err != nil {
+		t.Fatalf("tag: %v", err)
+	}
+	// A shallow single-branch clone refuses to serve a repo whose HEAD branch has
+	// no upstream config; nothing to configure for a local clone, but keep the
+	// remote name conventional so the clone resolves refs/heads/main normally.
+	_, _ = repo.CreateRemote(&config.RemoteConfig{Name: "origin", URLs: []string{dir}})
+	return dir
+}
+
+func TestDiscoverClonesAndReadsPipeline(t *testing.T) {
+	src := newTestRepo(t)
+
+	for _, ref := range []string{"", "main", "v1"} {
+		t.Run("ref="+ref, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			found, err := Discover(ctx, src, ref, nil)
+			if err != nil {
+				t.Fatalf("discover: %v", err)
+			}
+			if !found.HasPipeline() {
+				t.Fatalf("no pipeline found (path=%q err=%q)", found.Path, found.SpecError)
+			}
+			if found.Path != ".miabi/pipeline.yaml" {
+				t.Errorf("path = %q", found.Path)
+			}
+			if !found.HasDockerfile {
+				t.Error("root Dockerfile not detected")
+			}
+			if found.Commit == "" {
+				t.Error("commit not resolved")
+			}
+			if found.Raw != guestbookPipeline {
+				t.Error("stored spec is not byte-identical to the repo file")
+			}
+			if len(found.Spec.Steps) != 3 {
+				t.Errorf("steps = %d", len(found.Spec.Steps))
+			}
+		})
+	}
+}
+
+func TestDiscoverRepoWithoutPipeline(t *testing.T) {
+	src := newTestRepo(t)
+	if err := os.Remove(filepath.Join(src, ".miabi", "pipeline.yaml")); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	repo, err := gogit.PlainOpen(src)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	wt, _ := repo.Worktree()
+	if err := wt.AddGlob("."); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if _, err := wt.Commit("drop pipeline", &gogit.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "test@example.com", When: time.Unix(1700000001, 0)},
+	}); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	found, err := Discover(ctx, src, "main", nil)
+	if err != nil {
+		t.Fatalf("a repo without a pipeline must not error: %v", err)
+	}
+	if found.HasPipeline() || found.Path != "" {
+		t.Errorf("unexpected pipeline: %+v", found)
+	}
+	if !found.HasDockerfile {
+		t.Error("root Dockerfile not detected")
+	}
+}
+
+func TestDiscoverUnreachableRepo(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if _, err := Discover(ctx, filepath.Join(t.TempDir(), "nope"), "main", nil); err == nil {
+		t.Fatal("want an error for an unreachable repository")
+	}
+}

--- a/internal/services/pipeline/discover_test.go
+++ b/internal/services/pipeline/discover_test.go
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package pipeline
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+// guestbookPipeline is the document the guestbook example repo carries at
+// .miabi/pipeline.yaml — the shape adoption has to handle end to end.
+const guestbookPipeline = `apiVersion: miabi.io/v1
+kind: Pipeline
+metadata: { name: guestbook }
+on:
+  push: { branches: [main] }
+steps:
+  - name: build
+    uses: build
+    dockerfile: Dockerfile
+  - name: scan
+    image: aquasec/trivy:latest
+    continue-on-error: true
+    run: "trivy image --exit-code 1 --severity HIGH,CRITICAL $MIABI_IMAGE"
+  - name: deploy
+    uses: deploy
+`
+
+func TestDiscoverFSFindsPipeline(t *testing.T) {
+	fsys := fstest.MapFS{
+		"Dockerfile":           {Data: []byte("FROM scratch\n")},
+		".miabi/pipeline.yaml": {Data: []byte(guestbookPipeline)},
+		"README.md":            {Data: []byte("hi")},
+	}
+	path, raw, spec, err := DiscoverFS(fsys)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if path != ".miabi/pipeline.yaml" {
+		t.Fatalf("path = %q", path)
+	}
+	if string(raw) != guestbookPipeline {
+		t.Error("raw document was not returned verbatim")
+	}
+	if spec == nil || len(spec.Steps) != 3 {
+		t.Fatalf("spec = %+v", spec)
+	}
+	if spec.Metadata.Name != "guestbook" {
+		t.Errorf("metadata.name = %q", spec.Metadata.Name)
+	}
+	if !spec.Steps[1].ContinueOnError {
+		t.Error("continue-on-error was dropped")
+	}
+	if !spec.On.FiresOnBranch("main") || spec.On.FiresOnBranch("dev") {
+		t.Error("push trigger did not survive discovery")
+	}
+}
+
+func TestDiscoverFSNoPipelineIsNotAnError(t *testing.T) {
+	fsys := fstest.MapFS{"Dockerfile": {Data: []byte("FROM scratch\n")}}
+	path, raw, spec, err := DiscoverFS(fsys)
+	if err != nil {
+		t.Fatalf("a repo without a pipeline must not error, got %v", err)
+	}
+	if path != "" || raw != nil || spec != nil {
+		t.Fatalf("want zero values, got path=%q raw=%q spec=%+v", path, raw, spec)
+	}
+}
+
+func TestDiscoverFSPathPriority(t *testing.T) {
+	// Every accepted path holds a valid document; the highest-priority one wins.
+	for i, want := range SourcePaths {
+		fsys := fstest.MapFS{}
+		for _, p := range SourcePaths[i:] {
+			fsys[p] = &fstest.MapFile{Data: []byte(guestbookPipeline)}
+		}
+		path, _, spec, err := DiscoverFS(fsys)
+		if err != nil {
+			t.Fatalf("%s: %v", want, err)
+		}
+		if path != want || spec == nil {
+			t.Errorf("with %v present, picked %q, want %q", SourcePaths[i:], path, want)
+		}
+	}
+}
+
+func TestDiscoverFSMalformedReportsTheFile(t *testing.T) {
+	fsys := fstest.MapFS{
+		".miabi/pipeline.yaml": {Data: []byte("apiVersion: miabi.io/v1\nkind: Pipeline\nsteps: []\n")},
+	}
+	path, raw, spec, err := DiscoverFS(fsys)
+	if err == nil {
+		t.Fatal("want a parse error")
+	}
+	if spec != nil {
+		t.Error("spec must be nil when parsing failed")
+	}
+	// Path and bytes still come back so the caller can name the broken file.
+	if path != ".miabi/pipeline.yaml" || len(raw) == 0 {
+		t.Errorf("path = %q, raw len = %d", path, len(raw))
+	}
+	if !strings.Contains(err.Error(), ".miabi/pipeline.yaml") {
+		t.Errorf("error does not name the file: %v", err)
+	}
+}

--- a/internal/services/pipeline/pipeline.go
+++ b/internal/services/pipeline/pipeline.go
@@ -4,11 +4,13 @@
 package pipeline
 
 import (
+	"context"
 	"errors"
 	"strings"
 
 	"github.com/miabi-io/miabi/internal/declarative"
 	"github.com/miabi-io/miabi/internal/models"
+	"github.com/miabi-io/miabi/internal/services/gitrepo"
 	"github.com/miabi-io/miabi/internal/slug"
 	"github.com/miabi-io/miabi/internal/storage/repositories"
 )
@@ -21,6 +23,17 @@ var (
 	ErrInvalidSpec  = errors.New("invalid pipeline spec")
 	ErrDisabled     = errors.New("pipeline is disabled")
 	ErrUnauthorized = errors.New("invalid webhook signature")
+	// ErrRepoOwned rejects an in-place edit of a pipeline the repository owns.
+	// Only its enabled flag can be changed here.
+	ErrRepoOwned = errors.New("this pipeline is managed by its repository — edit the file in git and push, or disable the pipeline to build directly")
+	// ErrNoPipelineInRepo reports a repository that carries no pipeline-as-code
+	// document. It is an ordinary outcome of adoption, not a failure.
+	ErrNoPipelineInRepo = errors.New("repository carries no pipeline-as-code file")
+	// ErrNotGitApp rejects adoption for an app that has no git source to read.
+	ErrNotGitApp = errors.New("application does not build from a git repository")
+	// ErrAdoptionUnavailable reports that repository adoption is not wired up
+	// (no git credential service), so nothing can be discovered.
+	ErrAdoptionUnavailable = errors.New("repository pipeline adoption is not available")
 )
 
 // Enqueuer hands a created run to the background worker. It is an interface so
@@ -35,6 +48,11 @@ type Service struct {
 	repo      *repositories.PipelineRepository
 	enqueuer  Enqueuer
 	scheduler Scheduler
+	// gitRepos and apps back repository-owned pipelines: resolving an app's clone
+	// URL + credential so a spec can be discovered at adoption and re-read at each
+	// run. Both nil-safe — without them a pipeline is manual-only.
+	gitRepos *gitrepo.Service
+	apps     *repositories.ApplicationRepository
 }
 
 func NewService(repo *repositories.PipelineRepository, enqueuer Enqueuer) *Service {
@@ -56,6 +74,13 @@ type Input struct {
 	// Enabled is a pointer so an update can leave it unchanged (nil). On create,
 	// nil is treated as disabled (the zero value), matching the prior behavior.
 	Enabled *bool
+	// Source and the Source* fields mark a definition adopted from a repository's
+	// pipeline-as-code file. They are set by adoption, not by the public API — a
+	// user-authored pipeline leaves them zero and is treated as manual.
+	Source       models.PipelineSource
+	SourcePath   string
+	SourceRef    string
+	SourceCommit string
 }
 
 // Create validates the spec and stores a new pipeline definition.
@@ -74,9 +99,14 @@ func (s *Service) Create(workspaceID uint, in Input) (*models.PipelineDefinition
 	if taken, _ := s.repo.ExistsByName(workspaceID, name); taken {
 		return nil, ErrNameTaken
 	}
+	source := in.Source
+	if source == "" {
+		source = models.PipelineSourceManual
+	}
 	p := &models.PipelineDefinition{
 		WorkspaceID: workspaceID, Name: name, DisplayName: displayName, ApplicationID: in.ApplicationID,
 		Spec: in.Spec, Enabled: in.Enabled != nil && *in.Enabled, WebhookSecret: declarative.RandAlphaNum(40),
+		Source: source, SourcePath: in.SourcePath, SourceRef: in.SourceRef, SourceCommit: in.SourceCommit,
 	}
 	if err := s.repo.Create(p); err != nil {
 		return nil, err
@@ -90,6 +120,19 @@ func (s *Service) Update(workspaceID, id uint, in Input) (*models.PipelineDefini
 	p, err := s.Get(workspaceID, id)
 	if err != nil {
 		return nil, err
+	}
+	// A repo-owned pipeline is a mirror of a file in git, and everything about it
+	// but its enabled flag is derived: the spec from the file (an edit here is
+	// reverted by the next run's re-sync), the name and binding from the app it
+	// was adopted for (unbinding it would orphan the definition — re-sync needs
+	// the app to resolve the clone source, so it would silently freeze on a stale
+	// spec). Refuse the edit and say where it belongs.
+	//
+	// Enabled stays writable on purpose: it is the kill switch you need when the
+	// repository's pipeline is broken and you want deploys to build directly
+	// again without deleting anything.
+	if p.IsRepoOwned() && repoOwnedEditRequested(p, in) {
+		return nil, ErrRepoOwned
 	}
 	if in.Spec != "" {
 		if _, err := ParseSpec([]byte(in.Spec)); err != nil {
@@ -123,6 +166,34 @@ func (s *Service) Update(workspaceID, id uint, in Input) (*models.PipelineDefini
 	}
 	s.applySchedule(p)
 	return p, nil
+}
+
+// repoOwnedEditRequested reports whether an update asks to change something a
+// repository-owned pipeline derives rather than owns. A request that only
+// repeats the stored values (a UI form round-tripping unchanged fields) is not
+// an edit, so it is allowed through — only an actual change is refused.
+func repoOwnedEditRequested(p *models.PipelineDefinition, in Input) bool {
+	if in.Spec != "" && in.Spec != p.Spec {
+		return true
+	}
+	// Tri-state: the caller supplied application_id at all, and it differs.
+	if in.SetApplicationID && !sameAppID(in.ApplicationID, p.ApplicationID) {
+		return true
+	}
+	if name := slug.Make(in.Name, ""); name != "" && name != p.Name {
+		return true
+	}
+	if dn := strings.TrimSpace(in.DisplayName); dn != "" && dn != p.DisplayName {
+		return true
+	}
+	return false
+}
+
+func sameAppID(a, b *uint) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
 }
 
 // Get loads a pipeline definition without last-run enrichment. Used by internal
@@ -200,7 +271,10 @@ func (s *Service) Delete(workspaceID, id uint) error {
 
 // TriggerInput attributes and contextualizes a run.
 type TriggerInput struct {
-	Trigger       string // push | manual | schedule | upstream
+	Trigger string // push | manual | schedule | upstream
+	// Branch is the ref being built. It reaches steps as $MIABI_BRANCH and, for a
+	// repo-owned pipeline, selects the ref the spec is re-read from.
+	Branch        string
 	Commit        string
 	CommitMessage string
 	UserID        *uint
@@ -217,6 +291,24 @@ func (s *Service) Trigger(workspaceID, pipelineID uint, in TriggerInput) (*model
 	if !p.Enabled {
 		return nil, ErrDisabled
 	}
+	// A repo-owned pipeline re-reads its document before every run, so the steps
+	// this run executes are the ones the ref actually carries right now. This has
+	// to happen here rather than in the worker: the run's step rows are projected
+	// from the spec a few lines down, and a spec refreshed after that projection
+	// would leave the run executing a stale step list.
+	if p.IsRepoOwned() {
+		if _, err := s.SyncFromRepo(context.Background(), p, in.Branch); err != nil {
+			return nil, err
+		}
+		// Pin the run to the commit the spec was just read at. Two reasons: the
+		// steps and the tree the runner builds then come from one revision, and the
+		// runner checks out by commit — with none it clones the repository's default
+		// branch, which for an app tracking any other branch would silently build
+		// the wrong code.
+		if in.Commit == "" {
+			in.Commit = p.SourceCommit
+		}
+	}
 	spec, err := ParseSpec([]byte(p.Spec))
 	if err != nil {
 		return nil, errors.Join(ErrInvalidSpec, err)
@@ -228,7 +320,7 @@ func (s *Service) Trigger(workspaceID, pipelineID uint, in TriggerInput) (*model
 	run := &models.PipelineRun{
 		WorkspaceID: workspaceID, PipelineID: p.ID, Number: number,
 		Status: models.PipelineRunPending, Trigger: in.Trigger,
-		Commit: in.Commit, CommitMessage: in.CommitMessage,
+		Branch: in.Branch, Commit: in.Commit, CommitMessage: in.CommitMessage,
 		TriggeredByUserID: in.UserID, TriggeredByKeyID: in.APIKeyID,
 	}
 	if err := s.repo.CreateRun(run); err != nil {

--- a/internal/services/pipeline/triggers.go
+++ b/internal/services/pipeline/triggers.go
@@ -67,7 +67,9 @@ func (s *Service) TriggerScheduled(pipelineID uint) (*models.PipelineRun, error)
 	if err != nil {
 		return nil, ErrNotFound
 	}
-	return s.Trigger(p.WorkspaceID, p.ID, TriggerInput{Trigger: "schedule"})
+	// A repo-owned pipeline's scheduled run builds the ref it was adopted from;
+	// SourceRef is empty for a manual pipeline, leaving the branch unset as before.
+	return s.Trigger(p.WorkspaceID, p.ID, TriggerInput{Trigger: "schedule", Branch: p.SourceRef})
 }
 
 // VerifyWebhook checks an inbound push webhook's signature against the pipeline's
@@ -136,7 +138,7 @@ func (s *Service) TriggerPush(workspaceID, pipelineID uint, signature string, bo
 		return nil, false, nil // not an error; this push just doesn't apply
 	}
 	run, err = s.Trigger(workspaceID, pipelineID, TriggerInput{
-		Trigger: "push", Commit: commit, CommitMessage: message,
+		Trigger: "push", Branch: branch, Commit: commit, CommitMessage: message,
 	})
 	if err != nil {
 		return nil, false, err

--- a/internal/services/settings/provider.go
+++ b/internal/services/settings/provider.go
@@ -53,6 +53,13 @@ const (
 	// disabled everywhere regardless of any plan capability; when true, the
 	// per-plan AllowCustomLabels capability decides. Default true.
 	KeyCustomLabelsEnabled = "custom_labels_enabled"
+
+	// KeyRepoPipelinesEnabled is the fleet-wide kill-switch for adopting a
+	// pipeline out of a repository's .miabi/pipeline.yaml. Adopting one lets the
+	// repository choose the step images and shell commands a runner executes, so
+	// an operator can disable the capability entirely; git apps then always build
+	// and deploy directly. Default true.
+	KeyRepoPipelinesEnabled = "repo_pipelines_enabled"
 )
 
 // defaults seeds first-boot values. Keys absent here can still be created by the
@@ -70,6 +77,7 @@ var defaults = []models.Setting{
 	{Key: KeyExternalBaseDomain, Value: "", Type: models.SettingTypeString},
 	{Key: KeyExternalBaseProvider, Value: "", Type: models.SettingTypeString},
 	{Key: KeyCustomLabelsEnabled, Value: "true", Type: models.SettingTypeBool},
+	{Key: KeyRepoPipelinesEnabled, Value: "true", Type: models.SettingTypeBool},
 }
 
 // Provider caches settings in memory and exposes typed getters.

--- a/internal/storage/repositories/pipeline_repo.go
+++ b/internal/storage/repositories/pipeline_repo.go
@@ -92,6 +92,15 @@ func (r *PipelineRepository) ListEnabledByApp(appID uint) ([]models.PipelineDefi
 	return out, err
 }
 
+// ListByApp returns every pipeline definition bound to an app, enabled or not.
+// Used when the app is deleted, to clean up the repo-owned ones and unbind the
+// rest.
+func (r *PipelineRepository) ListByApp(appID uint) ([]models.PipelineDefinition, error) {
+	var out []models.PipelineDefinition
+	err := r.db.Where("application_id = ?", appID).Find(&out).Error
+	return out, err
+}
+
 // ListEnabled returns every enabled pipeline definition (cron registration sweep).
 func (r *PipelineRepository) ListEnabled() ([]models.PipelineDefinition, error) {
 	var out []models.PipelineDefinition

--- a/internal/worker/pipeline.go
+++ b/internal/worker/pipeline.go
@@ -59,6 +59,8 @@ type PipelineHandler struct {
 // value, so the login host and push host stay identical (a mismatch → "denied").
 type RegistryHostResolver interface{ RegistryHost() string }
 
+const builderHandoffTimeout = 10 * time.Minute
+
 // registryHost is the effective host runners use: the live resolved host when
 // available, else the raw env fallback.
 func (h *PipelineHandler) registryHost() string {
@@ -134,18 +136,36 @@ func (h *PipelineHandler) ProcessTask(ctx context.Context, task *asynq.Task) err
 		return h.failRun(run, fmt.Errorf("invalid pipeline spec: %w", perr))
 	}
 
+	// Every build runs on a registered runner — there is no on-node fallback. This
+	// worker may simply not be the process that holds the runner tunnels (a
+	// standalone `miabi worker`), which is a routing problem, not a failure: hand
+	// the run to the control-plane worker instead of killing it. Checked before the
+	// run is marked running, so a handed-off run stays pending.
+	if h.dispatcher == nil {
+		return h.handOffToBuilder(run)
+	}
+
 	now := time.Now()
 	run.Status = models.PipelineRunRunning
 	run.StartedAt = &now
 	_ = h.pipelines.UpdateRun(run)
 	h.publishStatus(run.ID, models.PipelineRunRunning)
 
-	// Every build runs on a registered runner — there is no on-node fallback. When
-	// none can take the run right now, it waits (bounded by runnerWaitTimeout).
-	if h.dispatcher == nil {
-		return h.failRun(run, fmt.Errorf("runner dispatch is not configured on this worker"))
-	}
 	return h.runOnRunner(ctx, run, def)
+}
+
+func (h *PipelineHandler) handOffToBuilder(run *models.PipelineRun) error {
+	if time.Since(run.CreatedAt) > builderHandoffTimeout {
+		return h.failRun(run, fmt.Errorf(
+			"no runner-capable worker picked this run up within %s — check that the control-plane server is running",
+			builderHandoffTimeout))
+	}
+	run.Status = models.PipelineRunPending
+	run.StartedAt = nil
+	_ = h.pipelines.UpdateRun(run)
+	h.log(run.ID, "handing the run off to the runner-capable worker…")
+	h.publishStatus(run.ID, models.PipelineRunPending)
+	return h.producer.EnqueuePipelineRunToBuilder(run.ID, runnerWaitInterval)
 }
 
 // runOnRunner dispatches the run to a runner and drives it to completion. When no
@@ -209,6 +229,7 @@ func (h *PipelineHandler) jobInputs(run *models.PipelineRun, def *models.Pipelin
 	in.Steps = run.Steps
 	in.Registry = reg
 	in.Ref = run.Commit
+	in.Branch = run.Branch
 	if def.ApplicationID != nil {
 		in.AppID = def.ApplicationID
 		if app, err := h.apps.FindByID(*def.ApplicationID); err == nil {

--- a/internal/worker/producer.go
+++ b/internal/worker/producer.go
@@ -293,6 +293,16 @@ func (p *Producer) EnqueuePipelineRunIn(runID uint, delay time.Duration) error {
 	return err
 }
 
+func (p *Producer) EnqueuePipelineRunToBuilder(runID uint, delay time.Duration) error {
+	payload, err := json.Marshal(RunPipelinePayload{PipelineRunID: runID})
+	if err != nil {
+		return err
+	}
+	task := asynq.NewTask(TypeRunPipeline, payload, asynq.Queue(QueueNode), asynq.MaxRetry(0), asynq.ProcessIn(delay))
+	_, err = p.client.Enqueue(task)
+	return err
+}
+
 // EnqueuePlatformBackup schedules a platform (control-plane) backup to run in
 // the background. Like volume backups it is not auto-retried — a failed run is
 // recorded on the backup row and the admin re-runs it explicitly. It always runs

--- a/web/src/api/apps.ts
+++ b/web/src/api/apps.ts
@@ -1,5 +1,19 @@
 import api from './client'
-import type { ApiResponse, Application, AppOverview, AppPort, Deployment, DeploymentLogHistory, Release, AppEnvVar, AppDatabase, ConnectionInfo, DeployStrategy, RestartPolicy, ImagePullPolicy, BuildMethod, HealthcheckType, ResourceLimits, LiveStatus, HostMountPreset, ProcessList, RuntimeKind, ServiceUpdateConfig } from './types'
+import type { ApiResponse, Application, AppOverview, AppPort, Deployment, DeploymentLogHistory, Release, AppEnvVar, AppDatabase, ConnectionInfo, DeployStrategy, RestartPolicy, ImagePullPolicy, BuildMethod, HealthcheckType, ResourceLimits, LiveStatus, HostMountPreset, ProcessList, RuntimeKind, ServiceUpdateConfig, PipelineRun } from './types'
+
+/**
+ * What a deploy returns when the app's repository owns a pipeline: the run that
+ * will build and deploy it, rather than a direct Deployment.
+ */
+export interface PipelineRunAccepted {
+  kind: 'pipeline_run'
+  run: PipelineRun
+}
+
+/** Narrow a deploy response to the pipeline-run case. */
+export function isPipelineRun(d: Deployment | PipelineRunAccepted): d is PipelineRunAccepted {
+  return (d as PipelineRunAccepted)?.kind === 'pipeline_run'
+}
 
 // Cluster runtime fields shared by create/update payloads (cluster mode).
 export interface AppRuntimeInput {
@@ -43,6 +57,12 @@ export interface CreateAppInput extends AppRuntimeInput {
   builder?: string
   buildpacks?: string[]
   build_env?: Record<string, string>
+  /**
+   * Adopt the pipeline-as-code the repository carries at .miabi/pipeline.yaml
+   * (git source only), so deploys run through it instead of building directly.
+   * A repository that turns out to carry none still creates the app.
+   */
+  use_pipeline?: boolean
   registry_id?: number | null
   git_repository_id?: number | null
   stack_id?: number | null
@@ -125,8 +145,13 @@ export const appApi = {
   remove(ws: number, id: number) {
     return api.delete<ApiResponse<{ message: string }>>(`/workspaces/${ws}/apps/${id}`)
   },
+  /**
+   * Deploy. An app whose repository owns a pipeline deploys by running it, so the
+   * response is either a Deployment (built and deployed directly) or a
+   * PipelineRunAccepted. Use `isPipelineRun` to tell them apart.
+   */
   deploy(ws: number, id: number, opts: DeployOptions = {}) {
-    return api.post<ApiResponse<Deployment>>(`/workspaces/${ws}/apps/${id}/deploy`, {
+    return api.post<ApiResponse<Deployment | PipelineRunAccepted>>(`/workspaces/${ws}/apps/${id}/deploy`, {
       registry_id: opts.registry_id ?? null,
       tag: opts.tag ?? '',
       strategy: opts.strategy ?? '',

--- a/web/src/api/gitRepositories.ts
+++ b/web/src/api/gitRepositories.ts
@@ -9,6 +9,38 @@ export interface GitRepositoryInput {
   secret?: string
 }
 
+/** What to probe. Either git_repo or a git_repository_id carrying a URL is required. */
+export interface GitInspectInput {
+  git_repo?: string
+  git_ref?: string
+  git_repository_id?: number | null
+}
+
+export interface GitInspectStep {
+  name: string
+  uses?: string
+  image?: string
+  continue_on_error?: boolean
+}
+
+/** What a repository holds: how it builds, and whether it carries pipeline-as-code. */
+export interface GitInspectResult {
+  ref: string
+  commit: string
+  has_dockerfile: boolean
+  has_pipeline: boolean
+  pipeline_path?: string
+  pipeline_name?: string
+  /** Set when a pipeline file exists but does not parse; has_pipeline is then false. */
+  pipeline_error?: string
+  steps?: GitInspectStep[]
+  push_branches?: string[]
+  triggers_push?: boolean
+  manual?: boolean
+  schedule?: string
+  spec?: string
+}
+
 const base = (ws: number) => `/workspaces/${ws}/git-repositories`
 
 export const gitRepositoryApi = {
@@ -18,4 +50,11 @@ export const gitRepositoryApi = {
   update: (ws: number, id: number, input: GitRepositoryInput) => api.patch<ApiResponse<GitRepository>>(`${base(ws)}/${id}`, input),
   test: (ws: number, id: number) => api.post<ApiResponse<{ message: string }>>(`${base(ws)}/${id}/test`),
   remove: (ws: number, id: number) => api.delete<ApiResponse<{ message: string }>>(`${base(ws)}/${id}`),
+  /**
+   * Probe a repository before an app exists to hang the question off: does it
+   * build from a Dockerfile, and does it carry a pipeline Miabi should adopt?
+   * Clones the repo server-side, so it is slower than a normal call.
+   */
+  inspect: (ws: number, input: GitInspectInput) =>
+    api.post<ApiResponse<GitInspectResult>>(`/workspaces/${ws}/git/inspect`, input),
 }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -1883,6 +1883,9 @@ export interface PipelineRunSummary {
   created_at: string
 }
 
+/** Who owns a pipeline's spec: authored in Miabi, or mirrored from a repo file. */
+export type PipelineSource = 'manual' | 'repo'
+
 export interface PipelineDefinition {
   id: number
   workspace_id: number
@@ -1891,6 +1894,14 @@ export interface PipelineDefinition {
   application_id?: number | null
   spec: string
   enabled: boolean
+  /** Absent on pipelines created before repository adoption existed — treat as 'manual'. */
+  source?: PipelineSource
+  /** Repo-relative path the spec is read from, e.g. '.miabi/pipeline.yaml'. */
+  source_path?: string
+  /** Branch the spec is read from. */
+  source_ref?: string
+  /** Commit the stored spec was last read at. */
+  source_commit?: string
   created_at: string
   updated_at: string
   last_run?: PipelineRunSummary | null
@@ -1933,6 +1944,7 @@ export interface PipelineRun {
   number: number
   status: PipelineRunStatus
   trigger: string
+  branch?: string
   commit?: string
   commit_message?: string
   image_id?: number | null

--- a/web/src/views/apps/AppDetail.vue
+++ b/web/src/views/apps/AppDetail.vue
@@ -3,7 +3,8 @@ import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { useNotificationStore } from '@/stores/notification'
-import { appApi, type ExternalAccess } from '@/api/apps'
+import { appApi, isPipelineRun, type ExternalAccess, type PipelineRunAccepted } from '@/api/apps'
+import { pipelineApi } from '@/api/pipelines'
 import { volumeApi, monitoringApi, databaseApi, usageApi } from '@/api/resources'
 import { registryApi } from '@/api/registries'
 import { gitRepositoryApi } from '@/api/gitRepositories'
@@ -20,7 +21,7 @@ import LogViewer from '@/components/LogViewer.vue'
 import ConfirmDialog from '@/components/ConfirmDialog.vue'
 import MetadataCard from '@/components/MetadataCard.vue'
 import AppAccessPanel from '@/components/AppAccessPanel.vue'
-import type { Application, AppOverview, Deployment, Release, AppEnvVar, Route, Network, Stack, Volume, StatsSample, Registry, GitRepository, AppEvent, AppPort, PortBinding, AppDatabase, ConnectionInfo, DeployStrategy, RestartPolicy, ImagePullPolicy, BuildMethod, HealthcheckType, ResourceLimits, LiveStatus, HostMountPreset, DatabaseInstance, LogicalDatabase, NodePlacement } from '@/api/types'
+import type { Application, AppOverview, Deployment, Release, AppEnvVar, Route, Network, Stack, Volume, StatsSample, Registry, GitRepository, AppEvent, AppPort, PortBinding, AppDatabase, ConnectionInfo, DeployStrategy, RestartPolicy, ImagePullPolicy, BuildMethod, HealthcheckType, ResourceLimits, LiveStatus, HostMountPreset, DatabaseInstance, LogicalDatabase, NodePlacement, PipelineDefinition } from '@/api/types'
 
 // Secret-reference example built here so `}}` doesn't break the template's
 // mustache parser.
@@ -423,6 +424,45 @@ const deployTag = ref('')
 const deployStrategy = ref<DeployStrategy>('rolling')
 const deploying = ref(false)
 
+// --- Repository pipeline ---
+//
+// When the app's repository carries a pipeline, deploys run through it. The app
+// then has no direct build of its own, which changes what several controls mean:
+// the build-method settings stop applying, and a deploy produces a run rather
+// than a deployment.
+const repoPipeline = ref<PipelineDefinition | null>(null)
+const deploysViaPipeline = computed(() => !!repoPipeline.value)
+
+async function loadRepoPipeline() {
+  repoPipeline.value = null
+  if (!wid.value || app.value?.source_type !== 'git') return
+  try {
+    // Pipelines are listed workspace-wide; find the repo-owned one bound to this
+    // app. Failure is silent — this only enriches the page.
+    const res = await pipelineApi.list(wid.value, 0, 100)
+    repoPipeline.value =
+      (res.data.data ?? []).find((p) => p.application_id === appId.value && p.source === 'repo' && p.enabled) ?? null
+  } catch {
+    repoPipeline.value = null
+  }
+}
+
+/**
+ * Follow whatever a deploy produced. A pipeline run has its own page — that is
+ * where its per-step logs live — while a direct deployment streams into the
+ * Deployments tab as before.
+ */
+function followDeploy(res: Deployment | PipelineRunAccepted, message: string) {
+  if (isPipelineRun(res)) {
+    notify.success(`${message} — pipeline run #${res.run.number} started`)
+    router.push({ name: 'pipeline-run', params: { id: res.run.pipeline_id, runId: res.run.id } })
+    return
+  }
+  notify.success(message)
+  tab.value = 'deployments'
+  streamLogs(res.id)
+}
+
 // Canary (live rollout state derived from the app)
 const canaryActive = computed(() => !!app.value?.canary_release_id)
 const canaryWeight = computed(() => app.value?.canary_weight ?? 0)
@@ -537,6 +577,7 @@ async function loadApp() {
   try {
     app.value = (await appApi.get(wid.value, appId.value)).data.data
     syncSettingsForm()
+    await loadRepoPipeline()
   } catch (e) {
     notify.apiError(e)
   }
@@ -794,10 +835,7 @@ async function requestBind() {
       // Auto-approved (privileged): the port only publishes on the next deploy.
       await loadApp() // refresh the "redeploy required" header indicator
       if (isDeployed.value && await askConfirm({ title: 'Host port bound', message: 'The port only publishes on the next deploy. Redeploy now to publish it?', confirmLabel: 'Redeploy now', cancelLabel: 'Later' })) {
-        const dep = (await appApi.deploy(wid.value, appId.value, {})).data.data
-        notify.success('Redeploying to publish the port')
-        tab.value = 'deployments'
-        streamLogs(dep.id)
+        followDeploy((await appApi.deploy(wid.value, appId.value, {})).data.data, 'Redeploying to publish the port')
       } else {
         notify.success(`Host port bound${changeNote()}`)
       }
@@ -837,10 +875,7 @@ async function removeBind(b: PortBinding) {
     await portBindingApi.cancel(wid.value, b.id)
     appBindings.value = (await portBindingApi.listByApp(wid.value, appId.value)).data.data ?? []
     if (approved && await askConfirm({ title: 'Binding released', message: 'Redeploy now to free the host port?', confirmLabel: 'Redeploy now', cancelLabel: 'Later' })) {
-      const dep = (await appApi.deploy(wid.value, appId.value, {})).data.data
-      notify.success('Redeploying to free the port')
-      tab.value = 'deployments'
-      streamLogs(dep.id)
+      followDeploy((await appApi.deploy(wid.value, appId.value, {})).data.data, 'Redeploying to free the port')
     } else {
       notify.success(approved ? 'Binding released — redeploy the app to free the port' : 'Binding cancelled')
     }
@@ -1028,11 +1063,9 @@ async function confirmDeploy() {
       strategy: deployStrategy.value,
       ...(app.value.source_type === 'image' ? { tag: deployTag.value.trim() } : {}),
     }
-    const dep = (await appApi.deploy(wid.value, appId.value, opts)).data.data
-    notify.success('Deployment started')
+    const res = (await appApi.deploy(wid.value, appId.value, opts)).data.data
     showDeploy.value = false
-    tab.value = 'deployments'
-    streamLogs(dep.id)
+    followDeploy(res, 'Deployment started')
   } catch (e) {
     notify.apiError(e, 'Deploy failed')
   } finally {
@@ -2443,9 +2476,18 @@ async function detachDatabase(d: AppDatabase) {
                 <input v-model="settingsForm.git_ref" class="form-input" placeholder="main" :disabled="!ws.canEdit" />
               </div>
             </div>
+            <div v-if="deploysViaPipeline" class="tpl-notice">
+              <span class="mdi mdi-pipe"></span>
+              <div class="tpl-notice-text">
+                <strong>This app builds through its repository's pipeline.</strong>
+                The steps in <code>{{ repoPipeline?.source_path }}</code> decide how the image is built, so the build
+                method and builder below no longer apply. Edit the file in git, or
+                <router-link :to="{ name: 'pipelines' }">remove the pipeline</router-link> to build directly again.
+              </div>
+            </div>
             <div class="form-group">
               <label class="form-label">Build method</label>
-              <select v-model="settingsForm.build_method" class="form-select" :disabled="!ws.canEdit">
+              <select v-model="settingsForm.build_method" class="form-select" :disabled="!ws.canEdit || deploysViaPipeline">
                 <option value="auto">Auto (recommended)</option>
                 <option value="buildpack">Buildpacks (no Dockerfile)</option>
                 <option value="dockerfile">Dockerfile</option>
@@ -2454,8 +2496,16 @@ async function detachDatabase(d: AppDatabase) {
             </div>
             <div v-if="settingsForm.build_method !== 'dockerfile'" class="form-group">
               <label class="form-label">Builder image <span class="text-muted">(optional, advanced)</span></label>
-              <input v-model="settingsForm.builder" class="form-input" placeholder="paketobuildpacks/builder-jammy-base" :disabled="!ws.canEdit" />
+              <input v-model="settingsForm.builder" class="form-input" placeholder="paketobuildpacks/builder-jammy-base" :disabled="!ws.canEdit || deploysViaPipeline" />
               <p class="form-hint">Override the Cloud Native Buildpacks builder. Leave empty to use the platform default.</p>
+            </div>
+            <div v-if="deploysViaPipeline" class="form-group">
+              <label class="form-label">Deploy on push</label>
+              <p class="form-hint">
+                Miabi runs the pipeline when you deploy. To also run it on every push, add its webhook to your Git
+                provider — the URL and secret are on the
+                <router-link :to="{ name: 'pipelines' }">Pipelines</router-link> page.
+              </p>
             </div>
           </template>
           <div class="form-group">
@@ -3034,6 +3084,15 @@ async function detachDatabase(d: AppDatabase) {
                 </div>
                 <p class="form-hint" style="margin-bottom: 16px">Deploys <code>{{ app.image }}:{{ deployTag.trim() || 'latest' }}</code> as a new release.</p>
               </template>
+              <div v-else-if="deploysViaPipeline" class="tpl-notice" style="margin-bottom: 16px">
+                <span class="mdi mdi-pipe"></span>
+                <div class="tpl-notice-text">
+                  <strong>Deploys run the “{{ repoPipeline?.display_name || repoPipeline?.name }}” pipeline.</strong>
+                  Miabi runs the steps in <code>{{ repoPipeline?.source_path }}</code> on
+                  <code>{{ app.git_ref || 'the default branch' }}</code>; the deploy step rolls out the image they build.
+                  You'll follow the run's logs, not a deployment's.
+                </div>
+              </div>
               <p v-else class="text-muted text-sm" style="margin-bottom: 16px">Builds the latest commit from the configured Git source as a new release.</p>
               <div class="form-group" style="margin-bottom: 8px">
                 <label class="form-label">Deployment strategy</label>

--- a/web/src/views/apps/Apps.vue
+++ b/web/src/views/apps/Apps.vue
@@ -7,7 +7,7 @@ import { useNotificationStore } from '@/stores/notification'
 import { appApi } from '@/api/apps'
 import { usageApi } from '@/api/resources'
 import { registryApi } from '@/api/registries'
-import { gitRepositoryApi } from '@/api/gitRepositories'
+import { gitRepositoryApi, type GitInspectResult } from '@/api/gitRepositories'
 import { networkApi } from '@/api/networks'
 import { stackApi } from '@/api/stacks'
 import type { Application, Registry, GitRepository, Network, Stack, AppPort, BuildMethod, RuntimeKind } from '@/api/types'
@@ -63,10 +63,69 @@ interface AppForm {
   // Swarm placement constraints, e.g. ["node.id==abc"]. Only meaningful for the
   // service runtime, where the scheduler — not server_id — decides placement.
   placement_constraints: string[]
+  // Adopt the pipeline the repository carries at .miabi/pipeline.yaml. Only
+  // offered once a probe has actually found one.
+  use_pipeline: boolean
 }
 function emptyForm(): AppForm {
-  return { name: '', server_id: 0, source_type: 'image', image: '', tag: '', git_repo: '', git_ref: '', build_method: 'auto', builder: '', registry_id: null, git_repository_id: null, stack_id: null, network_ids: [], ports: [{ container_port: 8080, protocol: 'tcp', scheme: 'http', name: '' }], runtime_kind: 'container', replicas: 1, placement_constraints: [] }
+  return { name: '', server_id: 0, source_type: 'image', image: '', tag: '', git_repo: '', git_ref: '', build_method: 'auto', builder: '', registry_id: null, git_repository_id: null, stack_id: null, network_ids: [], ports: [{ container_port: 8080, protocol: 'tcp', scheme: 'http', name: '' }], runtime_kind: 'container', replicas: 1, placement_constraints: [], use_pipeline: true }
 }
+
+// --- Repository inspection ---
+//
+// Probing clones the repo server-side, so it is deliberately manual: the user
+// asks for it once the URL and branch are filled in. The result decides whether
+// the pipeline toggle is offered at all.
+const inspecting = ref(false)
+const inspected = ref<GitInspectResult | null>(null)
+const inspectError = ref('')
+
+/** Reset the probe whenever the thing being probed changes. */
+function resetInspection() {
+  inspected.value = null
+  inspectError.value = ''
+}
+watch(() => [form.value.git_repo, form.value.git_ref, form.value.git_repository_id], resetInspection)
+
+const canInspect = computed(
+  () => form.value.source_type === 'git' && (!!form.value.git_repo.trim() || !!form.value.git_repository_id),
+)
+
+async function inspectRepo() {
+  if (!currentWorkspaceId.value || !canInspect.value) return
+  inspecting.value = true
+  inspectError.value = ''
+  inspected.value = null
+  try {
+    inspected.value = (
+      await gitRepositoryApi.inspect(currentWorkspaceId.value, {
+        git_repo: form.value.git_repo.trim() || undefined,
+        git_ref: form.value.git_ref.trim() || undefined,
+        git_repository_id: form.value.git_repository_id,
+      })
+    ).data.data ?? null
+    // Default the toggle on when a pipeline is found, off otherwise, so the
+    // create call never claims a pipeline the probe didn't see.
+    form.value.use_pipeline = inspected.value?.has_pipeline === true
+  } catch (e: any) {
+    inspectError.value = e?.response?.data?.message || e?.message || 'Could not read the repository'
+  } finally {
+    inspecting.value = false
+  }
+}
+
+/** A short human summary of when the discovered pipeline runs. */
+const pipelineTriggerLabel = computed(() => {
+  const r = inspected.value
+  if (!r?.has_pipeline) return ''
+  const parts: string[] = []
+  if (r.triggers_push) {
+    parts.push(r.push_branches?.length ? `on push to ${r.push_branches.join(', ')}` : 'on any push')
+  }
+  if (r.schedule) parts.push(`on schedule (${r.schedule})`)
+  if (!parts.length) parts.push('when you deploy')
+  return parts.join(' · ')
+})
 // A service is placed by the Swarm scheduler, which ignores server_id; a container
 // is placed by server_id. The two are never both meaningful, so the form shows one
 // control or the other.
@@ -125,6 +184,10 @@ async function create() {
       builder: !isImage && form.value.build_method !== 'dockerfile' ? form.value.builder.trim() || undefined : undefined,
       registry_id: isImage ? form.value.registry_id : null,
       git_repository_id: !isImage ? form.value.git_repository_id : null,
+      // Only claim a pipeline the probe actually found — the backend re-reads the
+      // repository regardless, but asking for one that isn't there just produces a
+      // warning on the app's timeline.
+      use_pipeline: !isImage && form.value.use_pipeline && inspected.value?.has_pipeline === true,
       stack_id: form.value.stack_id,
       network_ids: form.value.network_ids,
       ports: form.value.ports.filter((p) => p.container_port > 0),
@@ -338,6 +401,61 @@ function formatCreated(ts?: string) {
                   <input v-model="form.builder" class="form-input" placeholder="paketobuildpacks/builder-jammy-base" />
                   <p class="form-hint">Override the Cloud Native Buildpacks builder. Leave empty to use the platform default.</p>
                 </div>
+                <div class="form-group">
+                  <label class="form-label">Repository contents</label>
+                  <button type="button" class="btn btn-secondary btn-sm" :disabled="!canInspect || inspecting" @click="inspectRepo">
+                    <span class="mdi" :class="inspecting ? 'mdi-loading mdi-spin' : 'mdi-magnify'"></span>
+                    {{ inspecting ? 'Reading repository…' : 'Check repository' }}
+                  </button>
+                  <p class="form-hint">
+                    Looks for a Dockerfile and a <code>.miabi/pipeline.yaml</code>. Optional — it also verifies the URL and credentials.
+                  </p>
+
+                  <p v-if="inspectError" class="form-hint text-danger">
+                    <span class="mdi mdi-alert-circle-outline"></span> {{ inspectError }}
+                  </p>
+
+                  <div v-else-if="inspected" class="inspect-result">
+                    <!-- Found a usable pipeline: offer to adopt it. -->
+                    <template v-if="inspected.has_pipeline">
+                      <label class="inspect-toggle">
+                        <input v-model="form.use_pipeline" type="checkbox" />
+                        <span>
+                          <strong>Use the pipeline from {{ inspected.pipeline_path }}</strong>
+                          <span class="text-muted"> — runs {{ pipelineTriggerLabel }}</span>
+                        </span>
+                      </label>
+                      <ol class="inspect-steps">
+                        <li v-for="s in inspected.steps" :key="s.name">
+                          <span class="step-name">{{ s.name }}</span>
+                          <span class="text-muted">{{ s.uses ? `built-in: ${s.uses}` : s.image }}</span>
+                          <span v-if="s.continue_on_error" class="badge badge-neutral">continue on error</span>
+                        </li>
+                      </ol>
+                      <p v-if="form.use_pipeline" class="form-hint">
+                        Deploys run these steps instead of building directly. The file in git stays the source of
+                        truth — edit it there and push.
+                      </p>
+                      <p v-else class="form-hint">
+                        The app will build and deploy directly, skipping the steps above.
+                      </p>
+                    </template>
+
+                    <!-- A pipeline file exists but is broken: say so rather than silently building. -->
+                    <p v-else-if="inspected.pipeline_error" class="form-hint text-danger">
+                      <span class="mdi mdi-alert-circle-outline"></span>
+                      Found <code>{{ inspected.pipeline_path }}</code> but it isn't valid: {{ inspected.pipeline_error }}.
+                      The app will build directly until you fix it.
+                    </p>
+
+                    <p v-else class="form-hint">
+                      <span class="mdi mdi-check"></span>
+                      No pipeline file — this app will build
+                      {{ inspected.has_dockerfile ? 'from its Dockerfile' : 'with Cloud Native Buildpacks' }}
+                      and deploy.
+                    </p>
+                  </div>
+                </div>
               </template>
               <div class="form-group">
                 <label class="form-label">Container ports</label>
@@ -396,4 +514,11 @@ function formatCreated(ts?: string) {
 .form-row { display: flex; gap: 12px; margin-bottom: 20px; }
 .port-row { display: flex; gap: 8px; align-items: center; margin-bottom: 8px; }
 .form-hint code { background: var(--bg-tertiary); padding: 1px 6px; border-radius: 4px; font-size: 12px; color: var(--text-secondary); }
+.text-danger { color: var(--danger, #dc2626); }
+.inspect-result { margin-top: 10px; padding: 12px; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-secondary); }
+.inspect-toggle { display: flex; gap: 8px; align-items: flex-start; font-size: 13px; cursor: pointer; }
+.inspect-toggle input { margin-top: 3px; flex-shrink: 0; }
+.inspect-steps { margin: 10px 0 0; padding-left: 20px; font-size: 12px; display: flex; flex-direction: column; gap: 4px; }
+.inspect-steps li { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+.inspect-steps .step-name { font-weight: 600; }
 </style>

--- a/web/src/views/pipelines/Pipelines.vue
+++ b/web/src/views/pipelines/Pipelines.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useRouter } from 'vue-router'
 import { useWorkspaceStore } from '@/stores/workspace'
@@ -92,13 +92,24 @@ function openEdit(p: PipelineDefinition) {
   showModal.value = true
 }
 
+/** A repo-owned pipeline mirrors a file in git; its spec is read-only here. */
+function isRepoOwned(p: PipelineDefinition | null) { return p?.source === 'repo' }
+const editingRepoOwned = computed(() => isRepoOwned(editing.value))
+function shortCommit(sha?: string) { return sha ? sha.slice(0, 7) : '' }
+
 async function save() {
   if (!currentWorkspaceId.value) return
   saving.value = true
   try {
     if (editing.value) {
-      await pipelineApi.update(currentWorkspaceId.value, editing.value.id, form.value)
-      notify.success('Pipeline updated')
+      // A repo-owned pipeline only accepts its enabled flag; everything else is
+      // derived from the repository and the app, and the backend rejects a change
+      // to it. Send just that, so the one editable control still works.
+      const payload: PipelineInput = editingRepoOwned.value
+        ? { name: editing.value.name, spec: '', enabled: form.value.enabled }
+        : form.value
+      await pipelineApi.update(currentWorkspaceId.value, editing.value.id, payload)
+      notify.success(editingRepoOwned.value ? (form.value.enabled ? 'Pipeline enabled' : 'Pipeline disabled') : 'Pipeline updated')
     } else {
       await pipelineApi.create(currentWorkspaceId.value, form.value)
       notify.success('Pipeline created')
@@ -185,7 +196,12 @@ function openLastRun(p: PipelineDefinition) {
                 <div class="cell-id">
                   <span class="avatar avatar-sm"><span class="mdi mdi-pipe" style="font-size: 14px"></span></span>
                   <span class="cell-text">
-                    <span class="cell-title link" @click="openRuns(p)">{{ p.name }}</span>
+                    <span class="cell-title link" @click="openRuns(p)">
+                      {{ p.name }}
+                      <span v-if="isRepoOwned(p)" class="repo-chip" :title="`Spec read from ${p.source_path} on ${p.source_ref || 'the default branch'}`">
+                        <span class="mdi mdi-source-branch"></span> from repo
+                      </span>
+                    </span>
                     <span class="cell-sub" :title="new Date(p.created_at).toLocaleString()">created {{ relativeTime(p.created_at) }}</span>
                   </span>
                 </div>
@@ -213,7 +229,15 @@ function openLastRun(p: PipelineDefinition) {
                 <button v-if="ws.canEdit" class="btn-icon btn-icon-muted" title="Run now" aria-label="Run now" :disabled="triggering === p.id || !p.enabled" @click="trigger(p)">
                   <span class="mdi" :class="triggering === p.id ? 'mdi-loading mdi-spin' : 'mdi-play'"></span>
                 </button>
-                <button v-if="ws.canEdit" class="btn-icon btn-icon-muted" title="Edit" aria-label="Edit" @click="openEdit(p)"><span class="mdi mdi-pencil-outline"></span></button>
+                <button
+                  v-if="ws.canEdit"
+                  class="btn-icon btn-icon-muted"
+                  :title="isRepoOwned(p) ? 'View (managed by repository)' : 'Edit'"
+                  :aria-label="isRepoOwned(p) ? 'View' : 'Edit'"
+                  @click="openEdit(p)"
+                >
+                  <span class="mdi" :class="isRepoOwned(p) ? 'mdi-eye-outline' : 'mdi-pencil-outline'"></span>
+                </button>
                 <button v-if="ws.canEdit" class="btn-icon btn-icon-danger" title="Delete" aria-label="Delete" @click="toDelete = p"><span class="mdi mdi-delete-outline"></span></button>
               </td>
             </tr>
@@ -228,33 +252,66 @@ function openLastRun(p: PipelineDefinition) {
       <div v-if="showModal" class="modal-overlay" @click.self="showModal = false">
         <div class="modal modal-lg">
           <div class="modal-header">
-            <h3>{{ editing ? 'Edit pipeline' : 'New pipeline' }}</h3>
+            <h3>{{ editing ? (editingRepoOwned ? 'Pipeline' : 'Edit pipeline') : 'New pipeline' }}</h3>
             <button class="btn-icon btn-icon-muted" aria-label="Close" @click="showModal = false"><span class="mdi mdi-close"></span></button>
           </div>
           <form @submit.prevent="save">
             <div class="modal-body">
+              <div v-if="editingRepoOwned" class="repo-notice">
+                <span class="mdi mdi-source-branch"></span>
+                <div>
+                  <strong>Managed by its repository.</strong>
+                  Miabi re-reads <code>{{ editing?.source_path }}</code> on
+                  <code>{{ editing?.source_ref || 'the default branch' }}</code> before every run, so this pipeline
+                  can't be edited here — change the file in git and push. You can still disable it, which makes
+                  <template v-if="appName(editing?.application_id)">{{ appName(editing?.application_id) }}</template>
+                  <template v-else>its application</template>
+                  build and deploy directly again.
+                </div>
+              </div>
               <div class="form-row">
                 <div class="form-group">
                   <label class="form-label">Name</label>
-                  <input v-model="form.name" class="form-input" placeholder="e.g. web" required autofocus aria-label="Name" />
+                  <input v-model="form.name" class="form-input" placeholder="e.g. web" required autofocus aria-label="Name" :disabled="editingRepoOwned" />
                 </div>
                 <div class="form-group">
                   <label class="form-label">Deploy target <span class="text-muted">(for the deploy step)</span></label>
-                  <select v-model="form.application_id" class="form-select" aria-label="Deploy target">
+                  <select v-model="form.application_id" class="form-select" aria-label="Deploy target" :disabled="editingRepoOwned">
                     <option :value="null">None</option>
                     <option v-for="a in apps" :key="a.id" :value="a.id">{{ a.name }}</option>
                   </select>
                 </div>
               </div>
               <div class="form-group" style="margin-bottom: 0">
-                <label class="form-label">Pipeline spec <span class="text-muted">(kind: Pipeline)</span></label>
-                <textarea v-model="form.spec" class="form-textarea code" rows="16" spellcheck="false" required aria-label="Pipeline spec"></textarea>
+                <label class="form-label">
+                  Pipeline spec <span class="text-muted">(kind: Pipeline)</span>
+                  <span v-if="editingRepoOwned" class="repo-chip">
+                    <span class="mdi mdi-source-branch"></span> managed by repository
+                  </span>
+                </label>
+                <textarea
+                  v-model="form.spec"
+                  class="form-textarea code"
+                  rows="16"
+                  spellcheck="false"
+                  required
+                  aria-label="Pipeline spec"
+                  :readonly="editingRepoOwned"
+                ></textarea>
+                <p v-if="editingRepoOwned" class="form-hint">
+                  Read-only.
+                  <template v-if="editing?.source_commit">Synced from commit {{ shortCommit(editing.source_commit) }}.</template>
+                </p>
               </div>
               <label class="check"><input type="checkbox" v-model="form.enabled" /> <span>Enabled</span></label>
             </div>
             <div class="modal-footer">
-              <button type="button" class="btn btn-secondary" @click="showModal = false">Cancel</button>
-              <button type="submit" class="btn btn-primary" :disabled="saving">{{ saving ? 'Saving…' : (editing ? 'Save' : 'Create') }}</button>
+              <button type="button" class="btn btn-secondary" @click="showModal = false">
+                {{ editingRepoOwned ? 'Close' : 'Cancel' }}
+              </button>
+              <button type="submit" class="btn btn-primary" :disabled="saving">
+                {{ saving ? 'Saving…' : editingRepoOwned ? 'Save enabled state' : editing ? 'Save' : 'Create' }}
+              </button>
             </div>
           </form>
         </div>
@@ -264,7 +321,9 @@ function openLastRun(p: PipelineDefinition) {
     <ConfirmDialog
       :open="!!toDelete"
       title="Delete pipeline"
-      :message="`Delete pipeline &quot;${toDelete?.name}&quot;? Its run history is removed.`"
+      :message="isRepoOwned(toDelete)
+        ? `Delete pipeline &quot;${toDelete?.name}&quot;? Its run history is removed, and its application goes back to building and deploying directly — skipping the steps in ${toDelete?.source_path}.`
+        : `Delete pipeline &quot;${toDelete?.name}&quot;? Its run history is removed.`"
       confirm-label="Delete"
       variant="danger"
       :busy="deleting"
@@ -286,6 +345,22 @@ function openLastRun(p: PipelineDefinition) {
 .link { cursor: pointer; }
 .link:hover { color: var(--primary-500); }
 .code { font-family: 'JetBrains Mono', monospace; font-size: 12px; line-height: 1.5; }
+.form-textarea[readonly] { background: var(--bg-tertiary, rgba(127, 127, 127, 0.08)); cursor: default; }
+.repo-chip {
+  display: inline-flex; align-items: center; gap: 4px; font-size: 11px; font-weight: 500;
+  padding: 1px 7px; border-radius: 20px; margin-left: 6px; vertical-align: middle;
+  background: var(--bg-tertiary, rgba(127, 127, 127, 0.12)); color: var(--text-secondary, var(--text-muted));
+}
+.repo-chip .mdi { font-size: 12px; }
+.repo-notice {
+  display: flex; gap: 10px; align-items: flex-start; margin-bottom: 16px; padding: 12px;
+  border: 1px solid var(--border); border-radius: 8px;
+  background: var(--bg-tertiary, rgba(127, 127, 127, 0.08));
+  font-size: 13px; line-height: 1.5; color: var(--text-secondary, var(--text-muted));
+}
+.repo-notice .mdi { font-size: 18px; flex-shrink: 0; }
+.repo-notice code { background: var(--bg-secondary); padding: 1px 6px; border-radius: 4px; font-size: 12px; }
+.form-input:disabled, .form-select:disabled { opacity: 0.65; cursor: not-allowed; }
 .target-chip {
   display: inline-flex; align-items: center; gap: 5px; font-size: 12px; padding: 2px 9px;
   border-radius: 20px; background: var(--bg-tertiary, rgba(127, 127, 127, 0.12));


### PR DESCRIPTION
Creating an application from a Git repository built an image and deployed it, ignoring any pipeline the repository carried — the spec had to be copied into Miabi by hand, and it drifted from the file the moment either changed.