### PR TITLE
feat(analytics): show the status-code split as a pie

### DIFF
--- a/web/src/assets/styles.css
+++ b/web/src/assets/styles.css
@@ -102,7 +102,17 @@
   --sidebar-text-active: #ffffff;
 
   --checkmark: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='black'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='m4.5 12.75 6 6 9-13.5' /%3E%3C/svg%3E");
-  --checkmark-color: #581c87
+  --checkmark-color: #581c87;
+
+  /* Status-class colors for chart marks. 5xx steps deeper than --danger-500
+     because 4xx and 5xx sit against each other as adjacent pie wedges and
+     stacked bar segments: amber #d97706 vs #ef4444 measures ΔE 11.8 to normal
+     vision and 4.4 under deuteranopia — indistinguishable where they touch.
+     Dark mode gets its own step; #b91c1c goes muddy on a dark surface. */
+  --chart-2xx: var(--success-600);
+  --chart-3xx: #2563eb;
+  --chart-4xx: var(--warning-600);
+  --chart-5xx: var(--danger-700);
 }
 
 /* ─── Dark Theme ─── */
@@ -139,6 +149,8 @@
   --sidebar-border: rgba(255, 255, 255, 0.06);
   --sidebar-text: #8888a8;
   --sidebar-text-active: #e8e8f0;
+
+  --chart-5xx: #e11d48;
 
   --success-50: #0d2818;
   --warning-50: #2d1f0a;
@@ -1070,18 +1082,18 @@ input[type="checkbox"]:checked::before {
 .a-legend { display: flex; gap: 18px; margin-top: 14px; font-size: 12px; color: var(--text-muted); flex-wrap: wrap; }
 .dot { display: inline-block; width: 9px; height: 9px; border-radius: 2px; margin-right: 4px; vertical-align: middle; }
 .dot-ok { background: var(--primary-500); }
-.dot-5xx { background: var(--danger-500); }
-.dot-2xx { background: var(--success-600); }
-.dot-3xx { background: #2563eb; }
-.dot-4xx { background: var(--warning-600); }
+.dot-5xx { background: var(--chart-5xx); }
+.dot-2xx { background: var(--chart-2xx); }
+.dot-3xx { background: var(--chart-3xx); }
+.dot-4xx { background: var(--chart-4xx); }
 
-/* status-class stacked bar */
+/* status-class stacked bar (human vs bot on Web Analytics) */
 .status-bar { display: flex; height: 10px; border-radius: 5px; overflow: hidden; background: var(--border-primary); }
 .status-bar .seg { height: 100%; }
-.seg-2xx { background: var(--success-600); }
-.seg-3xx { background: #2563eb; }
-.seg-4xx { background: var(--warning-600); }
-.seg-5xx { background: var(--danger-500); }
+.seg-2xx { background: var(--chart-2xx); }
+.seg-3xx { background: var(--chart-3xx); }
+.seg-4xx { background: var(--chart-4xx); }
+.seg-5xx { background: var(--chart-5xx); }
 .status-legend { display: flex; gap: 18px; margin-top: 12px; font-size: 12px; color: var(--text-muted); flex-wrap: wrap; }
 .status-legend b { color: var(--text-primary); }
 

--- a/web/src/views/analytics/HttpTraffic.vue
+++ b/web/src/views/analytics/HttpTraffic.vue
@@ -1,16 +1,11 @@
 <script setup lang="ts">
 import AnalyticsShell from './AnalyticsShell.vue'
 import Breakdown from './Breakdown.vue'
+import StatusPie from './StatusPie.vue'
 import WorldMap from '@/components/WorldMap.vue'
-import type { AnalyticsReport } from '@/api/analytics'
 import { fmtNum } from './format'
 
 const GEOIP_DOCS = 'https://docs.miabi.io/docs/operations/analytics#geoip-database'
-
-function statusTotal(r: AnalyticsReport): number {
-  const s = r.status
-  return Math.max(1, s.s2xx + s.s3xx + s.s4xx + s.s5xx)
-}
 </script>
 
 <template>
@@ -46,18 +41,7 @@ function statusTotal(r: AnalyticsReport): number {
       <div class="card">
         <div class="a-card-header"><h3>Status codes</h3></div>
         <div class="card-body">
-          <div class="status-bar">
-            <div class="seg seg-2xx" :style="{ width: (report.status.s2xx / statusTotal(report)) * 100 + '%' }"></div>
-            <div class="seg seg-3xx" :style="{ width: (report.status.s3xx / statusTotal(report)) * 100 + '%' }"></div>
-            <div class="seg seg-4xx" :style="{ width: (report.status.s4xx / statusTotal(report)) * 100 + '%' }"></div>
-            <div class="seg seg-5xx" :style="{ width: (report.status.s5xx / statusTotal(report)) * 100 + '%' }"></div>
-          </div>
-          <div class="status-legend">
-            <span><i class="dot dot-2xx"></i> 2xx <b>{{ fmtNum(report.status.s2xx) }}</b></span>
-            <span><i class="dot dot-3xx"></i> 3xx <b>{{ fmtNum(report.status.s3xx) }}</b></span>
-            <span><i class="dot dot-4xx"></i> 4xx <b>{{ fmtNum(report.status.s4xx) }}</b></span>
-            <span><i class="dot dot-5xx"></i> 5xx <b>{{ fmtNum(report.status.s5xx) }}</b></span>
-          </div>
+          <StatusPie :status="report.status" />
         </div>
       </div>
 

--- a/web/src/views/analytics/Overview.vue
+++ b/web/src/views/analytics/Overview.vue
@@ -4,6 +4,7 @@ import Sparkline from '@/components/Sparkline.vue'
 import AnalyticsShell from './AnalyticsShell.vue'
 import StatTile from './StatTile.vue'
 import RequestsChart from './RequestsChart.vue'
+import StatusPie from './StatusPie.vue'
 import type { AnalyticsReport } from '@/api/analytics'
 import { fmtNum, fmtBytes, fmtMs, fmtPct, delta, countryFlag, countryName } from './format'
 
@@ -16,10 +17,6 @@ function rate(n: number, total: number): number {
 // Quiet buckets carry no latency, so they'd drag the sparkline to zero.
 function latency(r: AnalyticsReport): number[] {
   return r.series.filter((p) => p.requests > 0).map((p) => p.p95_latency_ms)
-}
-function statusTotal(r: AnalyticsReport): number {
-  const s = r.status
-  return Math.max(1, s.s2xx + s.s3xx + s.s4xx + s.s5xx)
 }
 const topCountries = (r: AnalyticsReport) => r.web.top_countries.slice(0, 5)
 </script>
@@ -60,18 +57,7 @@ const topCountries = (r: AnalyticsReport) => r.web.top_countries.slice(0, 5)
       <div class="card">
         <div class="a-card-header"><h3>Status codes</h3></div>
         <div class="card-body">
-          <div class="status-bar">
-            <div class="seg seg-2xx" :style="{ width: (report.status.s2xx / statusTotal(report)) * 100 + '%' }"></div>
-            <div class="seg seg-3xx" :style="{ width: (report.status.s3xx / statusTotal(report)) * 100 + '%' }"></div>
-            <div class="seg seg-4xx" :style="{ width: (report.status.s4xx / statusTotal(report)) * 100 + '%' }"></div>
-            <div class="seg seg-5xx" :style="{ width: (report.status.s5xx / statusTotal(report)) * 100 + '%' }"></div>
-          </div>
-          <div class="status-legend">
-            <span><i class="dot dot-2xx"></i> 2xx <b>{{ fmtNum(report.status.s2xx) }}</b></span>
-            <span><i class="dot dot-3xx"></i> 3xx <b>{{ fmtNum(report.status.s3xx) }}</b></span>
-            <span><i class="dot dot-4xx"></i> 4xx <b>{{ fmtNum(report.status.s4xx) }}</b></span>
-            <span><i class="dot dot-5xx"></i> 5xx <b>{{ fmtNum(report.status.s5xx) }}</b></span>
-          </div>
+          <StatusPie :status="report.status" />
           <div class="perf-inline">
             <span>Avg {{ fmtMs(report.totals.avg_latency_ms) }}</span>
             <span>p95 {{ fmtMs(report.totals.p95_latency_ms) }}</span>

--- a/web/src/views/analytics/RequestsChart.vue
+++ b/web/src/views/analytics/RequestsChart.vue
@@ -220,8 +220,8 @@ const summary = computed(
 /* 2px of card surface separates touching segments — no strokes. */
 .rc-bar.gap { margin-bottom: 2px; }
 .b-ok { background: var(--primary-500); }
-.b-4xx { background: var(--warning-600); }
-.b-5xx { background: var(--danger-500); }
+.b-4xx { background: var(--chart-4xx); }
+.b-5xx { background: var(--chart-5xx); }
 /* A bucket with no traffic keeps a baseline mark, so "zero" never reads as "missing". */
 .rc-zero { height: 2px; background: var(--border-primary); border-radius: 1px; }
 
@@ -248,8 +248,8 @@ const summary = computed(
 .rc-tip-foot.no-top { margin-top: 0; padding-top: 0; border-top: none; }
 .k { width: 10px; height: 2px; border-radius: 1px; flex: 0 0 auto; }
 .k-ok { background: var(--primary-500); }
-.k-4xx { background: var(--warning-600); }
-.k-5xx { background: var(--danger-500); }
+.k-4xx { background: var(--chart-4xx); }
+.k-5xx { background: var(--chart-5xx); }
 
 @media (max-width: 639px) {
   .rc-frame { grid-template-rows: 160px auto; }

--- a/web/src/views/analytics/StatusPie.vue
+++ b/web/src/views/analytics/StatusPie.vue
@@ -1,0 +1,217 @@
+<script setup lang="ts">
+// Status-code split as a pie, with the counts beside it.
+//
+// The pie answers "is this workspace healthy at a glance"; it cannot answer
+// "how many 4xx" — a real distribution is something like 460/9/1/0, where the
+// last two classes are sub-degree slivers. So the legend beside it is not
+// decoration: it is where the numbers actually live, and every slice is named
+// there whether or not it is visible in the ring.
+//
+// `hole` is the inner radius as a fraction of the outer one; 0 draws a solid
+// pie instead of a ring.
+import { computed, ref } from 'vue'
+import type { AnalyticsStatus } from '@/api/analytics'
+import { fmtNum } from './format'
+
+// The legend is a column of percentages, so they all carry the same precision —
+// the shared fmtPct switches decimals below 10% and would set 97.9% next to
+// 1.91%. A class with traffic never rounds away to "0.0%".
+function pct(frac: number): string {
+  if (frac > 0 && frac < 0.001) return '<0.1%'
+  return (frac * 100).toFixed(1) + '%'
+}
+
+const props = withDefaults(
+  defineProps<{
+    status: AnalyticsStatus
+    hole?: number
+    size?: number
+  }>(),
+  { hole: 0.62, size: 148 },
+)
+
+const R = 46 // outer radius in viewBox units (viewBox is 0 0 100 100)
+const C = 50 // center
+
+const hover = ref<string | null>(null)
+
+interface Slice {
+  key: string
+  label: string
+  hint: string
+  count: number
+}
+
+const slices = computed<Slice[]>(() => [
+  { key: '2xx', label: '2xx', hint: 'Success', count: props.status.s2xx },
+  { key: '3xx', label: '3xx', hint: 'Redirects', count: props.status.s3xx },
+  { key: '4xx', label: '4xx', hint: 'Client errors', count: props.status.s4xx },
+  { key: '5xx', label: '5xx', hint: 'Server errors', count: props.status.s5xx },
+])
+
+const total = computed(() => slices.value.reduce((a, s) => a + s.count, 0))
+const rows = computed(() =>
+  slices.value.map((s) => ({ ...s, frac: total.value > 0 ? s.count / total.value : 0 })),
+)
+// Only non-zero classes get a wedge; the zero ones still get a legend row.
+const drawn = computed(() => rows.value.filter((r) => r.count > 0))
+
+function pt(angle: number, r: number): string {
+  return `${(C + r * Math.cos(angle)).toFixed(3)},${(C + r * Math.sin(angle)).toFixed(3)}`
+}
+
+// arc builds one wedge (or ring segment when hole > 0) from a0 to a1 radians.
+function arc(a0: number, a1: number): string {
+  const ri = R * props.hole
+  const large = a1 - a0 > Math.PI ? 1 : 0
+  if (ri <= 0) {
+    return `M${C},${C} L${pt(a0, R)} A${R},${R} 0 ${large} 1 ${pt(a1, R)} Z`
+  }
+  return (
+    `M${pt(a0, R)} A${R},${R} 0 ${large} 1 ${pt(a1, R)}` +
+    ` L${pt(a1, ri)} A${ri},${ri} 0 ${large} 0 ${pt(a0, ri)} Z`
+  )
+}
+
+// A 2px gap of surface between neighbours, in radians at the outer edge. Slices
+// too thin to survive the padding keep their full angle — a sliver that would
+// vanish is worse than one that touches its neighbour.
+const PAD = 2 / R
+
+const wedges = computed(() => {
+  const out: { key: string; d: string }[] = []
+  let a = -Math.PI / 2 // 12 o'clock
+  for (const r of drawn.value) {
+    const span = r.frac * Math.PI * 2
+    const pad = span > PAD * 3 && drawn.value.length > 1 ? PAD / 2 : 0
+    out.push({ key: r.key, d: arc(a + pad, a + span - pad) })
+    a += span
+  }
+  return out
+})
+
+// One class holding everything is a full circle: an arc whose ends coincide
+// draws nothing, so it needs the circle primitive instead.
+const solo = computed(() => (drawn.value.length === 1 ? drawn.value[0] : null))
+const ringWidth = computed(() => R - R * props.hole)
+const ringRadius = computed(() => (R + R * props.hole) / 2)
+
+const active = computed(() => rows.value.find((r) => r.key === hover.value) ?? null)
+
+const summary = computed(
+  () =>
+    `Status codes: ${rows.value.map((r) => `${r.label} ${r.count}`).join(', ')} of ${total.value} requests`,
+)
+</script>
+
+<template>
+  <div class="sp">
+    <div class="sp-chart" :style="{ width: size + 'px', height: size + 'px' }">
+      <svg viewBox="0 0 100 100" role="img" :aria-label="summary" class="sp-svg">
+        <template v-if="total > 0">
+          <template v-if="solo">
+            <circle
+              v-if="hole > 0"
+              :cx="C" :cy="C" :r="ringRadius"
+              :stroke-width="ringWidth"
+              :class="['w', 'ring', 'w-' + solo.key]"
+            />
+            <circle v-else :cx="C" :cy="C" :r="R" :class="['w', 'w-' + solo.key]" />
+          </template>
+          <path
+            v-for="w in wedges"
+            v-else
+            :key="w.key"
+            :d="w.d"
+            :class="['w', 'w-' + w.key, { dim: hover !== null && hover !== w.key, on: hover === w.key }]"
+            @pointerenter="hover = w.key"
+            @pointerleave="hover = null"
+          />
+        </template>
+        <!-- No traffic at all: an empty track, so the card still has a shape. -->
+        <circle
+          v-else
+          :cx="C" :cy="C" :r="ringRadius"
+          fill="none" :stroke-width="ringWidth" class="w-empty"
+        />
+      </svg>
+
+      <!-- The hole doubles as the readout: hovering a slice swaps the total for
+           that class, which beats a floating tooltip over a 0.8° sliver. -->
+      <div v-if="hole > 0" class="sp-center">
+        <template v-if="active">
+          <div class="sp-c-value">{{ pct(active.frac) }}</div>
+          <div class="sp-c-label">{{ active.label }} · {{ fmtNum(active.count) }}</div>
+        </template>
+        <template v-else>
+          <div class="sp-c-value">{{ fmtNum(total) }}</div>
+          <div class="sp-c-label">requests</div>
+        </template>
+      </div>
+    </div>
+
+    <ul class="sp-legend">
+      <li
+        v-for="r in rows"
+        :key="r.key"
+        :class="{ on: hover === r.key, zero: r.count === 0 }"
+        @pointerenter="hover = r.key"
+        @pointerleave="hover = null"
+      >
+        <i class="sp-key" :class="'k-' + r.key"></i>
+        <span class="sp-l">{{ r.label }}</span>
+        <span class="sp-hint">{{ r.hint }}</span>
+        <b class="sp-n">{{ fmtNum(r.count) }}</b>
+        <span class="sp-p">{{ pct(r.frac) }}</span>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.sp { display: flex; align-items: center; gap: 22px; flex-wrap: wrap; }
+.sp-chart { position: relative; flex: 0 0 auto; }
+.sp-svg { width: 100%; height: 100%; display: block; overflow: visible; }
+
+/* The class carries the hue via `color`; the shape decides whether that lands on
+   the fill or the stroke. Setting both would put a 1-unit outline on every wedge,
+   which swallows the 2px gaps between them. */
+.w { fill: currentColor; stroke: none; transition: opacity 0.15s, transform 0.15s; cursor: default; }
+.w.ring { fill: none; stroke: currentColor; }
+.w.dim { opacity: 0.4; }
+/* The hovered wedge lifts out of the ring, so the highlight reads as "this one"
+   rather than "everything else faded". */
+.w.on { transform: scale(1.04); transform-origin: 50px 50px; transform-box: view-box; }
+.w-2xx { color: var(--chart-2xx); }
+.w-3xx { color: var(--chart-3xx); }
+.w-4xx { color: var(--chart-4xx); }
+.w-5xx { color: var(--chart-5xx); }
+.w-empty { stroke: var(--border-primary); }
+
+.sp-center {
+  position: absolute; inset: 0; display: flex; flex-direction: column;
+  align-items: center; justify-content: center; pointer-events: none; text-align: center;
+}
+.sp-c-value { font-size: 22px; font-weight: 700; color: var(--text-primary); letter-spacing: -0.02em; }
+.sp-c-label { font-size: 11px; color: var(--text-muted); margin-top: 1px; }
+
+.sp-legend { flex: 1 1 190px; min-width: 190px; list-style: none; margin: 0; padding: 0; }
+.sp-legend li {
+  display: flex; align-items: center; gap: 8px;
+  padding: 5px 6px; margin: 0 -6px; border-radius: 6px;
+  font-size: 13px; color: var(--text-secondary);
+}
+.sp-legend li.on { background: var(--bg-tertiary); }
+.sp-legend li.zero { color: var(--text-muted); }
+.sp-key { width: 9px; height: 9px; border-radius: 2px; flex: 0 0 auto; }
+.k-2xx { background: var(--chart-2xx); }
+.k-3xx { background: var(--chart-3xx); }
+.k-4xx { background: var(--chart-4xx); }
+.k-5xx { background: var(--chart-5xx); }
+.sp-l { font-weight: 600; color: var(--text-primary); }
+.sp-legend li.zero .sp-l { color: var(--text-muted); font-weight: 500; }
+.sp-hint { flex: 1; color: var(--text-muted); font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.sp-n { font-variant-numeric: tabular-nums; color: var(--text-primary); }
+.sp-legend li.zero .sp-n { color: var(--text-muted); }
+.sp-p { font-variant-numeric: tabular-nums; color: var(--text-muted); font-size: 12px; min-width: 46px; text-align: right; }
+</style>


### PR DESCRIPTION
Replaces the stacked bar on Overview and HTTP Traffic with a ring, keeping every class and its count.