### PR TITLE
feat(analytics): live visitors

### DIFF
--- a/cmd/miabi/server.go
+++ b/cmd/miabi/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/miabi-io/miabi/internal/runners"
 	"github.com/miabi-io/miabi/internal/selfcontainer"
 	"github.com/miabi-io/miabi/internal/services/alerting"
+	"github.com/miabi-io/miabi/internal/services/analytics"
 	"github.com/miabi-io/miabi/internal/services/application"
 	"github.com/miabi-io/miabi/internal/services/backup"
 	"github.com/miabi-io/miabi/internal/services/backupsettings"
@@ -477,6 +478,7 @@ func runServer(cli *okapicli.CLI) {
 					repositories.NewAnalyticsRepository(res.db),
 					cfg.AnalyticsStream, analyticsConsumerName("server"),
 					time.Duration(cfg.AnalyticsFlushSeconds)*time.Second, analyticsRetention(cfg, edition),
+					analytics.NewLiveTracker(res.redis, liveWindow(cfg)),
 				)
 				go analyticsConsumer.Run(eventCtx)
 			}
@@ -618,6 +620,12 @@ func analyticsRetention(cfg *config.Config, edition enterprise.EE) func() int {
 	return func() int {
 		return enterprise.ClampAnalyticsRetention(cfg.AnalyticsRetentionDays, edition.Entitlements().AnalyticsRetentionDays())
 	}
+}
+
+// liveWindow resolves how long a visitor counts as live. Shared by the consumer
+// (which writes) and the API (which reads), so both agree on the window.
+func liveWindow(cfg *config.Config) time.Duration {
+	return time.Duration(cfg.AnalyticsLiveWindowSeconds) * time.Second
 }
 
 func shutdownServer(res *serverResources) {

--- a/cmd/miabi/worker.go
+++ b/cmd/miabi/worker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/miabi-io/miabi/internal/netguard"
 	"github.com/miabi-io/miabi/internal/nodes"
 	"github.com/miabi-io/miabi/internal/proxy"
+	"github.com/miabi-io/miabi/internal/services/analytics"
 	"github.com/miabi-io/miabi/internal/services/application"
 	"github.com/miabi-io/miabi/internal/services/backup"
 	"github.com/miabi-io/miabi/internal/services/backupsettings"
@@ -289,6 +290,7 @@ func runWorker() error {
 			repositories.NewAnalyticsRepository(db),
 			cfg.AnalyticsStream, analyticsConsumerName("worker"),
 			time.Duration(cfg.AnalyticsFlushSeconds)*time.Second, analyticsRetention(cfg, edition),
+			analytics.NewLiveTracker(cfg.Redis.Client, liveWindow(cfg)),
 		)
 		go analyticsConsumer.Run(context.Background())
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -160,6 +160,13 @@ type Config struct {
 	AnalyticsFlushSeconds int
 	// AnalyticsRetentionDays bounds how long rollups are kept before pruning.
 	AnalyticsRetentionDays int
+	// AnalyticsLiveWindowSeconds is how long a visitor keeps counting as "live"
+	// after their last request. It spans the gap between one visitor's requests,
+	// not the length of their visit — someone reading a page sends nothing for
+	// minutes and is still there, which is why 5m is the norm. Keep it in step
+	// with the gateway's monitoring.visitorTTL, or the dashboard's live count and
+	// Goma's Prometheus gauge will disagree.
+	AnalyticsLiveWindowSeconds int
 
 	// ACMEDirectoryURL is the ACME CA directory Miabi issues managed (DNS-01)
 	// certificates from. Empty = Let's Encrypt production. Point it at the LE
@@ -541,6 +548,7 @@ func New() *Config {
 		AnalyticsStream:            goutils.Env("MIABI_ANALYTICS_STREAM", "goma:analytics"),
 		AnalyticsFlushSeconds:      goutils.EnvInt("MIABI_ANALYTICS_FLUSH_SECONDS", 15),
 		AnalyticsRetentionDays:     goutils.EnvInt("MIABI_ANALYTICS_RETENTION_DAYS", 90),
+		AnalyticsLiveWindowSeconds: goutils.EnvInt("MIABI_ANALYTICS_LIVE_WINDOW_SECONDS", 300),
 		ACMEDirectoryURL:           goutils.Env("MIABI_ACME_DIRECTORY_URL", ""),
 		CertRenewDays:              goutils.EnvInt("MIABI_CERT_RENEW_DAYS", 30),
 		KeyAutoRotate:              goutils.EnvBool("MIABI_KEY_AUTO_ROTATE", false),

--- a/internal/handlers/analytics_handler.go
+++ b/internal/handlers/analytics_handler.go
@@ -24,10 +24,14 @@ import (
 type AnalyticsHandler struct {
 	repo *repositories.AnalyticsRepository
 	ee   enterprise.EE
+	// live is nil when Redis isn't configured; the endpoint then reports zero
+	// rather than failing, since live visitors is an accent on the dashboard and
+	// not something worth erroring a page over.
+	live *analytics.LiveTracker
 }
 
-func NewAnalyticsHandler(repo *repositories.AnalyticsRepository, ee enterprise.EE) *AnalyticsHandler {
-	return &AnalyticsHandler{repo: repo, ee: ee}
+func NewAnalyticsHandler(repo *repositories.AnalyticsRepository, ee enterprise.EE, live *analytics.LiveTracker) *AnalyticsHandler {
+	return &AnalyticsHandler{repo: repo, ee: ee, live: live}
 }
 
 // maxAnalyticsRange caps how far back a single query may look, keeping the
@@ -137,6 +141,38 @@ func (h *AnalyticsHandler) Export(c *okapi.Context) error {
 		})
 	}
 	return nil
+}
+
+// Live returns the number of distinct visitors seen in the last few minutes,
+// for the workspace or (with ?app=) one application. It is polled by the
+// dashboard, so it stays a single cheap Redis read and never touches the
+// database. Community and Enterprise alike.
+func (h *AnalyticsHandler) Live(c *okapi.Context) error {
+	wsID := middlewares.WorkspaceID(c)
+
+	appFilter, err := appFilterParam(c)
+	if err != nil {
+		return c.AbortBadRequest("invalid app id")
+	}
+	var app uint
+	if appFilter != nil {
+		app = *appFilter
+	}
+
+	window := analytics.DefaultLiveWindow
+	if h.live != nil {
+		window = h.live.Window()
+	}
+	// A missing or unreachable Redis means "nobody counted", not an error: the
+	// rest of the dashboard reads from Postgres and is unaffected.
+	count, err := h.live.Count(c.Request().Context(), wsID, app)
+	if err != nil {
+		count = 0
+	}
+	return ok(c, map[string]any{
+		"visitors":       count,
+		"window_seconds": int(window.Seconds()),
+	})
 }
 
 // appFilterParam reads an optional ?app= application id (nil when absent).

--- a/internal/routes/monitoring_routes.go
+++ b/internal/routes/monitoring_routes.go
@@ -94,6 +94,14 @@ func (r *Router) monitoringRoutes() []okapi.RouteDefinition {
 		},
 		{
 			Method:      http.MethodGet,
+			Path:        "/{workspace}/analytics/live",
+			Group:       g,
+			Middlewares: scoped(models.WorkspaceRoleViewer),
+			Handler:     r.h.analytics.Live,
+			Summary:     "Visitors active in the last few minutes — ?app=",
+		},
+		{
+			Method:      http.MethodGet,
 			Path:        "/{workspace}/analytics/export",
 			Group:       g,
 			Middlewares: scoped(models.WorkspaceRoleViewer),

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -26,6 +26,7 @@ import (
 	"github.com/miabi-io/miabi/internal/proxy"
 	"github.com/miabi-io/miabi/internal/runners"
 	"github.com/miabi-io/miabi/internal/services/account"
+	"github.com/miabi-io/miabi/internal/services/analytics"
 	"github.com/miabi-io/miabi/internal/services/application"
 	"github.com/miabi-io/miabi/internal/services/apply"
 	"github.com/miabi-io/miabi/internal/services/audit"
@@ -956,7 +957,7 @@ func InitRoutes(app *okapi.Okapi, db *gorm.DB, redisClient *redis.Client, cfg *c
 			volumeBackup:    handlers.NewVolumeBackupHandler(volumeBackupService, volumeRepo, volumeBackupRepo, auditLogger),
 			workspaceBundle: handlers.NewWorkspaceBundleHandler(wsBundleService, auditLogger),
 			monitoring:      handlers.NewMonitoringHandler(monitoringService),
-			analytics:       handlers.NewAnalyticsHandler(repositories.NewAnalyticsRepository(db), ee),
+			analytics:       handlers.NewAnalyticsHandler(repositories.NewAnalyticsRepository(db), ee, analytics.NewLiveTracker(redisClient, time.Duration(cfg.AnalyticsLiveWindowSeconds)*time.Second)),
 			inbox:           handlers.NewNotificationInboxHandler(repositories.NewNotificationInboxRepository(db), bus),
 			alerts:          handlers.NewAlertHandler(repositories.NewAlertRepository(db)),
 			marketplace:     handlers.NewMarketplaceHandler(marketplaceService, auditLogger),

--- a/internal/services/analytics/aggregate.go
+++ b/internal/services/analytics/aggregate.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/axiomhq/hyperloglog"
 	"github.com/miabi-io/miabi/internal/models"
@@ -86,6 +87,25 @@ func Percentile(hist []int64, p float64) float64 {
 	return float64(LatencyBoundsMs[len(LatencyBoundsMs)-1])
 }
 
+// maxPathLen bounds a stored request path. The gateway has no per-request path
+// patterns, so the paths breakdown is keyed on the raw request path — which is
+// client-controlled and ends up in the rollup's JSON map, so it can't be left
+// unbounded.
+const maxPathLen = 128
+
+// clipPath truncates an over-long path on a rune boundary, so the stored key
+// stays valid UTF-8.
+func clipPath(p string) string {
+	if len(p) <= maxPathLen {
+		return p
+	}
+	cut := maxPathLen
+	for cut > 0 && !utf8.RuneStart(p[cut]) {
+		cut--
+	}
+	return p[:cut] + "…"
+}
+
 // topKAdd adds n to key in m, keeping m bounded: once at cap, a new key only
 // displaces the current minimum (approximate top-K, fine for a dashboard).
 func topKAdd(m map[string]int64, key string, n int64) {
@@ -119,6 +139,14 @@ func mergeTopK(dst, src map[string]int64) {
 // classifyUA derives a coarse browser family, OS and device from a User-Agent
 // string with cheap substring matching — enough for the analytics breakdowns,
 // no dependency, no fingerprinting beyond family. bot is true for common crawlers.
+// IsBotUA reports whether a user agent looks automated, using the same rule as
+// the rollups' bot/human split — exported so callers outside the aggregator
+// (live visitors) classify traffic identically.
+func IsBotUA(ua string) bool {
+	_, _, _, bot := classifyUA(ua)
+	return bot
+}
+
 func classifyUA(ua string) (family, os, device string, bot bool) {
 	u := strings.ToLower(ua)
 	if u == "" {
@@ -271,10 +299,13 @@ func (a *Aggregator) Ingest(e *Event, ws, app uint) {
 	if e.VID != "" {
 		b.hll.Insert([]byte(e.VID))
 	}
+	// Prefer a path template when the gateway can supply one (it collapses
+	// /orders/1 and /orders/2 into one row); today it can't, so this is the raw
+	// request path.
 	if p := e.PathTemplate; p != "" {
-		topKAdd(r.TopPaths, p, 1)
+		topKAdd(r.TopPaths, clipPath(p), 1)
 	} else if e.Path != "" {
-		topKAdd(r.TopPaths, e.Path, 1)
+		topKAdd(r.TopPaths, clipPath(e.Path), 1)
 	}
 	topKAdd(r.TopReferrers, e.RefererHost, 1)
 	topKAdd(r.TopCountries, e.Country, 1)

--- a/internal/services/analytics/aggregate_test.go
+++ b/internal/services/analytics/aggregate_test.go
@@ -5,6 +5,7 @@ package analytics
 
 import (
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -91,8 +92,10 @@ func TestAggregatorIngestFlushAndMerge(t *testing.T) {
 
 	mk := func(status int, dur int64, vid, path string) *Event {
 		return &Event{
+			// No PathTemplate: the gateway has no per-request patterns, so real
+			// events carry only the request path.
 			Ts: base, Route: "mb-ws9-shop", Method: "GET", Status: status,
-			Path: path, PathTemplate: path, ReqBytes: 100, RespBytes: 2000,
+			Path: path, ReqBytes: 100, RespBytes: 2000,
 			DurationMs: dur, UpstreamMs: dur - 2, VID: vid, Country: "US",
 			UA: "Mozilla/5.0 Chrome/120", RefererHost: "google.com",
 		}
@@ -185,5 +188,58 @@ func TestBuildReportFillsEmptyBuckets(t *testing.T) {
 	}
 	if nonEmpty != 2 || total != 14 {
 		t.Fatalf("non-empty buckets = %d (want 2), total requests = %d (want 14)", nonEmpty, total)
+	}
+}
+
+// Top paths is keyed on the request path, so distinct paths stay distinct. The
+// gateway used to send its route mount prefix as PathTemplate — "/" for most
+// routes — and since a template wins over the raw path, every request in a route
+// collapsed into a single "/" row.
+func TestIngestKeysPathsOnRequestPath(t *testing.T) {
+	a := NewAggregator()
+	base := time.Date(2026, 7, 18, 10, 30, 0, 0, time.UTC).UnixMilli()
+	ev := func(path string) *Event {
+		return &Event{Ts: base, Route: "mb-ws9-shop", Method: "GET", Status: 200, Path: path, VID: "v1"}
+	}
+	a.Ingest(ev("/"), 9, 3)
+	a.Ingest(ev("/pricing"), 9, 3)
+	a.Ingest(ev("/pricing"), 9, 3)
+	a.Ingest(ev("/docs/getting-started"), 9, 3)
+	// An over-long path is truncated rather than stored whole.
+	long := "/" + strings.Repeat("x", 400)
+	a.Ingest(ev(long), 9, 3)
+
+	rows := a.Flush(time.UnixMilli(base).UTC().Add(2 * time.Minute))
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	paths := rows[0].TopPaths
+	if paths["/pricing"] != 2 || paths["/"] != 1 || paths["/docs/getting-started"] != 1 {
+		t.Fatalf("paths keyed wrong: %+v", paths)
+	}
+	if _, ok := paths[long]; ok {
+		t.Fatalf("stored an unbounded path: %d bytes", len(long))
+	}
+	for k := range paths {
+		if len(k) > maxPathLen+4 { // +4 covers the multi-byte ellipsis
+			t.Fatalf("path key not clipped: %d bytes", len(k))
+		}
+	}
+}
+
+// A template still wins when the gateway can supply one, so the breakdown
+// collapses /orders/1 and /orders/2 if routing ever grows real path patterns.
+func TestIngestPrefersPathTemplateWhenPresent(t *testing.T) {
+	a := NewAggregator()
+	base := time.Date(2026, 7, 18, 10, 30, 0, 0, time.UTC).UnixMilli()
+	for _, id := range []string{"1", "2", "3"} {
+		a.Ingest(&Event{
+			Ts: base, Route: "mb-ws9-shop", Method: "GET", Status: 200,
+			Path: "/orders/" + id, PathTemplate: "/orders/:id", VID: "v1",
+		}, 9, 3)
+	}
+	rows := a.Flush(time.UnixMilli(base).UTC().Add(2 * time.Minute))
+	if got := rows[0].TopPaths["/orders/:id"]; got != 3 {
+		t.Fatalf("template not preferred: %+v", rows[0].TopPaths)
 	}
 }

--- a/internal/services/analytics/live.go
+++ b/internal/services/analytics/live.go
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package analytics
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// LiveTracker answers "how many distinct visitors are active right now", from
+// the same Goma event stream the rollups are built from. It is separate from the
+// gateway's own visitor tracker, which is a single gateway-wide Prometheus gauge:
+// this one is per workspace and per app. Both key on the event's daily-salted
+// visitor id, so no client address is stored.
+//
+// One sorted set per scope — member = visitor id, score = last-seen unix seconds
+// — so a count is a range query and expiry a range delete, both O(log N). State
+// lives in Redis rather than in the worker, so several workers (or control-plane
+// replicas) agree on one number and it survives a restart.
+//
+// Correctness comes from the score range on read, not from sweeping: a visitor
+// outside the window is never counted even if their entry is still there. Sweep
+// only bounds memory.
+type LiveTracker struct {
+	rdb    *redis.Client
+	window time.Duration
+
+	// scopes are the keys this process has written, so it knows what to sweep.
+	// Bounded by the number of workspaces and apps with traffic.
+	mu     sync.Mutex
+	scopes map[string]struct{}
+}
+
+// DefaultLiveWindow is how far back a visitor still counts as "live" — the
+// convention analytics products settled on (Plausible, Cloudflare, Fathom).
+const DefaultLiveWindow = 5 * time.Minute
+
+// liveKeyPrefix namespaces these keys. Miabi-owned, distinct from Goma's own
+// visitor set in the same Redis.
+const liveKeyPrefix = "miabi:live:"
+
+// liveKeyTTL drops a scope that stops receiving traffic even if no worker is
+// left to sweep it. Refreshed on every write.
+const liveKeyTTL = time.Hour
+
+// LiveVisit is one visitor sighting: the scope it belongs to, and who.
+type LiveVisit struct {
+	Workspace uint
+	App       uint
+	VID       string
+}
+
+func NewLiveTracker(rdb *redis.Client, window time.Duration) *LiveTracker {
+	if window <= 0 {
+		window = DefaultLiveWindow
+	}
+	return &LiveTracker{rdb: rdb, window: window, scopes: map[string]struct{}{}}
+}
+
+// Window is the "active within" period the counts describe.
+func (t *LiveTracker) Window() time.Duration { return t.window }
+
+// scopeKey builds the key for one scope. app 0 is the workspace-wide scope.
+func scopeKey(ws, app uint) string {
+	if app == 0 {
+		return fmt.Sprintf("%sws%d", liveKeyPrefix, ws)
+	}
+	return fmt.Sprintf("%sws%d:app%d", liveKeyPrefix, ws, app)
+}
+
+// Touch records a batch of sightings as active now. Callers batch by their
+// natural boundary (one stream read) so this is a handful of round trips per
+// batch rather than one per event. Best-effort: a Redis failure costs a live
+// count, never an ingest.
+func (t *LiveTracker) Touch(ctx context.Context, visits []LiveVisit) {
+	if t == nil || t.rdb == nil || len(visits) == 0 {
+		return
+	}
+	now := float64(time.Now().Unix())
+
+	// Group by scope so each key takes one multi-member ZADD. A visitor seen
+	// twice in a batch is one member either way — the score just lands on the
+	// later value.
+	byKey := make(map[string][]redis.Z, 4)
+	for _, v := range visits {
+		if v.Workspace == 0 || v.VID == "" {
+			continue
+		}
+		z := redis.Z{Score: now, Member: v.VID}
+		byKey[scopeKey(v.Workspace, 0)] = append(byKey[scopeKey(v.Workspace, 0)], z)
+		if v.App != 0 {
+			byKey[scopeKey(v.Workspace, v.App)] = append(byKey[scopeKey(v.Workspace, v.App)], z)
+		}
+	}
+	if len(byKey) == 0 {
+		return
+	}
+
+	pipe := t.rdb.Pipeline()
+	for key, members := range byKey {
+		pipe.ZAdd(ctx, key, members...)
+		pipe.Expire(ctx, key, liveKeyTTL)
+	}
+	if _, err := pipe.Exec(ctx); err != nil {
+		return // best-effort; don't remember scopes we failed to write
+	}
+
+	t.mu.Lock()
+	for key := range byKey {
+		t.scopes[key] = struct{}{}
+	}
+	t.mu.Unlock()
+}
+
+// Count returns the distinct visitors active within the window for a scope
+// (app 0 = the whole workspace). Exact, and unaffected by how recently a sweep
+// ran, because the window is applied as a score range.
+func (t *LiveTracker) Count(ctx context.Context, ws, app uint) (int64, error) {
+	if t == nil || t.rdb == nil || ws == 0 {
+		return 0, nil
+	}
+	since := time.Now().Add(-t.window).Unix()
+	n, err := t.rdb.ZCount(ctx, scopeKey(ws, app), strconv.FormatInt(since, 10), "+inf").Result()
+	if err == redis.Nil {
+		return 0, nil
+	}
+	return n, err
+}
+
+// Sweep drops visitors who have fallen outside the window from every scope this
+// process writes to. Purely housekeeping — counts are already window-correct —
+// so a failure is logged by the caller at most, never fatal.
+func (t *LiveTracker) Sweep(ctx context.Context) {
+	if t == nil || t.rdb == nil {
+		return
+	}
+	t.mu.Lock()
+	keys := make([]string, 0, len(t.scopes))
+	for k := range t.scopes {
+		keys = append(keys, k)
+	}
+	t.mu.Unlock()
+	if len(keys) == 0 {
+		return
+	}
+
+	cutoff := "(" + strconv.FormatInt(time.Now().Add(-t.window).Unix(), 10)
+	pipe := t.rdb.Pipeline()
+	for _, k := range keys {
+		pipe.ZRemRangeByScore(ctx, k, "-inf", cutoff)
+	}
+	_, _ = pipe.Exec(ctx)
+}

--- a/internal/services/analytics/live_test.go
+++ b/internal/services/analytics/live_test.go
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package analytics
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestLiveScopeKey(t *testing.T) {
+	// The workspace scope and an app scope inside it must never collide.
+	ws := scopeKey(9, 0)
+	app := scopeKey(9, 3)
+	if ws == app {
+		t.Fatalf("workspace and app scope share a key: %q", ws)
+	}
+	if ws != "miabi:live:ws9" || app != "miabi:live:ws9:app3" {
+		t.Fatalf("unexpected keys: %q %q", ws, app)
+	}
+	// Distinct workspaces never share a set (ws1+app11 vs ws11+app1).
+	if scopeKey(1, 11) == scopeKey(11, 1) {
+		t.Fatal("workspace/app ids ambiguous in the key")
+	}
+}
+
+func TestLiveWindowDefaults(t *testing.T) {
+	if got := NewLiveTracker(nil, 0).Window(); got != DefaultLiveWindow {
+		t.Fatalf("zero window = %v, want %v", got, DefaultLiveWindow)
+	}
+	if got := NewLiveTracker(nil, 90*time.Second).Window(); got != 90*time.Second {
+		t.Fatalf("explicit window = %v, want 90s", got)
+	}
+}
+
+// Redis is optional: with none wired the tracker stays silent rather than
+// erroring, since live visitors is an accent on a dashboard that otherwise reads
+// from Postgres.
+func TestLiveTrackerNoRedisIsInert(t *testing.T) {
+	ctx := context.Background()
+	tr := NewLiveTracker(nil, time.Minute)
+	tr.Touch(ctx, []LiveVisit{{Workspace: 9, App: 3, VID: "vid"}}) // must not panic
+	tr.Sweep(ctx)
+	n, err := tr.Count(ctx, 9, 0)
+	if err != nil || n != 0 {
+		t.Fatalf("Count with no redis = %d, %v; want 0, nil", n, err)
+	}
+
+	var nilTracker *LiveTracker
+	nilTracker.Touch(ctx, []LiveVisit{{Workspace: 9, VID: "vid"}})
+	nilTracker.Sweep(ctx)
+	if n, err := nilTracker.Count(ctx, 9, 0); err != nil || n != 0 {
+		t.Fatalf("nil tracker Count = %d, %v; want 0, nil", n, err)
+	}
+}
+
+// An empty or unusable batch must not reach Redis at all — the nil client here
+// would panic if a command were issued.
+func TestLiveTrackerSkipsUnusableVisits(t *testing.T) {
+	tr := &LiveTracker{rdb: nil, window: time.Minute, scopes: map[string]struct{}{}}
+	tr.Touch(context.Background(), nil)
+	tr.Touch(context.Background(), []LiveVisit{
+		{Workspace: 0, App: 3, VID: "no-workspace"},
+		{Workspace: 9, App: 3, VID: ""},
+	})
+	if len(tr.scopes) != 0 {
+		t.Fatalf("remembered scopes for unusable visits: %v", tr.scopes)
+	}
+}
+
+// Counting a scope with no traffic must be zero, not an error, so the pill can
+// render before the first visitor arrives.
+func TestLiveCountUnknownScope(t *testing.T) {
+	tr := NewLiveTracker(nil, time.Minute)
+	if n, err := tr.Count(context.Background(), 4242, 0); err != nil || n != 0 {
+		t.Fatalf("unknown scope = %d, %v; want 0, nil", n, err)
+	}
+}
+
+func TestIsBotUA(t *testing.T) {
+	if !IsBotUA("Googlebot/2.1 (+http://www.google.com/bot.html)") {
+		t.Error("googlebot not classified as a bot")
+	}
+	if IsBotUA("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120 Safari/537.36") {
+		t.Error("chrome classified as a bot")
+	}
+}

--- a/internal/worker/analytics.go
+++ b/internal/worker/analytics.go
@@ -33,10 +33,14 @@ const (
 // interval. It resolves each event's workspace from the route name and its app
 // from a cached route→app map. Holds no per-request rows and no PII.
 type AnalyticsConsumer struct {
-	rdb      *redis.Client
-	routes   *repositories.RouteRepository
-	store    *repositories.AnalyticsRepository
-	agg      *analytics.Aggregator
+	rdb    *redis.Client
+	routes *repositories.RouteRepository
+	store  *repositories.AnalyticsRepository
+	agg    *analytics.Aggregator
+	// live counts visitors active in the last few minutes, straight off the
+	// stream — the rollups can't answer it, since a bucket isn't written until
+	// its minute closes and the grace period passes.
+	live     *analytics.LiveTracker
 	stream   string
 	consumer string
 
@@ -53,13 +57,19 @@ type AnalyticsConsumer struct {
 
 // NewAnalyticsConsumer wires the consumer. consumer is this worker's unique name
 // within the group (so pending-message ownership is per-worker). retentionDays is
-// evaluated on each prune; nil disables pruning (keep forever).
-func NewAnalyticsConsumer(rdb *redis.Client, routes *repositories.RouteRepository, store *repositories.AnalyticsRepository, stream, consumer string, flushEvery time.Duration, retentionDays func() int) *AnalyticsConsumer {
+// evaluated on each prune; nil disables pruning (keep forever). live is the
+// tracker the API reads from — passed in rather than built here so the window is
+// configured once, at the call site that owns it.
+func NewAnalyticsConsumer(rdb *redis.Client, routes *repositories.RouteRepository, store *repositories.AnalyticsRepository, stream, consumer string, flushEvery time.Duration, retentionDays func() int, live *analytics.LiveTracker) *AnalyticsConsumer {
 	if flushEvery <= 0 {
 		flushEvery = 15 * time.Second
 	}
+	if live == nil {
+		live = analytics.NewLiveTracker(rdb, analytics.DefaultLiveWindow)
+	}
 	return &AnalyticsConsumer{
 		rdb: rdb, routes: routes, store: store, agg: analytics.NewAggregator(),
+		live:   live,
 		stream: stream, consumer: consumer,
 		flushEvery: flushEvery, retentionDays: retentionDays,
 		routeMap: map[string]uint{},
@@ -102,12 +112,17 @@ func (c *AnalyticsConsumer) Run(ctx context.Context) {
 			continue
 		}
 		var ids []string
+		var visits []analytics.LiveVisit
 		for _, stream := range res {
 			for _, msg := range stream.Messages {
-				c.ingestMessage(msg)
+				if v, ok := c.ingestMessage(msg); ok {
+					visits = append(visits, v)
+				}
 				ids = append(ids, msg.ID)
 			}
 		}
+		// One write per stream read rather than one per event.
+		c.live.Touch(ctx, visits)
 		if len(ids) > 0 {
 			// Ack in-memory-accepted events; buckets persist on the flush ticker.
 			if err := c.rdb.XAck(ctx, c.stream, analyticsGroup, ids...).Err(); err != nil {
@@ -128,24 +143,33 @@ func (c *AnalyticsConsumer) ensureGroup(ctx context.Context) error {
 }
 
 // ingestMessage parses one stream message and folds it into the aggregator.
-func (c *AnalyticsConsumer) ingestMessage(msg redis.XMessage) {
+// ingestMessage rolls one event into its bucket and reports the visitor sighting
+// the caller should record, if the event counts towards live visitors.
+func (c *AnalyticsConsumer) ingestMessage(msg redis.XMessage) (analytics.LiveVisit, bool) {
 	raw, ok := msg.Values["e"].(string)
 	if !ok || raw == "" {
-		return
+		return analytics.LiveVisit{}, false
 	}
 	var e analytics.Event
 	if err := json.Unmarshal([]byte(raw), &e); err != nil {
-		return
+		return analytics.LiveVisit{}, false
 	}
 	if e.Route == "" {
-		return
+		return analytics.LiveVisit{}, false
 	}
 	ws := analytics.WorkspaceIDFromRoute(e.Route)
 	if ws == 0 {
-		return // not a workspace route (e.g. the platform gateway's own route)
+		return analytics.LiveVisit{}, false // not a workspace route (e.g. the platform gateway's own)
 	}
 	app := c.appFor(e.Route)
 	c.agg.Ingest(&e, ws, app)
+
+	// Live visitors counts people, so automated traffic is left out — a crawler
+	// sweeping the site shouldn't read as an audience.
+	if e.VID == "" || analytics.IsBotUA(e.UA) {
+		return analytics.LiveVisit{}, false
+	}
+	return analytics.LiveVisit{Workspace: ws, App: app, VID: e.VID}, true
 }
 
 // appFor resolves a Goma route name to its application id via a short-lived cache
@@ -188,6 +212,9 @@ func (c *AnalyticsConsumer) flushLoop(ctx context.Context) {
 			return
 		case <-flush.C:
 			c.flush(ctx)
+			// Live counts are already window-correct on read; this just keeps the
+			// visitor sets from holding everyone who ever visited.
+			c.live.Sweep(ctx)
 		case <-prune.C:
 			c.prune(ctx)
 		}

--- a/web/src/api/analytics.ts
+++ b/web/src/api/analytics.ts
@@ -93,6 +93,12 @@ export interface AnalyticsReport {
   exportable: boolean
 }
 
+// Distinct visitors seen within the live window (server-defined, ~5 minutes).
+export interface LiveVisitors {
+  visitors: number
+  window_seconds: number
+}
+
 // Workspace Analytics: HTTP traffic, performance and web analytics rolled up
 // from the gateway's request stream. `range` is a window ending now
 // (15m, 1h, 24h, 7d, 30d); `app` filters to a single application.
@@ -104,6 +110,12 @@ export const analyticsApi = {
   apps: (ws: number, range: string) =>
     api.get<ApiResponse<{ application_ids: number[] }>>(`${w(ws)}/analytics/apps`, {
       params: { range },
+    }),
+  // Visitors active in the last few minutes. Independent of `range` — it's a
+  // "right now" number, polled while the dashboard is open.
+  live: (ws: number, app?: number) =>
+    api.get<ApiResponse<LiveVisitors>>(`${w(ws)}/analytics/live`, {
+      params: { ...(app ? { app } : {}) },
     }),
   // CSV export (Enterprise-gated server-side). Returns the relative API path so
   // the caller can open it as a download.

--- a/web/src/stores/analytics.ts
+++ b/web/src/stores/analytics.ts
@@ -27,6 +27,13 @@ export const useAnalyticsStore = defineStore('analytics', () => {
   const appIds = ref<number[]>([])
   const appNames = ref<Record<number, string>>({})
 
+  // Live visitors is a "right now" number, so it polls on its own cadence
+  // instead of riding the report load. null = not loaded yet (the pill hides).
+  const live = ref<number | null>(null)
+  const liveWindowSeconds = ref(300)
+  let liveTimer: ReturnType<typeof setInterval> | null = null
+  let liveWatchers = 0
+
   let lastKey = ''
 
   function key(ws: number) {
@@ -75,6 +82,54 @@ export const useAnalyticsStore = defineStore('analytics', () => {
     }
   }
 
+  // LIVE_POLL_MS is the refresh cadence of the live pill. The number is a count
+  // over a multi-minute window, so polling faster only adds requests.
+  const LIVE_POLL_MS = 10_000
+
+  async function loadLive() {
+    const ws = useWorkspaceStore().currentWorkspaceId
+    if (!ws) return
+    try {
+      const res = await analyticsApi.live(ws, appFilter.value ?? undefined)
+      live.value = res.data.data?.visitors ?? 0
+      if (res.data.data?.window_seconds) liveWindowSeconds.value = res.data.data.window_seconds
+    } catch {
+      // Best-effort: a failed poll leaves the last known value in place rather
+      // than flashing the pill away.
+    }
+  }
+
+  // watchLive starts polling for the first watcher and stops when the last one
+  // leaves, so a backgrounded dashboard isn't polling forever. Returns the
+  // matching stop function. Polling pauses while the tab is hidden.
+  function watchLive(): () => void {
+    liveWatchers++
+    if (liveWatchers === 1) {
+      loadLive()
+      liveTimer = setInterval(() => {
+        if (!document.hidden) loadLive()
+      }, LIVE_POLL_MS)
+      document.addEventListener('visibilitychange', onVisible)
+    }
+    let stopped = false
+    return () => {
+      if (stopped) return
+      stopped = true
+      liveWatchers--
+      if (liveWatchers === 0) {
+        if (liveTimer) clearInterval(liveTimer)
+        liveTimer = null
+        document.removeEventListener('visibilitychange', onVisible)
+      }
+    }
+  }
+
+  // Refresh straight away when the tab comes back, so the pill isn't showing a
+  // number from before the user switched away.
+  function onVisible() {
+    if (!document.hidden) loadLive()
+  }
+
   function setRange(r: string) {
     if (r === range.value) return
     range.value = r
@@ -85,7 +140,12 @@ export const useAnalyticsStore = defineStore('analytics', () => {
     if (id === appFilter.value) return
     appFilter.value = id
     load()
+    loadLive() // the pill is app-scoped too
   }
 
-  return { range, appFilter, report, loading, error, appIds, appNames, load, setRange, setApp }
+  return {
+    range, appFilter, report, loading, error, appIds, appNames,
+    live, liveWindowSeconds,
+    load, setRange, setApp, loadLive, watchLive,
+  }
 })

--- a/web/src/views/analytics/AnalyticsHeader.vue
+++ b/web/src/views/analytics/AnalyticsHeader.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useRoute, useRouter } from 'vue-router'
 import { useAnalyticsStore, ANALYTICS_RANGES } from '@/stores/analytics'
@@ -13,7 +13,7 @@ import { windowLabel } from './timeaxis'
 // only renders the report, and it mirrors the range + app selection into the URL
 // query so a reload or shared link restores the same view.
 const store = useAnalyticsStore()
-const { range, appFilter, appIds, appNames, report } = storeToRefs(store)
+const { range, appFilter, appIds, appNames, report, live, liveWindowSeconds } = storeToRefs(store)
 const ws = useWorkspaceStore()
 const { currentWorkspaceId } = storeToRefs(ws)
 const route = useRoute()
@@ -52,12 +52,25 @@ function seedFromQuery() {
   if (Number.isFinite(a) && a > 0) store.appFilter = a
 }
 
+let stopLive: (() => void) | null = null
 onMounted(() => {
   seedFromQuery()
   store.load()
+  stopLive = store.watchLive()
 })
+onBeforeUnmount(() => stopLive?.())
 // Reload when the workspace changes (range/app changes go through store actions).
-watch(currentWorkspaceId, () => store.load())
+watch(currentWorkspaceId, () => {
+  store.load()
+  store.loadLive()
+})
+
+// The live pill hides until the first poll answers, so it never flashes a 0 that
+// only means "not asked yet".
+const liveLabel = computed(() => {
+  const m = Math.round(liveWindowSeconds.value / 60)
+  return `${live.value} visitor${live.value === 1 ? '' : 's'} active in the last ${m} minute${m === 1 ? '' : 's'}`
+})
 
 // Mirror the current selection into the URL (replace, so it doesn't spam history).
 watch([range, appFilter], () => {
@@ -86,6 +99,10 @@ function onAppChange(e: Event) {
         </span>
       </div>
       <div class="a-controls">
+        <span v-if="live !== null" class="a-live" :class="{ idle: live === 0 }" :title="liveLabel">
+          <i class="a-live-dot"></i>
+          <b>{{ live }}</b> live
+        </span>
         <select
           :value="appFilter ?? ''"
           class="form-select a-select" style="max-width: 180px;"
@@ -143,6 +160,27 @@ function onAppChange(e: Event) {
 .a-title h1 { margin: 0; font-size: 24px; line-height: 1.2; }
 .a-ns { color: var(--text-muted); font-size: 14px; }
 .a-window { color: var(--text-muted); font-size: 12px; white-space: nowrap; font-variant-numeric: tabular-nums; }
+
+/* Live visitors: a count of who's on the site right now, so it sits with the
+   controls rather than in the report body — it doesn't move with the range. */
+.a-live {
+  height: 34px; flex-shrink: 0;
+  display: inline-flex; align-items: center; gap: 7px;
+  padding: 0 12px; border: 1px solid var(--border-primary); border-radius: 8px;
+  background: var(--bg-secondary); color: var(--text-secondary);
+  font-size: 13px; white-space: nowrap;
+}
+.a-live b { color: var(--text-primary); font-variant-numeric: tabular-nums; }
+.a-live-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--success-600); flex: 0 0 auto; animation: a-live-pulse 2s ease-in-out infinite; }
+.a-live.idle { color: var(--text-muted); }
+.a-live.idle .a-live-dot { background: var(--text-muted); animation: none; }
+@keyframes a-live-pulse {
+  0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(22, 163, 74, 0.45); }
+  50% { opacity: 0.75; box-shadow: 0 0 0 4px rgba(22, 163, 74, 0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .a-live-dot { animation: none; }
+}
 .a-window .mdi { font-size: 13px; vertical-align: -1px; }
 .a-controls { display: flex; gap: 10px; align-items: center; flex-wrap: nowrap; max-width: 100%;}
 .a-select { padding: 7px 10px; border: 1px solid var(--border-primary); border-radius: 8px; background: var(--bg-secondary); color: var(--text-primary); font-size: 13px; }


### PR DESCRIPTION
Adds a live pill to the analytics header: distinct visitors active in the last few minutes, per workspace and per app, polled every 10s while the tab is visible