### PR TITLE
feat(credentials): declare registries in manifests and back them with vault secrets

### DIFF
--- a/cmd/miabi/server.go
+++ b/cmd/miabi/server.go
@@ -447,6 +447,9 @@ func runServer(cli *okapicli.CLI) {
 				nodeClients, bus, res.producer,
 			)
 			pipelineHandler.SetLogStore(logStore)
+			// Resolve a Git credential that references a workspace Secret instead of
+			// storing its own copy of the token.
+			pipelineHandler.SetSecrets(secretService)
 			// Translate Docker daemon container events into application events
 			// (start/crash/oom/health). One subscriber for the local node, plus one
 			// per remote node — started/stopped by the connection manager as agents

--- a/cmd/miabi/worker.go
+++ b/cmd/miabi/worker.go
@@ -277,6 +277,9 @@ func runWorker() error {
 		producer,
 	)
 	pipelineHandler.SetLogStore(logStore)
+	// Resolve a Git credential that references a workspace Secret instead of
+	// storing its own copy of the token.
+	pipelineHandler.SetSecrets(secretService)
 
 	// A standalone worker has no agent tunnels, so it must not consume the
 	// remote-node queue — those tasks are reserved for the control-plane server's

--- a/examples/apply/container-labels.yaml
+++ b/examples/apply/container-labels.yaml
@@ -1,0 +1,78 @@
+# Exposing an application through a label-driven reverse proxy (Traefik, Caddy
+# with the docker-proxy plugin, nginx-proxy, …) instead of Miabi's own gateway.
+#
+# `containerLabels` are stamped verbatim onto the app's container — or its Swarm
+# service — at deploy time, which is exactly what a proxy that discovers routes
+# from the Docker API reads. Editing one here redeploys the container, so a
+# routing rule is versioned in git like everything else.
+#
+# Two things this needs beyond the labels themselves:
+#
+#   1. A shared network. The proxy can only reach a container it shares a
+#      network with. Grouping both into one Stack is the declarative way to get
+#      that: stack members join the stack's network and resolve each other by
+#      name. Note an app with no Route never joins Miabi's shared gateway
+#      network, which is what you want here.
+#   2. Access to the Docker socket for the proxy itself. That is a privileged
+#      host mount, granted per app outside the manifest (Settings → Mounts on a
+#      privileged workspace) — a manifest can never bind a host path.
+#
+# Reserved namespaces (`io.miabi.*`, `com.docker.*`) are dropped on apply, so a
+# manifest can't spoof the platform's own labels; they are ignored by the diff
+# too, rather than reading as drift on every plan.
+#
+#   miabi apply -f container-labels.yaml
+---
+apiVersion: miabi.io/v1
+kind: Stack
+metadata:
+  name: edge
+spec:
+  description: Label-routed edge — the proxy and the apps it fronts
+---
+# The proxy. It discovers the app below from the Docker API and routes to it
+# over the stack network. Grant it the Docker socket after the first apply.
+apiVersion: miabi.io/v1
+kind: Application
+metadata:
+  name: traefik
+spec:
+  image: traefik
+  tag: "v3.3"
+  stack: edge
+  command:
+    - --providers.docker=true
+    # Only containers that opt in with traefik.enable are routed.
+    - --providers.docker.exposedbydefault=false
+    - --entrypoints.web.address=:80 # inside the container; published below
+  ports:
+    # The one port that faces the outside world. Host ports are bounded by
+    # MIABI_HOST_PORT_MIN/MAX (1024–… by default), and 80/443 belong to the
+    # platform's own gateway — so the proxy takes a high port and whatever sits
+    # in front of the node (a load balancer, or an nftables redirect) maps 80
+    # onto it. Drop hostPort to have one auto-allocated from the pool instead.
+    - container: 80
+      protocol: tcp
+      publish: true
+      hostPort: 8080
+---
+# The app being fronted. It publishes nothing itself: traffic reaches it only
+# through the proxy, over the stack network.
+apiVersion: miabi.io/v1
+kind: Application
+metadata:
+  name: web
+spec:
+  image: nginx
+  tag: "1.27-alpine"
+  stack: edge
+  ports:
+    - container: 80
+      scheme: http
+  containerLabels:
+    traefik.enable: "true"
+    traefik.http.routers.web.rule: "Host(`app.example.com`)"
+    traefik.http.routers.web.entrypoints: web
+    # The container port to forward to — the proxy addresses the app by its
+    # service name on the stack network.
+    traefik.http.services.web.loadbalancer.server.port: "80"

--- a/examples/apply/private-registry.yaml
+++ b/examples/apply/private-registry.yaml
@@ -1,0 +1,52 @@
+# Pulling a private image.
+#
+# A Registry is a container-registry credential. An Application selects one by
+# name through `spec.registry`; without it every pull is anonymous, so a private
+# image fails at deploy with a bare "manifest unknown" from the registry.
+#
+# Apply with:  miabi apply -f private-registry.yaml
+---
+# Keep the token in the vault, not in git. This Secret is what you rotate; the
+# Registry below only references it.
+apiVersion: miabi.io/v1
+kind: Secret
+metadata:
+  name: ghcr-token
+spec:
+  value: ghp_replace_me
+---
+apiVersion: miabi.io/v1
+kind: Registry
+metadata:
+  name: ghcr
+  annotations:
+    description: Read-only package token for the org's private images
+spec:
+  server: ghcr.io
+  username: my-org
+  # Two forms, and the difference is when the secret is read:
+  #
+  #   {{ .secrets.NAME }}    rendered at apply time — a copy is stored on the
+  #                          credential, so rotating the Secret needs a re-apply
+  #                          (the plan then reports "password: (current) → (rotated)")
+  #   ${{ secrets.NAME }}    stored as a live reference — read from the vault at
+  #                          every pull, so rotating the Secret is enough
+  #
+  # Neither is ever read back or shown in a plan. Prefer the reference form
+  # unless you want the credential pinned to the value at apply time.
+  password: "${{ secrets.ghcr-token }}"
+---
+apiVersion: miabi.io/v1
+kind: Application
+metadata:
+  name: api
+spec:
+  image: ghcr.io/my-org/api
+  tag: v1.4.0
+  # The credential need not be declared in this bundle: a name that isn't here is
+  # resolved against the workspace's existing credentials, so a token created
+  # once in the UI can be referenced from every manifest.
+  registry: ghcr
+  ports:
+    - container: 3000
+      externalAccess: true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -363,11 +364,15 @@ type RedisConfig struct {
 // with until the process restarts. The remaining fields override the
 // corresponding admin setting on boot.
 type RegistryConfig struct {
-	Enabled bool
-	Host    string
+	// Enabled runs the registry. EnabledSet distinguishes "MIABI_REGISTRY_ENABLED
+	// says false" from "nobody said anything": when the variable is absent the
+	// admin UI owns the switch, and only an explicitly-set variable pins it.
+	Enabled    bool
+	EnabledSet bool
+	Host       string
 	// StorageType is "filesystem" | "s3". S3 requires the registry_s3
-	// entitlement, checked at container start (registryserver), because the
-	// environment — not an API call — is what selects it.
+	// entitlement, checked both where the driver is selected (the admin API) and
+	// where it is used (container start).
 	StorageType string
 	Image       string // override the registry image (also via the image catalog)
 	// AuthURL is the address the gateway's forwardAuth calls to reach Miabi's
@@ -559,6 +564,7 @@ func New() *Config {
 		GomaConfigEncryptionKey:    goutils.Env("GOMA_CONFIG_ENCRYPTION_KEY", ""),
 		Registry: RegistryConfig{
 			Enabled:       goutils.EnvBool("MIABI_REGISTRY_ENABLED", false),
+			EnabledSet:    envPresent("MIABI_REGISTRY_ENABLED"),
 			Host:          goutils.Env("MIABI_REGISTRY_HOST", ""),
 			StorageType:   goutils.Env("MIABI_REGISTRY_STORAGE", ""),
 			Image:         goutils.Env("MIABI_REGISTRY_IMAGE", ""),
@@ -717,6 +723,14 @@ func (c *Config) DeploymentURL() string {
 // through — so "off" silences Okapi's logger and nothing else. Offering a switch that
 // looks like it turns logging off while the logs keep coming is worse than not
 // offering it. Use "error" for near-silence.
+// envPresent reports whether an environment variable was set at all, blank or
+// not. It is how a configuration field tells "the operator pinned this" from
+// "nobody said anything, so the admin UI owns it" — a zero value alone cannot.
+func envPresent(key string) bool {
+	_, ok := os.LookupEnv(key)
+	return ok
+}
+
 func (c *Config) LogLevelFor() (logger.LogLevel, error) {
 	switch strings.ToLower(strings.TrimSpace(c.LogLevel)) {
 	case "":

--- a/internal/declarative/container_labels_test.go
+++ b/internal/declarative/container_labels_test.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package declarative_test
+
+import (
+	"testing"
+
+	d "github.com/miabi-io/miabi/internal/declarative"
+)
+
+// live builds the snapshot form of an app carrying the given container labels.
+func liveApp(labels map[string]string) *d.ResourceSet {
+	set := d.NewResourceSet()
+	set.Add(d.Resource{
+		APIVersion: d.APIVersion, Kind: d.KindApplication, Metadata: d.Meta{Name: "web"},
+		Application: &d.ApplicationSpec{Image: "nginx", ContainerLabels: labels},
+	})
+	return set
+}
+
+func desiredApp(t *testing.T, labels string) *d.ResourceSet {
+	t.Helper()
+	src := "apiVersion: miabi.io/v1\nkind: Application\nmetadata: { name: web }\nspec:\n  image: nginx\n" + labels
+	set, err := d.Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return set
+}
+
+// An app exposed through a label-reading proxy is configured entirely by its
+// labels, so editing a routing rule must redeploy the container. Before this was
+// diffed, such an edit planned as nothing at all.
+func TestContainerLabelChangeConverges(t *testing.T) {
+	desired := desiredApp(t, "  containerLabels:\n    traefik.enable: \"true\"\n    traefik.http.routers.web.rule: \"Host(`new.example.com`)\"\n")
+	live := liveApp(map[string]string{
+		"traefik.enable":                "true",
+		"traefik.http.routers.web.rule": "Host(`old.example.com`)",
+	})
+
+	plan := d.BuildPlan(desired, live, d.PlanOptions{})
+	if _, u, _, _ := plan.Counts(); u != 1 {
+		t.Fatalf("an edited label must plan 1 update, got %d (%+v)", u, plan.Changes)
+	}
+	fields := plan.Changes[0].Fields
+	if len(fields) != 1 {
+		t.Fatalf("want only the changed label in the diff, got %+v", fields)
+	}
+	f := fields[0]
+	if f.Field != "containerLabels.traefik.http.routers.web.rule" {
+		t.Errorf("field = %q, want the label named per key", f.Field)
+	}
+	if f.From != "Host(`old.example.com`)" || f.To != "Host(`new.example.com`)" {
+		t.Errorf("diff = %+v, want old → new", f)
+	}
+}
+
+func TestContainerLabelsUnchangedIsNoop(t *testing.T) {
+	labels := map[string]string{"traefik.enable": "true", "com.example.team": "platform"}
+	desired := desiredApp(t, "  containerLabels:\n    traefik.enable: \"true\"\n    com.example.team: \"platform\"\n")
+	if _, u, _, _ := d.BuildPlan(desired, liveApp(labels), d.PlanOptions{}).Counts(); u != 0 {
+		t.Errorf("identical labels must be a no-op, got %d updates", u)
+	}
+}
+
+func TestRemovedContainerLabelConverges(t *testing.T) {
+	desired := desiredApp(t, "  containerLabels:\n    traefik.enable: \"true\"\n")
+	live := liveApp(map[string]string{"traefik.enable": "true", "traefik.http.routers.web.rule": "Host(`x`)"})
+
+	plan := d.BuildPlan(desired, live, d.PlanOptions{})
+	if _, u, _, _ := plan.Counts(); u != 1 {
+		t.Fatalf("a dropped label must plan 1 update, got %d (%+v)", u, plan.Changes)
+	}
+	if f := plan.Changes[0].Fields[0]; f.To != "" || f.Field != "containerLabels.traefik.http.routers.web.rule" {
+		t.Errorf("dropped label diff = %+v, want the key going to empty", f)
+	}
+}
+
+// A platform-reserved key is stripped when the app is written, so it can never
+// come back in live state. Diffing it would report drift the apply can never
+// resolve — an apply loop that redeploys on every sync.
+func TestReservedContainerLabelDoesNotDrift(t *testing.T) {
+	desired := desiredApp(t, "  containerLabels:\n    traefik.enable: \"true\"\n    io.miabi.app: \"999\"\n    com.docker.compose.project: \"mine\"\n")
+	live := liveApp(map[string]string{"traefik.enable": "true"})
+
+	plan := d.BuildPlan(desired, live, d.PlanOptions{})
+	if _, u, _, _ := plan.Counts(); u != 0 {
+		t.Errorf("reserved labels must not drift, got %d updates (%+v)", u, plan.Changes)
+	}
+}

--- a/internal/declarative/edges.go
+++ b/internal/declarative/edges.go
@@ -21,6 +21,7 @@ const (
 	EdgeDatabase EdgeType = "database" // Application -> Database (env {{ .databases.X }})
 	EdgeSecret   EdgeType = "secret"   // Application -> Secret   (env {{ .secrets.X }})
 	EdgeAppRef   EdgeType = "app-ref"  // Application -> Application (env {{ .applications.X }})
+	EdgeRegistry EdgeType = "registry" // Application -> Registry (spec.registry)
 )
 
 // Edge is a directed dependency from one resource to another, keyed by Resource
@@ -78,6 +79,10 @@ func Edges(set *ResourceSet) []Edge {
 			for _, mt := range a.Mounts {
 				add(KindApplication, name, KindVolume, mt.Volume, EdgeMount)
 			}
+			// Only drawn when the credential is declared in the same bundle — add()
+			// skips targets outside the set, so referencing a workspace credential
+			// created elsewhere leaves no dangling edge.
+			add(KindApplication, name, KindRegistry, a.Registry, EdgeRegistry)
 			for _, v := range a.Env {
 				for _, m := range tmplRef.FindAllStringSubmatch(v, -1) {
 					switch m[1] {

--- a/internal/declarative/examples_validate_test.go
+++ b/internal/declarative/examples_validate_test.go
@@ -55,6 +55,23 @@ func TestExamplesParse(t *testing.T) {
 		t.Fatalf("parse apply/app-ports.yaml: %v", perr)
 	}
 
+	// Private-registry bundle: the app's spec.registry must name the declared
+	// credential, so the example can't drift out of sync with the schema.
+	if pr, derr := os.ReadFile(filepath.Join(examplesDir, "apply", "private-registry.yaml")); derr != nil {
+		t.Fatalf("read private-registry.yaml: %v", derr)
+	} else if prSet, perr := d.Parse(pr); perr != nil {
+		t.Fatalf("parse apply/private-registry.yaml: %v", perr)
+	} else {
+		regs := prSet.ByKind(d.KindRegistry)
+		if len(regs) == 0 {
+			t.Fatal("private-registry.yaml should declare a Registry")
+		}
+		apps := prSet.ByKind(d.KindApplication)
+		if len(apps) == 0 || apps[0].Application.Registry != regs[0].Metadata.Name {
+			t.Errorf("private-registry.yaml app should reference registry %q", regs[0].Metadata.Name)
+		}
+	}
+
 	// GitOps env folders via ParseFS.
 	for _, env := range []string{"dev", "prod"} {
 		dir := filepath.Join(examplesDir, "gitops", "envs", env)

--- a/internal/declarative/examples_validate_test.go
+++ b/internal/declarative/examples_validate_test.go
@@ -55,6 +55,28 @@ func TestExamplesParse(t *testing.T) {
 		t.Fatalf("parse apply/app-ports.yaml: %v", perr)
 	}
 
+	// Label-routed bundle: the fronted app must actually carry the labels a
+	// label-reading proxy discovers it by, and both apps must be in the stack
+	// that gives them a shared network.
+	if cl, derr := os.ReadFile(filepath.Join(examplesDir, "apply", "container-labels.yaml")); derr != nil {
+		t.Fatalf("read container-labels.yaml: %v", derr)
+	} else if clSet, perr := d.Parse([]byte(cl)); perr != nil {
+		t.Fatalf("parse apply/container-labels.yaml: %v", perr)
+	} else {
+		labelled := 0
+		for _, a := range clSet.ByKind(d.KindApplication) {
+			if a.Application.Stack == "" {
+				t.Errorf("application %q should join the stack it is routed on", a.Metadata.Name)
+			}
+			if len(a.Application.ContainerLabels) > 0 {
+				labelled++
+			}
+		}
+		if labelled == 0 {
+			t.Error("container-labels.yaml should set containerLabels on the fronted app")
+		}
+	}
+
 	// Private-registry bundle: the app's spec.registry must name the declared
 	// credential, so the example can't drift out of sync with the schema.
 	if pr, derr := os.ReadFile(filepath.Join(examplesDir, "apply", "private-registry.yaml")); derr != nil {

--- a/internal/declarative/marshal.go
+++ b/internal/declarative/marshal.go
@@ -56,6 +56,10 @@ func (r Resource) spec() any {
 		return r.Route
 	case r.Secret != nil:
 		return r.Secret
+	case r.Domain != nil:
+		return r.Domain
+	case r.Registry != nil:
+		return r.Registry
 	default:
 		return nil
 	}

--- a/internal/declarative/parse.go
+++ b/internal/declarative/parse.go
@@ -213,6 +213,12 @@ func parseNode(node *yaml.Node) ([]Resource, error) {
 			return nil, specErr(head.Kind, meta.Name, err)
 		}
 		r.Domain = &s
+	case KindRegistry:
+		var s RegistrySpec
+		if err := decodeSpec(&head.Spec, &s); err != nil {
+			return nil, specErr(head.Kind, meta.Name, err)
+		}
+		r.Registry = &s
 	case KindProject:
 		var raw rawProjectSpec
 		if err := decodeSpec(&head.Spec, &raw); err != nil {

--- a/internal/declarative/plan.go
+++ b/internal/declarative/plan.go
@@ -303,6 +303,23 @@ func diffRegistry(actual, desired Resource) []FieldDiff {
 	return out
 }
 
+// reservedLabelPrefixes are the container-label namespaces the platform owns.
+// A manifest may name one, but the application service strips it on write
+// (docker.SanitizeUserLabels), so it can never appear in live state. Excluding
+// it from the diff on both sides is what stops such a label reading as drift on
+// every plan. Duplicated here rather than imported so the declarative package
+// stays free of runtime dependencies; the two lists must agree.
+var reservedLabelPrefixes = []string{"io.miabi.", "com.docker."}
+
+func reservedLabelKey(key string) bool {
+	for _, p := range reservedLabelPrefixes {
+		if strings.HasPrefix(key, p) {
+			return true
+		}
+	}
+	return false
+}
+
 // specFields flattens a resource's comparable spec into field->value. Fields
 // named in an application's secretEnv are masked so secret values never appear
 // in a plan, while still letting presence be compared.
@@ -322,6 +339,16 @@ func specFields(r Resource) map[string]string {
 		// The credential the image is pulled with is part of the app's identity:
 		// re-pointing it at another registry must converge like any other change.
 		f["registry"] = a.Registry
+		// Container labels drive label-reading tooling (Traefik routing rules,
+		// Watchtower policies), so editing one has to redeploy the container.
+		// Compared per key, like env: a plan then names the label that changed
+		// instead of showing one opaque blob.
+		for k, v := range a.ContainerLabels {
+			if reservedLabelKey(k) {
+				continue // stripped on write, so it can never be live: skip both sides
+			}
+			f["containerLabels."+k] = v
+		}
 		if a.Resources != nil {
 			// Compare resource caps by their canonical numeric value so "512Mi"
 			// and the live byte count (or "0.5" vs nano-CPUs) don't read as drift.

--- a/internal/declarative/plan.go
+++ b/internal/declarative/plan.go
@@ -107,7 +107,11 @@ func applyRank(k Kind) int {
 		// Independent, foundational resources. Domains come before the routes that
 		// bind hostnames under them.
 		return 0
-	case KindDatabase, KindStack:
+	case KindDatabase, KindStack, KindRegistry:
+		// A registry credential ranks above Secret rather than beside it: its
+		// password is typically "{{ .secrets.x }}", and same-rank changes are
+		// ordered by kind name — which would put Registry before Secret and fail
+		// the strict render on a first apply.
 		return 1
 	case KindApplication:
 		return 2
@@ -247,6 +251,9 @@ func diffFields(actual, desired Resource) []FieldDiff {
 	if desired.Kind == KindSecret {
 		return nil // opaque: an existing secret is treated as in-sync
 	}
+	if desired.Kind == KindRegistry {
+		return diffRegistry(actual, desired)
+	}
 	av := specFields(actual)
 	dv := specFields(desired)
 	keys := map[string]bool{}
@@ -266,6 +273,36 @@ func diffFields(actual, desired Resource) []FieldDiff {
 	return out
 }
 
+// diffRegistry compares a registry credential. Server and username are ordinary
+// visible fields. The password is not: it is compared through the fingerprints
+// the apply engine stamped on both sides (never the value itself) and reported
+// with fixed labels, so a rotation converges without a plan ever carrying
+// anything derived from the token.
+//
+// The password is only compared when the manifest actually declares one — a
+// credential whose token is managed out-of-band (declared in git, pasted in the
+// UI) must not read as drift on every plan.
+func diffRegistry(actual, desired Resource) []FieldDiff {
+	a, d := actual.Registry, desired.Registry
+	if d == nil {
+		return nil
+	}
+	var out []FieldDiff
+	if a == nil {
+		a = &RegistrySpec{}
+	}
+	if a.Server != d.Server {
+		out = append(out, FieldDiff{Field: "server", From: a.Server, To: d.Server})
+	}
+	if a.Username != d.Username {
+		out = append(out, FieldDiff{Field: "username", From: a.Username, To: d.Username})
+	}
+	if d.Password != "" && d.PasswordFP != "" && a.PasswordFP != "" && a.PasswordFP != d.PasswordFP {
+		out = append(out, FieldDiff{Field: "password", From: "(current)", To: "(rotated)"})
+	}
+	return out
+}
+
 // specFields flattens a resource's comparable spec into field->value. Fields
 // named in an application's secretEnv are masked so secret values never appear
 // in a plan, while still letting presence be compared.
@@ -282,6 +319,9 @@ func specFields(r Resource) map[string]string {
 		f["tag"] = a.Tag
 		f["digest"] = a.Digest
 		f["command"] = strings.Join(a.Command, " ")
+		// The credential the image is pulled with is part of the app's identity:
+		// re-pointing it at another registry must converge like any other change.
+		f["registry"] = a.Registry
 		if a.Resources != nil {
 			// Compare resource caps by their canonical numeric value so "512Mi"
 			// and the live byte count (or "0.5" vs nano-CPUs) don't read as drift.

--- a/internal/declarative/registry_test.go
+++ b/internal/declarative/registry_test.go
@@ -1,0 +1,286 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package declarative_test
+
+import (
+	"strings"
+	"testing"
+
+	d "github.com/miabi-io/miabi/internal/declarative"
+)
+
+const registryBundle = `apiVersion: miabi.io/v1
+kind: Registry
+metadata: { name: ghcr }
+spec:
+  server: ghcr.io
+  username: my-org
+  password: tok-1
+---
+apiVersion: miabi.io/v1
+kind: Application
+metadata: { name: api }
+spec:
+  image: ghcr.io/my-org/api
+  registry: ghcr`
+
+func TestRegistryKindParsesAndLinks(t *testing.T) {
+	set, err := d.Parse([]byte(registryBundle))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	regs := set.ByKind(d.KindRegistry)
+	if len(regs) != 1 {
+		t.Fatalf("want 1 registry, got %d", len(regs))
+	}
+	if regs[0].Registry.Server != "ghcr.io" || regs[0].Registry.Username != "my-org" {
+		t.Errorf("registry spec mismatch: %+v", regs[0].Registry)
+	}
+	apps := set.ByKind(d.KindApplication)
+	if apps[0].Application.Registry != "ghcr" {
+		t.Errorf("app registry = %q, want ghcr", apps[0].Application.Registry)
+	}
+
+	// The credential must exist before the app that pulls through it.
+	plan := d.BuildPlan(set, d.NewResourceSet(), d.PlanOptions{})
+	var order []string
+	for _, ch := range plan.Changes {
+		order = append(order, string(ch.Kind))
+	}
+	if len(order) != 2 || order[0] != "Registry" || order[1] != "Application" {
+		t.Errorf("apply order = %v, want [Registry Application]", order)
+	}
+
+	// The dependency is drawn only when both ends are in the bundle.
+	var found bool
+	for _, e := range d.Edges(set) {
+		if e.From == "Application/api" && e.To == "Registry/ghcr" && e.Type == d.EdgeRegistry {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("missing Application->Registry edge in %+v", d.Edges(set))
+	}
+}
+
+// A registry's password is normally "{{ .secrets.x }}", and the apply engine
+// renders it strictly at execute time — so a Secret declared in the same bundle
+// must be created first. Same-rank changes order by kind name, which would put
+// Registry before Secret; the ranks must keep them apart.
+func TestSecretIsCreatedBeforeRegistry(t *testing.T) {
+	src := `apiVersion: miabi.io/v1
+kind: Registry
+metadata: { name: ghcr }
+spec:
+  server: ghcr.io
+  username: my-org
+  password: "{{ .secrets.tok }}"
+---
+apiVersion: miabi.io/v1
+kind: Secret
+metadata: { name: tok }
+spec: { generate: true }`
+	set, err := d.Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	plan := d.BuildPlan(set, d.NewResourceSet(), d.PlanOptions{})
+	var order []string
+	for _, ch := range plan.Changes {
+		order = append(order, string(ch.Kind))
+	}
+	if len(order) != 2 || order[0] != "Secret" || order[1] != "Registry" {
+		t.Errorf("apply order = %v, want [Secret Registry]", order)
+	}
+}
+
+// A registry referenced but not declared is legal: it resolves against the
+// workspace's existing credentials at apply time.
+func TestRegistryReferenceNeedNotBeDeclared(t *testing.T) {
+	src := `apiVersion: miabi.io/v1
+kind: Application
+metadata: { name: api }
+spec:
+  image: ghcr.io/my-org/api
+  registry: created-in-the-ui`
+	set, err := d.Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("an undeclared registry reference must parse: %v", err)
+	}
+	if e := d.Edges(set); len(e) != 0 {
+		t.Errorf("no edge should be drawn to a resource outside the set, got %+v", e)
+	}
+}
+
+func TestRegistryServerNormalizedAndValidated(t *testing.T) {
+	// A scheme is stripped and an omitted host defaults to Docker Hub, so a
+	// manifest converges against what the registry service stores.
+	for _, tc := range []struct{ in, want string }{
+		{"", d.DefaultRegistryServer},
+		{"https://ghcr.io", "ghcr.io"},
+		{"registry.example.com:5000/", "registry.example.com:5000"},
+	} {
+		src := "apiVersion: miabi.io/v1\nkind: Registry\nmetadata: { name: r }\nspec:\n  username: u\n  password: p\n  server: \"" + tc.in + "\""
+		set, err := d.Parse([]byte(src))
+		if err != nil {
+			t.Fatalf("parse server %q: %v", tc.in, err)
+		}
+		if got := set.ByKind(d.KindRegistry)[0].Registry.Server; got != tc.want {
+			t.Errorf("server %q normalized to %q, want %q", tc.in, got, tc.want)
+		}
+	}
+
+	bad := "apiVersion: miabi.io/v1\nkind: Registry\nmetadata: { name: r }\nspec: { server: \"ghcr.io/org/repo\" }"
+	if _, err := d.Parse([]byte(bad)); err == nil {
+		t.Error("a server with a path must be rejected")
+	}
+	noUser := "apiVersion: miabi.io/v1\nkind: Registry\nmetadata: { name: r }\nspec: { password: p }"
+	if _, err := d.Parse([]byte(noUser)); err == nil {
+		t.Error("a password without a username must be rejected")
+	}
+}
+
+func TestRegistryDiffHidesThePassword(t *testing.T) {
+	desired := d.NewResourceSet()
+	desired.Add(d.Resource{
+		APIVersion: d.APIVersion, Kind: d.KindRegistry, Metadata: d.Meta{Name: "ghcr"},
+		Registry: &d.RegistrySpec{Server: "ghcr.io", Username: "my-org", Password: "tok-2", PasswordFP: "bbbb"},
+	})
+	live := func(fp string) *d.ResourceSet {
+		s := d.NewResourceSet()
+		s.Add(d.Resource{
+			APIVersion: d.APIVersion, Kind: d.KindRegistry, Metadata: d.Meta{Name: "ghcr"},
+			Registry: &d.RegistrySpec{Server: "ghcr.io", Username: "my-org", PasswordFP: fp},
+		})
+		return s
+	}
+
+	// Same fingerprint: converged, no churn.
+	if _, u, _, _ := d.BuildPlan(desired, live("bbbb"), d.PlanOptions{}).Counts(); u != 0 {
+		t.Errorf("an unchanged credential must be a no-op, got %d updates", u)
+	}
+
+	// Rotated: one update, reported without anything derived from the token.
+	plan := d.BuildPlan(desired, live("aaaa"), d.PlanOptions{})
+	if _, u, _, _ := plan.Counts(); u != 1 {
+		t.Fatalf("a rotated password must be 1 update, got %d (%+v)", u, plan.Changes)
+	}
+	fields := plan.Changes[0].Fields
+	if len(fields) != 1 || fields[0].Field != "password" {
+		t.Fatalf("want a single password field diff, got %+v", fields)
+	}
+	if fields[0].From != "(current)" || fields[0].To != "(rotated)" {
+		t.Errorf("password diff = %+v, want masked labels", fields[0])
+	}
+	for _, f := range fields {
+		if strings.Contains(f.From+f.To, "tok-") || strings.Contains(f.From+f.To, "aaaa") || strings.Contains(f.From+f.To, "bbbb") {
+			t.Errorf("plan leaked password material: %+v", f)
+		}
+	}
+}
+
+// A credential whose token is managed out-of-band (declared in git, pasted in the
+// UI) must not read as drift on every plan.
+func TestRegistryWithoutPasswordDoesNotDrift(t *testing.T) {
+	desired := d.NewResourceSet()
+	desired.Add(d.Resource{
+		APIVersion: d.APIVersion, Kind: d.KindRegistry, Metadata: d.Meta{Name: "ghcr"},
+		Registry: &d.RegistrySpec{Server: "ghcr.io", Username: "my-org"},
+	})
+	live := d.NewResourceSet()
+	live.Add(d.Resource{
+		APIVersion: d.APIVersion, Kind: d.KindRegistry, Metadata: d.Meta{Name: "ghcr"},
+		Registry: &d.RegistrySpec{Server: "ghcr.io", Username: "my-org", PasswordFP: "aaaa"},
+	})
+	if _, u, _, _ := d.BuildPlan(desired, live, d.PlanOptions{}).Counts(); u != 0 {
+		t.Errorf("an out-of-band token must not drift, got %d updates", u)
+	}
+}
+
+func TestApplicationRegistryChangeIsDrift(t *testing.T) {
+	desired, _ := d.Parse([]byte(registryBundle))
+	live := d.NewResourceSet()
+	live.Add(d.Resource{
+		APIVersion: d.APIVersion, Kind: d.KindRegistry, Metadata: d.Meta{Name: "ghcr"},
+		Registry: &d.RegistrySpec{Server: "ghcr.io", Username: "my-org"},
+	})
+	live.Add(d.Resource{
+		APIVersion: d.APIVersion, Kind: d.KindApplication, Metadata: d.Meta{Name: "api"},
+		Application: &d.ApplicationSpec{Image: "ghcr.io/my-org/api", Registry: "dockerhub"},
+	})
+	plan := d.BuildPlan(desired, live, d.PlanOptions{})
+	for _, ch := range plan.Changes {
+		if ch.Kind != d.KindApplication {
+			continue
+		}
+		for _, f := range ch.Fields {
+			if f.Field == "registry" && f.From == "dockerhub" && f.To == "ghcr" {
+				return
+			}
+		}
+	}
+	t.Errorf("re-pointing an app at another credential must show as drift: %+v", plan.Changes)
+}
+
+// A manifest may carry either secret form, and they mean different things:
+// "{{ .secrets.x }}" is rendered at apply time into a stored copy, while
+// "${{ secrets.X }}" is stored as a live reference the platform resolves at every
+// pull. The runtime form must survive parsing untouched — Go's template engine
+// would choke on the inner braces if anything tried to render it.
+func TestRegistryRuntimeSecretReferenceIsNotATemplate(t *testing.T) {
+	src := `apiVersion: miabi.io/v1
+kind: Registry
+metadata: { name: ghcr }
+spec:
+  server: ghcr.io
+  username: my-org
+  password: "${{ secrets.GHCR_TOKEN }}"`
+	set, err := d.Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got := set.ByKind(d.KindRegistry)[0].Registry.Password
+	if got != "${{ secrets.GHCR_TOKEN }}" {
+		t.Errorf("password = %q, want the reference verbatim", got)
+	}
+	// And it must survive the Marshal round trip GitOps canonicalizes through.
+	out, err := d.Marshal(set)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	back, err := d.Parse(out)
+	if err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	if got := back.ByKind(d.KindRegistry)[0].Registry.Password; got != "${{ secrets.GHCR_TOKEN }}" {
+		t.Errorf("password after round trip = %q, want the reference verbatim", got)
+	}
+}
+
+// GitOps canonicalizes a bundle through Marshal before applying it, so a
+// registry (password included) has to survive the round trip.
+func TestRegistryMarshalRoundTrips(t *testing.T) {
+	set, err := d.Parse([]byte(registryBundle))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	out, err := d.Marshal(set)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	back, err := d.Parse(out)
+	if err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	got := back.ByKind(d.KindRegistry)
+	if len(got) != 1 {
+		t.Fatalf("want 1 registry after round trip, got %d", len(got))
+	}
+	if got[0].Registry.Password != "tok-1" {
+		t.Errorf("password lost in round trip: %+v", got[0].Registry)
+	}
+	if apps := back.ByKind(d.KindApplication); apps[0].Application.Registry != "ghcr" {
+		t.Errorf("app registry lost in round trip: %+v", apps[0].Application)
+	}
+}

--- a/internal/declarative/schema.go
+++ b/internal/declarative/schema.go
@@ -35,6 +35,10 @@ const (
 	// TLS policy and (optional) wildcard coverage. DNS-ownership verification is a
 	// runtime action, not a declarable field.
 	KindDomain Kind = "Domain"
+	// KindRegistry is a container-registry credential used to pull private images.
+	// It is deliberately not called a "secret": Miabi's Secret kind is the vault,
+	// and an Application references this one by name through spec.registry.
+	KindRegistry Kind = "Registry"
 	// KindProject bundles a set of resources living in one repo/namespace.
 	KindProject Kind = "Project"
 )
@@ -49,6 +53,7 @@ var knownKinds = map[Kind]bool{
 	KindRoute:       true,
 	KindSecret:      true,
 	KindDomain:      true,
+	KindRegistry:    true,
 	KindProject:     true,
 }
 
@@ -83,6 +88,7 @@ type Resource struct {
 	Route       *RouteSpec       `yaml:"-" json:"route,omitempty"`
 	Secret      *SecretSpec      `yaml:"-" json:"secret,omitempty"`
 	Domain      *DomainSpec      `yaml:"-" json:"domain,omitempty"`
+	Registry    *RegistrySpec    `yaml:"-" json:"registry,omitempty"`
 	Project     *ProjectSpec     `yaml:"-" json:"project,omitempty"`
 }
 
@@ -109,6 +115,12 @@ type ApplicationSpec struct {
 	ContainerLabels map[string]string `yaml:"containerLabels,omitempty" json:"containerLabels,omitempty"`
 	// Stack optionally names the owning Stack resource.
 	Stack string `yaml:"stack,omitempty" json:"stack,omitempty"`
+	// Registry names the Registry credential used to pull this image (a private
+	// registry). Empty = an anonymous, public pull. The credential does not have
+	// to be declared in the same bundle: a name that is not in the manifest is
+	// resolved against the workspace's existing credentials, so a token created
+	// once in the UI can be referenced by every manifest.
+	Registry string `yaml:"registry,omitempty" json:"registry,omitempty"`
 	// ExternalLabel pins the subdomain used for external access
 	// (`<label>.<base-domain>`). Optional — when unset Miabi generates a
 	// stable label; pinning it keeps the public URL deterministic across applies.
@@ -187,6 +199,27 @@ type RouteSpec struct {
 type DomainSpec struct {
 	TLS      string `yaml:"tls,omitempty" json:"tls,omitempty"` // acme|custom (default acme)
 	Wildcard bool   `yaml:"wildcard,omitempty" json:"wildcard,omitempty"`
+}
+
+// RegistrySpec is a container-registry credential. Server is the registry host
+// (empty = Docker Hub); Username and Password authenticate to it. An Application
+// selects one by name through its spec.registry.
+//
+// Password is write-only — it is never read back and never appears in a plan.
+// Prefer referencing the vault ("{{ .secrets.ghcr_token }}") over an inline
+// literal, so a manifest committed to git carries no token. A rotation still
+// converges: the plan compares an unreadable fingerprint of the stored password
+// (see PasswordFP) and reports the change as "password: (current) → (rotated)".
+type RegistrySpec struct {
+	Server   string `yaml:"server,omitempty" json:"server,omitempty"`
+	Username string `yaml:"username,omitempty" json:"username,omitempty"`
+	Password string `yaml:"password,omitempty" json:"password,omitempty"`
+	// PasswordFP is the fingerprint of the *rendered* password, filled in by the
+	// apply engine on both sides of the diff (from the manifest for the desired
+	// side, from the stored credential for the live side). It is deliberately not
+	// serialized: it is derived state, so a Marshal→Parse round trip (how GitOps
+	// canonicalizes a bundle) simply recomputes it.
+	PasswordFP string `yaml:"-" json:"-"`
 }
 
 // SecretSpec is a write-only secret value. Value is never read back; the diff

--- a/internal/declarative/validate.go
+++ b/internal/declarative/validate.go
@@ -64,7 +64,28 @@ func (r *Resource) normalize() {
 		if r.Domain.TLS == "" {
 			r.Domain.TLS = "acme"
 		}
+	case r.Registry != nil:
+		r.Registry.Server = normalizeRegistryServer(r.Registry.Server)
 	}
+}
+
+// DefaultRegistryServer is the implicit registry host when a manifest names none
+// (Docker Hub). It mirrors registry.DefaultServer — normalization is duplicated
+// here rather than imported so the declarative package stays free of service
+// dependencies, and both sides must agree or a converged registry would diff.
+const DefaultRegistryServer = "registry-1.docker.io"
+
+// normalizeRegistryServer trims a registry host to its bare authority, matching
+// what the registry service stores, so an unqualified manifest converges instead
+// of drifting on every plan.
+func normalizeRegistryServer(server string) string {
+	server = strings.TrimSpace(server)
+	if server == "" {
+		return DefaultRegistryServer
+	}
+	server = strings.TrimPrefix(server, "https://")
+	server = strings.TrimPrefix(server, "http://")
+	return strings.TrimSuffix(server, "/")
 }
 
 // validate enforces a single resource's semantic rules. Manifests are untrusted
@@ -90,6 +111,8 @@ func (r *Resource) validate() error {
 		return r.validateRoute()
 	case KindDomain:
 		return r.validateDomain()
+	case KindRegistry:
+		return r.validateRegistry()
 	case KindVolume, KindStack, KindSecret, KindProject:
 		return nil
 	default:
@@ -142,6 +165,29 @@ func (r *Resource) validateDomain() error {
 	return nil
 }
 
+// registryServerRe matches a registry authority: a dotted host with an optional
+// port ("ghcr.io", "registry.example.com:5000", "localhost:5000").
+var registryServerRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*(:[0-9]{1,5})?$`)
+
+func (r *Resource) validateRegistry() error {
+	reg := r.Registry
+	if reg == nil {
+		return fmt.Errorf("registry %q: spec is required", r.Metadata.Name)
+	}
+	// normalize() has already stripped any scheme and defaulted the host, so what
+	// is left must be a bare authority.
+	if !registryServerRe.MatchString(reg.Server) {
+		return fmt.Errorf("registry %q: server %q must be a host, optionally with a port (no scheme, no path)", r.Metadata.Name, reg.Server)
+	}
+	// A password is optional in the manifest: a credential may be declared in git
+	// and have its token set out-of-band (once, in the UI). Creating it then fails
+	// loudly at apply time rather than silently storing an empty secret.
+	if strings.TrimSpace(reg.Username) == "" && strings.TrimSpace(reg.Password) != "" {
+		return fmt.Errorf("registry %q: username is required when a password is set", r.Metadata.Name)
+	}
+	return nil
+}
+
 func (r *Resource) validateApplication() error {
 	a := r.Application
 	if a == nil {
@@ -172,6 +218,9 @@ func (r *Resource) validateApplication() error {
 	}
 	if a.ExternalLabel != "" && !nameRe.MatchString(a.ExternalLabel) {
 		return fmt.Errorf("application %q: externalLabel %q must be a DNS label", r.Metadata.Name, a.ExternalLabel)
+	}
+	if a.Registry != "" && !nameRe.MatchString(a.Registry) {
+		return fmt.Errorf("application %q: registry %q must be a resource name matching %s", r.Metadata.Name, a.Registry, nameRe)
 	}
 	for _, mt := range a.Mounts {
 		if mt.Volume == "" {

--- a/internal/handlers/admin_registry_confirm_test.go
+++ b/internal/handlers/admin_registry_confirm_test.go
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package handlers
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/miabi-io/miabi/internal/models"
+	"github.com/miabi-io/miabi/internal/services/registryserver"
+)
+
+func str(s string) *string { return &s }
+
+func withRepos(n int, err error) *AdminRegistryHandler {
+	return &AdminRegistryHandler{
+		repoCount: func(context.Context) (int, error) { return n, err },
+	}
+}
+
+// Changing the hostname is gated whenever there is an old name to strand
+// references against, whether or not anything has been pushed yet: the
+// references live in Miabi's own records, not in the registry.
+func TestHostChangeNeedsConfirmation(t *testing.T) {
+	h := withRepos(0, nil)
+	current := &models.RegistrySettings{Host: "registry.old.test"}
+
+	msg := h.destructiveChange(context.Background(), current, registryserver.Locks{},
+		RegistrySettingsBody{Host: str("registry.new.test")})
+	if msg == "" {
+		t.Fatal("moving the hostname must require confirmation")
+	}
+	for _, want := range []string{"registry.old.test", "registry.new.test"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("prompt %q should name %q", msg, want)
+		}
+	}
+
+	// The same value, differently spelled, is not a change.
+	if msg := h.destructiveChange(context.Background(), current, registryserver.Locks{},
+		RegistrySettingsBody{Host: str("REGISTRY.OLD.TEST")}); msg != "" {
+		t.Errorf("re-sending the same host must not prompt, got %q", msg)
+	}
+	// Naming a host for the first time strands nothing.
+	if msg := h.destructiveChange(context.Background(), &models.RegistrySettings{}, registryserver.Locks{},
+		RegistrySettingsBody{Host: str("registry.new.test")}); msg != "" {
+		t.Errorf("setting the first host must not prompt, got %q", msg)
+	}
+	// An env-pinned host is never written, so it can never be a change.
+	if msg := h.destructiveChange(context.Background(), current, registryserver.Locks{Host: true},
+		RegistrySettingsBody{Host: str("registry.new.test")}); msg != "" {
+		t.Errorf("a pinned host must not prompt, got %q", msg)
+	}
+}
+
+// Switching storage only matters once there are blobs to strand.
+func TestStorageChangeNeedsConfirmationOnlyWhenImagesExist(t *testing.T) {
+	current := &models.RegistrySettings{StorageType: models.RegistryStorageFilesystem}
+	body := RegistrySettingsBody{StorageType: str(models.RegistryStorageS3)}
+
+	if msg := withRepos(0, nil).destructiveChange(context.Background(), current, registryserver.Locks{}, body); msg != "" {
+		t.Errorf("an empty registry must switch freely, got %q", msg)
+	}
+
+	msg := withRepos(3, nil).destructiveChange(context.Background(), current, registryserver.Locks{}, body)
+	if msg == "" {
+		t.Fatal("switching storage with images stored must require confirmation")
+	}
+	if !strings.Contains(msg, "3 repositories") {
+		t.Errorf("prompt %q should say how much is at stake", msg)
+	}
+
+	// Re-sending the current driver is not a change.
+	if msg := withRepos(3, nil).destructiveChange(context.Background(), current, registryserver.Locks{},
+		RegistrySettingsBody{StorageType: str(models.RegistryStorageFilesystem)}); msg != "" {
+		t.Errorf("re-sending the same driver must not prompt, got %q", msg)
+	}
+}
+
+func TestBucketChangeNeedsConfirmation(t *testing.T) {
+	current := &models.RegistrySettings{StorageType: models.RegistryStorageS3, S3Bucket: "old-bucket"}
+
+	msg := withRepos(1, nil).destructiveChange(context.Background(), current, registryserver.Locks{},
+		RegistrySettingsBody{S3Bucket: str("new-bucket")})
+	if !strings.Contains(msg, "old-bucket") || !strings.Contains(msg, "new-bucket") {
+		t.Errorf("prompt %q should name both buckets", msg)
+	}
+	// Singular reads as a sentence, not "1 repositories".
+	if !strings.Contains(msg, "1 repository") {
+		t.Errorf("prompt %q should count one repository in the singular", msg)
+	}
+}
+
+// A registry that can't be reached must not wedge the settings form behind a
+// confirmation the admin has no way to satisfy — the probe failing is not
+// evidence that images exist.
+func TestUnreachableRegistryDoesNotBlockSaving(t *testing.T) {
+	h := withRepos(0, errors.New("connection refused"))
+	msg := h.destructiveChange(context.Background(), &models.RegistrySettings{StorageType: models.RegistryStorageFilesystem},
+		registryserver.Locks{}, RegistrySettingsBody{StorageType: str(models.RegistryStorageS3)})
+	if msg != "" {
+		t.Errorf("an unreachable registry must not block a storage change, got %q", msg)
+	}
+}
+
+// Saving the operational knobs alone is never a destructive change.
+func TestRoutineSaveIsNotGated(t *testing.T) {
+	h := withRepos(9, nil)
+	msg := h.destructiveChange(context.Background(),
+		&models.RegistrySettings{Host: "registry.old.test", StorageType: models.RegistryStorageS3, S3Bucket: "b"},
+		registryserver.Locks{},
+		RegistrySettingsBody{DeleteEnabled: true, PerWorkspaceQuotaMB: 500})
+	if msg != "" {
+		t.Errorf("changing quota/deletes must not prompt, got %q", msg)
+	}
+}

--- a/internal/handlers/admin_registry_handler.go
+++ b/internal/handlers/admin_registry_handler.go
@@ -5,6 +5,9 @@ package handlers
 
 import (
 	"context"
+	"errors"
+	"strconv"
+	"strings"
 
 	"github.com/jkaninda/logger"
 	"github.com/jkaninda/okapi"
@@ -27,6 +30,22 @@ type AdminRegistryHandler struct {
 	ensure func(context.Context) error
 	// gc runs a garbage collection on demand.
 	gc func(context.Context) error
+	// runtime reads the registry container's live state and resource usage.
+	runtime func(context.Context) (*registryserver.Runtime, error)
+	// repoCount reports how many repositories the registry holds, so a storage
+	// change can tell "nothing to strand" from "this abandons real images".
+	repoCount func(context.Context) (int, error)
+}
+
+// SetRuntime wires the live container status/usage reader.
+func (h *AdminRegistryHandler) SetRuntime(fn func(context.Context) (*registryserver.Runtime, error)) {
+	h.runtime = fn
+}
+
+// SetRepoCount wires the "how many repositories are stored" probe used to decide
+// whether a storage change needs confirmation.
+func (h *AdminRegistryHandler) SetRepoCount(fn func(context.Context) (int, error)) {
+	h.repoCount = fn
 }
 
 func NewAdminRegistryHandler(svc *registryserver.Service, ee enterprise.EE, auditLog *audit.Logger) *AdminRegistryHandler {
@@ -52,43 +71,57 @@ func (h *AdminRegistryHandler) RunGC(c *okapi.Context) error {
 	return message(c, "garbage collection complete")
 }
 
-// UpdateRegistrySettingsRequest is the body for updating the registry settings:
-// the two operational knobs an admin may turn at runtime.
+// UpdateRegistrySettingsRequest is the body for updating the registry settings.
 //
-// Enablement, the hostname, and the storage configuration are not in this body.
-// They are fixed at boot from MIABI_REGISTRY_ENABLED / MIABI_REGISTRY_HOST /
-// MIABI_REGISTRY_STORAGE + MIABI_REGISTRY_S3_* and take a restart to change:
-// they determine whether the registry exists, what name every image reference on
-// the platform is anchored to, and where its blobs live. None of that may be
-// movable by an API call while deployments hold references to the old value and
-// blobs sit in the old backend.
+// The platform fields (enablement, hostname, storage) are pointers: nil means
+// "not sent, leave it alone", which is what lets a partial save from one tab not
+// clobber another's. Any field the environment pins is ignored — see
+// registryserver.Locks.
 type UpdateRegistrySettingsRequest struct {
-	Body struct {
-		DeleteEnabled       bool `json:"delete_enabled"`
-		PerWorkspaceQuotaMB int  `json:"per_workspace_quota_mb"`
-	} `json:"body"`
+	Body RegistrySettingsBody `json:"body"`
 }
 
-// RegistrySettingsView is the settings response enriched with the effective host
-// and the read-only storage explanation the UI renders.
+// RegistrySettingsBody is the settings payload, named so the confirmation check
+// can take it without restating every field.
+type RegistrySettingsBody struct {
+	DeleteEnabled       bool `json:"delete_enabled"`
+	PerWorkspaceQuotaMB int  `json:"per_workspace_quota_mb"`
+
+	Enabled     *bool   `json:"enabled"`
+	Host        *string `json:"host"`
+	StorageType *string `json:"storage_type"`
+
+	S3Endpoint       *string `json:"s3_endpoint"`
+	S3Bucket         *string `json:"s3_bucket"`
+	S3Region         *string `json:"s3_region"`
+	S3AccessKey      *string `json:"s3_access_key"`
+	S3SecretKey      *string `json:"s3_secret_key"` // blank keeps the stored one
+	S3ForcePathStyle *bool   `json:"s3_force_path_style"`
+
+	// Confirm acknowledges a change the platform cannot undo for you — moving the
+	// hostname every stored image reference is anchored to, or switching a storage
+	// backend that does not migrate its blobs. Without it such a change is refused
+	// with an explanation, so it can never be made by accident.
+	Confirm bool `json:"confirm"`
+}
+
+// RegistrySettingsView is the settings response enriched with the effective
+// host, which fields the environment pins, and why the registry might not be
+// serving.
 type RegistrySettingsView struct {
 	*models.RegistrySettings
 	EffectiveHost string `json:"effective_host"`
 	S3Entitled    bool   `json:"s3_entitled"`
-	// HostLocked reports that enablement and the hostname are read-only here:
-	// they come from MIABI_REGISTRY_ENABLED / MIABI_REGISTRY_HOST and take a
-	// restart to change. Always true — it exists so the UI can render the two
-	// fields as fixed and explain why, rather than offering inputs whose values
-	// the server discards.
-	HostLocked bool `json:"host_locked"`
-	// HostSource is where the effective host came from: "env", "stored" (a legacy
-	// value saved while the field was editable), "base_domain", or "unset".
-	HostSource string `json:"host_source"`
-
-	StorageLocked bool `json:"storage_locked"`
-
+	// Locks reports the environment-pinned fields. The UI renders each as fixed
+	// and names the variable that owns it; everything else is editable.
+	Locks registryserver.Locks `json:"locks"`
+	// HostSource / StorageSource explain where the effective value came from,
+	// which is what the UI shows under a field ("set by MIABI_REGISTRY_HOST",
+	// "derived from the base domain", …).
+	HostSource    string `json:"host_source"`
 	StorageSource string `json:"storage_source"`
-
+	// StorageError is why the registry cannot serve from its configured storage
+	// (a missing entitlement or bucket). Empty when storage is usable.
 	StorageError string `json:"storage_error,omitempty"`
 }
 
@@ -97,12 +130,23 @@ func (h *AdminRegistryHandler) view(st *models.RegistrySettings) RegistrySetting
 		RegistrySettings: st,
 		EffectiveHost:    h.svc.HostFor(st),
 		S3Entitled:       h.ee.Has(enterprise.FlagRegistryS3),
-		HostLocked:       true,
+		Locks:            h.svc.Locks(),
 		HostSource:       h.svc.HostSource(st),
-		StorageLocked:    true,
 		StorageSource:    h.svc.StorageSource(st),
 		StorageError:     h.svc.StorageUnavailableReason(st),
 	}
+}
+
+// Runtime returns the registry container's live state and resource usage.
+func (h *AdminRegistryHandler) Runtime(c *okapi.Context) error {
+	if h.runtime == nil {
+		return c.AbortInternalServerError("registry runtime status is unavailable", nil)
+	}
+	rt, err := h.runtime(c.Request().Context())
+	if err != nil {
+		return c.AbortInternalServerError("failed to read registry status", err)
+	}
+	return ok(c, rt)
 }
 
 // GetSettings returns the registry settings (secret omitted).
@@ -114,21 +158,67 @@ func (h *AdminRegistryHandler) GetSettings(c *okapi.Context) error {
 	return ok(c, h.view(st))
 }
 
-// UpdateSettings upserts the two mutable registry settings and applies them to
-// the container. The storage configuration is not accepted here at all — it is
-// environment-only (see UpdateRegistrySettingsRequest), which is also what makes
-// the S3 entitlement enforceable: it is checked where the driver is used, at
-// container start, not where it used to be selected.
+// UpdateSettings saves the registry configuration and applies it to the running
+// container.
+//
+// Two changes are irreversible in ways the platform cannot fix afterwards, so
+// each is refused unless the caller confirms it:
+//
+//   - Moving the hostname. Every image reference Miabi has recorded — on past
+//     deployments, in pipeline runs — is anchored to the old name, and matching
+//     against it is how one workspace's images are told apart from another's.
+//   - Switching the storage driver or bucket. Blobs do not migrate: the images
+//     already pushed stay in the old backend and become invisible.
+//
+// Both are legitimate operations (a domain move, a migration to S3); they just
+// must not happen by mis-click while a form is being saved for another reason.
 func (h *AdminRegistryHandler) UpdateSettings(c *okapi.Context, req *UpdateRegistrySettingsRequest) error {
 	b := req.Body
 	if b.PerWorkspaceQuotaMB < 0 {
 		return c.AbortBadRequest("the per-workspace quota cannot be negative (0 = unlimited)")
 	}
+	current, err := h.svc.Get()
+	if err != nil {
+		return c.AbortInternalServerError("failed to load registry settings", err)
+	}
+	locks := h.svc.Locks()
+
+	// Selecting S3 is gated here, where the driver is chosen. The service checks
+	// it again at container start, which covers the environment path and a licence
+	// that lapses later.
+	wantsS3 := current.UsesS3()
+	if b.StorageType != nil && !locks.Storage {
+		wantsS3 = *b.StorageType == models.RegistryStorageS3
+	}
+	if wantsS3 && !h.ee.Has(enterprise.FlagRegistryS3) {
+		return c.AbortWithError(402, errors.New(
+			"S3/MinIO storage for the built-in registry requires an Enterprise license (the registry_s3 entitlement)"))
+	}
+
+	if msg := h.destructiveChange(c.Request().Context(), current, locks, b); msg != "" && !b.Confirm {
+		// 409: the request is well-formed but conflicts with what is already stored.
+		// The message is the confirmation prompt the UI shows verbatim.
+		return c.AbortWithError(409, errors.New(msg))
+	}
+
 	st, err := h.svc.Save(registryserver.SaveInput{
 		DeleteEnabled:       b.DeleteEnabled,
 		PerWorkspaceQuotaMB: b.PerWorkspaceQuotaMB,
+		Enabled:             b.Enabled,
+		Host:                b.Host,
+		StorageType:         b.StorageType,
+		S3Endpoint:          b.S3Endpoint,
+		S3Bucket:            b.S3Bucket,
+		S3Region:            b.S3Region,
+		S3AccessKey:         b.S3AccessKey,
+		S3SecretKey:         b.S3SecretKey,
+		S3ForcePathStyle:    b.S3ForcePathStyle,
 	})
 	if err != nil {
+		// A rejected hostname is the admin's typo, not a server fault.
+		if strings.HasPrefix(err.Error(), "host:") {
+			return c.AbortBadRequest(err.Error())
+		}
 		return c.AbortInternalServerError("failed to save registry settings", err)
 	}
 	// Apply to the running container (recreate on change / tear down when disabled),
@@ -140,6 +230,68 @@ func (h *AdminRegistryHandler) UpdateSettings(c *okapi.Context, req *UpdateRegis
 	}
 	h.record(c, "registry.settings_update")
 	return ok(c, h.view(st))
+}
+
+// destructiveChange returns the confirmation prompt for a change that strands
+// data or breaks stored references, or "" when the update is safe.
+//
+// A change is only destructive against something that exists: moving the host of
+// a registry that has never served, or switching the storage of one holding no
+// repositories, costs nothing and is not gated.
+func (h *AdminRegistryHandler) destructiveChange(
+	ctx context.Context, current *models.RegistrySettings, locks registryserver.Locks, b RegistrySettingsBody,
+) string {
+	repos := h.storedRepoCount(ctx)
+
+	if b.Host != nil && !locks.Host {
+		want, err := registryserver.NormalizeHost(*b.Host)
+		if err == nil && want != "" && current.Host != "" && want != current.Host {
+			return "Changing the registry hostname from " + current.Host + " to " + want +
+				" leaves every image reference Miabi has already recorded pointing at the old name." +
+				" Existing deployments keep referencing " + current.Host + " and will fail to pull until they are redeployed."
+		}
+	}
+
+	// Nothing stored yet — no blobs to strand, so a storage change is free.
+	if repos <= 0 {
+		return ""
+	}
+	if b.StorageType != nil && !locks.Storage {
+		want := *b.StorageType
+		if (want == models.RegistryStorageS3) != current.UsesS3() {
+			return "Switching the storage driver abandons the " + plural(repos, "repository", "repositories") +
+				" already pushed: blobs are not migrated between backends, and the images stay in the old one."
+		}
+	}
+	if current.UsesS3() && b.S3Bucket != nil && !locks.S3Bucket {
+		if want := strings.TrimSpace(*b.S3Bucket); want != "" && current.S3Bucket != "" && want != current.S3Bucket {
+			return "Pointing the registry at bucket " + want + " abandons the " +
+				plural(repos, "repository", "repositories") + " stored in " + current.S3Bucket + "."
+		}
+	}
+	return ""
+}
+
+// storedRepoCount is the repository count, or 0 when it cannot be determined —
+// an unreachable registry is treated as empty so a probe failure can't wedge the
+// settings form behind a confirmation nobody can satisfy.
+func (h *AdminRegistryHandler) storedRepoCount(ctx context.Context) int {
+	if h.repoCount == nil {
+		return 0
+	}
+	n, err := h.repoCount(ctx)
+	if err != nil {
+		logger.Warn("registry: repository count unavailable for the storage-change check", "error", err)
+		return 0
+	}
+	return n
+}
+
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return "1 " + one
+	}
+	return strconv.Itoa(n) + " " + many
 }
 
 func (h *AdminRegistryHandler) record(c *okapi.Context, action string) {

--- a/internal/handlers/git_repository_handler.go
+++ b/internal/handlers/git_repository_handler.go
@@ -139,7 +139,8 @@ func (h *GitRepositoryHandler) mapErr(c *okapi.Context, err error) error {
 	switch {
 	case errors.Is(err, gitrepo.ErrNameTaken):
 		return c.AbortWithError(409, err)
-	case errors.Is(err, gitrepo.ErrNameRequired), errors.Is(err, gitrepo.ErrURLRequired), errors.Is(err, gitrepo.ErrSecretRequired):
+	case errors.Is(err, gitrepo.ErrNameRequired), errors.Is(err, gitrepo.ErrURLRequired),
+		errors.Is(err, gitrepo.ErrSecretRequired), errors.Is(err, gitrepo.ErrUnknownSecret):
 		return c.AbortBadRequest(err.Error())
 	case errors.Is(err, gitrepo.ErrNotFound):
 		return c.AbortNotFound("git repository not found")

--- a/internal/handlers/helper.go
+++ b/internal/handlers/helper.go
@@ -200,6 +200,23 @@ func queryInt(c *okapi.Context, key string, def int) int {
 	return def
 }
 
+// queryBool reads an optional tri-state boolean query parameter: "true"/"false"
+// select a value, anything else (including absent) means "no filter" and yields
+// nil. Use it for filters where "either" is a meaningful third choice, so a
+// caller can't accidentally narrow the result by omitting the parameter.
+func queryBool(c *okapi.Context, key string) *bool {
+	switch strings.ToLower(strings.TrimSpace(c.Query(key))) {
+	case "true":
+		v := true
+		return &v
+	case "false":
+		v := false
+		return &v
+	default:
+		return nil
+	}
+}
+
 // timeRange parses the ?from / ?to query params into a created_at window.
 // Each accepts RFC3339 or a YYYY-MM-DD date; absent/invalid values yield a zero
 // time (unbounded). A date-only `to` is advanced to the next midnight so the

--- a/internal/handlers/registry_handler.go
+++ b/internal/handlers/registry_handler.go
@@ -132,7 +132,8 @@ func (h *RegistryHandler) mapErr(c *okapi.Context, err error) error {
 	switch {
 	case errors.Is(err, registry.ErrNameTaken):
 		return c.AbortWithError(409, err)
-	case errors.Is(err, registry.ErrNameRequired), errors.Is(err, registry.ErrSecretRequired):
+	case errors.Is(err, registry.ErrNameRequired), errors.Is(err, registry.ErrSecretRequired),
+		errors.Is(err, registry.ErrUnknownSecret):
 		return c.AbortBadRequest(err.Error())
 	case errors.Is(err, registry.ErrNotFound):
 		return c.AbortNotFound("registry not found")

--- a/internal/handlers/secret_handler.go
+++ b/internal/handlers/secret_handler.go
@@ -42,10 +42,12 @@ type UpdateSecretRequest struct {
 	} `json:"body"`
 }
 
-// List returns a paginated, searchable list of a workspace's secrets (no values).
+// List returns a paginated, searchable list of a workspace's secrets (no
+// values). ?managed=true|false narrows to platform-owned or hand-created
+// secrets; omitting it returns both.
 func (h *SecretHandler) List(c *okapi.Context) error {
 	page, size, offset := normalizePageParams(queryInt(c, "page", 0), queryInt(c, "size", 20))
-	secrets, total, err := h.svc.ListPaged(middlewares.WorkspaceID(c), c.Query("search"), size, offset)
+	secrets, total, err := h.svc.ListPaged(middlewares.WorkspaceID(c), c.Query("search"), queryBool(c, "managed"), size, offset)
 	if err != nil {
 		return c.AbortInternalServerError("failed to list secrets", err)
 	}

--- a/internal/models/git_repository.go
+++ b/internal/models/git_repository.go
@@ -35,12 +35,21 @@ type GitRepository struct {
 	// ("x-access-token") at clone time.
 	Username string `json:"username"`
 	// Secret holds the access token (token auth) or SSH private key (ssh auth),
-	// encrypted at rest.
+	// encrypted at rest. Empty when the credential points at the vault instead
+	// (see SecretRef).
 	Secret string `json:"-" gorm:"not null"`
+	// SecretRef names a workspace Secret holding the token or key, instead of
+	// storing a copy here (the `${{ secrets.NAME }}` form a client sends in the
+	// secret field). The value is read from the vault at every clone, so rotating
+	// that secret rotates this credential with no edit here. Mutually exclusive
+	// with Secret. Not sensitive — it is a name, so it is returned by the API.
+	SecretRef string `json:"secret_ref,omitempty"`
 
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 
-	// HasSecret is a transient flag for responses (never persisted).
+	// HasSecret is a transient flag for responses (never persisted): true when the
+	// credential can authenticate, whether from its own stored secret or a vault
+	// reference.
 	HasSecret bool `json:"has_secret" gorm:"-"`
 }

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -11,6 +11,7 @@ import (
 // images at deploy time. The Secret (password / access token) is encrypted at
 // rest and never serialized.
 type Registry struct {
+	UIDModel
 	ID          uint `json:"id" gorm:"primaryKey"`
 	WorkspaceID uint `json:"workspace_id" gorm:"index:idx_registry_workspace_name,unique;not null"`
 	// Name is the unique slug handle scoped to the workspace.
@@ -21,12 +22,30 @@ type Registry struct {
 	// "registry.gitlab.com". Empty defaults to Docker Hub.
 	Server   string `json:"server"`
 	Username string `json:"username"`
-	// Secret holds the password or access token, encrypted at rest.
+	// Secret holds the password or access token, encrypted at rest. Empty when the
+	// credential points at the vault instead (see SecretRef).
 	Secret string `json:"-" gorm:"not null"`
+	// SecretRef names a workspace Secret holding the password, instead of storing
+	// a copy here (the `${{ secrets.NAME }}` form a client sends in the secret
+	// field). The value is read from the vault at every use, so rotating that
+	// secret rotates this credential with no edit here. Mutually exclusive with
+	// Secret. Not sensitive — it is a name, so it is returned by the API.
+	SecretRef string `json:"secret_ref,omitempty"`
+
+	// Metadata holds free-form labels (provenance, grouping, declarative/GitOps).
+	// Keys under the reserved "miabi.io/" prefix are platform-managed — the
+	// managed-by label is what keeps a GitOps prune from deleting a credential
+	// created by hand.
+	Metadata Metadata `json:"metadata,omitempty" gorm:"serializer:json"`
+	// Annotations holds free-form, non-identifying descriptive metadata (the
+	// manifest's metadata.annotations); no reserved keys. Persisted as JSON.
+	Annotations Metadata `json:"annotations,omitempty" gorm:"serializer:json"`
 
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 
-	// HasSecret is a transient flag for responses (never persisted).
+	// HasSecret is a transient flag for responses (never persisted): true when the
+	// credential can authenticate, whether from its own stored secret or a vault
+	// reference.
 	HasSecret bool `json:"has_secret" gorm:"-"`
 }

--- a/internal/routes/registry_server_routes.go
+++ b/internal/routes/registry_server_routes.go
@@ -41,6 +41,14 @@ func (r *Router) registryServerRoutes() []okapi.RouteDefinition {
 			Request:     &handlers.UpdateRegistrySettingsRequest{},
 		},
 		{
+			Method:      http.MethodGet,
+			Path:        "/registry/runtime",
+			Group:       admin,
+			Middlewares: adminMw,
+			Handler:     r.h.adminRegistry.Runtime,
+			Summary:     "Get the registry container's live state and resource usage",
+		},
+		{
 			Method:      http.MethodPost,
 			Path:        "/registry/gc",
 			Group:       admin,

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -664,6 +664,9 @@ func InitRoutes(app *okapi.Okapi, db *gorm.DB, redisClient *redis.Client, cfg *c
 		}
 	}
 	registryService := registry.NewService(repositories.NewRegistryRepository(db))
+	// A credential may hold a `${{ secrets.NAME }}` reference instead of its own
+	// copy of the password, resolved from the vault at every use.
+	registryService.SetSecrets(secretService)
 	// Built-in Docker registry (distinct from the external-creds registryService).
 	registryServerService := registryserver.NewService(
 		repositories.NewRegistrySettingsRepository(db),
@@ -676,6 +679,7 @@ func InitRoutes(app *okapi.Okapi, db *gorm.DB, redisClient *redis.Client, cfg *c
 	registryServerService.SetEntitlements(ee)
 	gitRepoRepo := repositories.NewGitRepoRepository(db)
 	gitRepoService := gitrepo.NewService(gitRepoRepo)
+	gitRepoService.SetSecrets(secretService) // same vault-reference support as registries
 	domainRepo := repositories.NewDomainRepository(db)
 	domainService := domain.NewService(domainRepo)
 	dnsProviderService := dnsprovider.NewService(repositories.NewDNSProviderRepository(db), repositories.NewDNSRecordRepository(db), domainRepo)
@@ -778,7 +782,7 @@ func InitRoutes(app *okapi.Okapi, db *gorm.DB, redisClient *redis.Client, cfg *c
 	// Gate custom-certificate imports on the workspace's registered domains.
 	certificateService.SetDomains(domainRepo)
 	// Declarative apply engine (shared by the one-shot apply API and GitOps).
-	applyService := apply.NewService(appService, storageService, databaseService, stackService, secretService, routeService, domainService)
+	applyService := apply.NewService(appService, storageService, databaseService, stackService, secretService, routeService, domainService, registryService)
 	// Declarative Application port exposure: externalAccess (reverse-proxy URLs,
 	// over the platform base domain) and publish/hostPort (host-port bindings).
 	applyService.SetPortExposure(func() route.ExternalConfig {
@@ -789,6 +793,7 @@ func InitRoutes(app *okapi.Okapi, db *gorm.DB, redisClient *redis.Client, cfg *c
 	}, portBindingService)
 	// GitOps: reconcile a repo of miabi.io/v1 manifests via the apply engine.
 	gitopsService := gitops.NewService(repositories.NewGitSourceRepository(db), gitRepoRepo, applyService)
+	gitopsService.SetSecrets(secretService) // resolve a vault-backed Git credential when fetching
 	// CI/CD pipelines: definitions + runs on the internal runner (worker).
 	pipelineService := pipeline.NewService(repositories.NewPipelineRepository(db), producer)
 	// Repository-owned pipelines: adopting a repo's .miabi/pipeline.yaml and

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -1096,6 +1096,12 @@ func InitRoutes(app *okapi.Okapi, db *gorm.DB, redisClient *redis.Client, cfg *c
 	r.h.adminRegistry.SetGC(func(ctx context.Context) error {
 		return registryServerService.GarbageCollect(ctx, dockerClient)
 	})
+	// Live container state + resource usage for the admin overview, and the
+	// repository count that decides whether a storage change strands images.
+	r.h.adminRegistry.SetRuntime(func(ctx context.Context) (*registryserver.Runtime, error) {
+		return registryServerService.RuntimeStatus(ctx, dockerClient)
+	})
+	r.h.adminRegistry.SetRepoCount(registryServerService.RepositoryCount)
 	go func() {
 		if err := registryServerService.Ensure(context.Background(), dockerClient); err != nil {
 			logger.Warn("internal registry ensure on boot failed", "error", err)

--- a/internal/services/apply/apply.go
+++ b/internal/services/apply/apply.go
@@ -22,6 +22,7 @@ import (
 	"github.com/miabi-io/miabi/internal/services/database"
 	"github.com/miabi-io/miabi/internal/services/domain"
 	"github.com/miabi-io/miabi/internal/services/portbinding"
+	"github.com/miabi-io/miabi/internal/services/registry"
 	"github.com/miabi-io/miabi/internal/services/route"
 	"github.com/miabi-io/miabi/internal/services/secret"
 	"github.com/miabi-io/miabi/internal/services/stack"
@@ -50,13 +51,14 @@ var (
 
 // Service computes and executes declarative plans for a workspace.
 type Service struct {
-	apps    *application.Service
-	storage *storage.Service
-	dbs     *database.Service
-	stacks  *stack.Service
-	secrets *secret.Service
-	routes  *route.Service
-	domains *domain.Service
+	apps       *application.Service
+	storage    *storage.Service
+	dbs        *database.Service
+	stacks     *stack.Service
+	secrets    *secret.Service
+	routes     *route.Service
+	domains    *domain.Service
+	registries *registry.Service
 
 	// Port-exposure reconcilers (optional; wired via SetPortExposure). extConfig
 	// resolves the platform external-access base domain at apply time; bindings
@@ -66,8 +68,11 @@ type Service struct {
 }
 
 // NewService wires the apply engine over the existing resource services.
-func NewService(apps *application.Service, storage *storage.Service, dbs *database.Service, stacks *stack.Service, secrets *secret.Service, routes *route.Service, domains *domain.Service) *Service {
-	return &Service{apps: apps, storage: storage, dbs: dbs, stacks: stacks, secrets: secrets, routes: routes, domains: domains}
+func NewService(apps *application.Service, storage *storage.Service, dbs *database.Service, stacks *stack.Service, secrets *secret.Service, routes *route.Service, domains *domain.Service, registries *registry.Service) *Service {
+	return &Service{
+		apps: apps, storage: storage, dbs: dbs, stacks: stacks,
+		secrets: secrets, routes: routes, domains: domains, registries: registries,
+	}
 }
 
 // SetPortExposure wires the reconcilers for an Application's per-port exposure:
@@ -411,12 +416,49 @@ func (s *Service) render(workspaceID uint, desired *declarative.ResourceSet) {
 	r := declarative.NewRenderer(ctx)
 	for i := range desired.All() {
 		res := desired.All()[i]
-		if res.Application == nil || len(res.Application.Env) == 0 {
-			continue
+		switch {
+		case res.Application != nil && len(res.Application.Env) > 0:
+			res.Application.Env = r.RenderEnvLenient(res.Metadata.Name, res.Application.Env)
+			desired.Add(res) // write back the rendered copy
+		case res.Registry != nil:
+			s.renderRegistryPassword(r, res.Metadata.Name, res.Registry, false)
+			desired.Add(res)
 		}
-		res.Application.Env = r.RenderEnvLenient(res.Metadata.Name, res.Application.Env)
-		desired.Add(res) // write back the rendered copy
 	}
+}
+
+// renderRegistryPassword resolves a registry password's templates and stamps the
+// fingerprint the plan compares against the stored credential. strict fails on an
+// unresolvable reference (execute time); lenient leaves the template in place
+// (plan time), and then deliberately leaves the fingerprint empty — an
+// unresolved template is not a password, and comparing its digest would report a
+// rotation that isn't one.
+func (s *Service) renderRegistryPassword(r *declarative.Renderer, name string, spec *declarative.RegistrySpec, strict bool) error {
+	if spec.Password == "" {
+		return nil
+	}
+	// `${{ secrets.X }}` is the *runtime* reference form: it is stored as a live
+	// pointer at the vault and resolved at every pull, so it must reach the
+	// registry service untouched. Rendering it would fail anyway — Go's template
+	// engine would read the inner {{ … }} as an undefined function call.
+	if ref := secret.RefName(spec.Password); ref != "" {
+		// Fingerprint the canonical spelling, so "${{secrets.x}}" and
+		// "${{ secrets.x }}" are the same credential rather than perpetual drift.
+		spec.PasswordFP = registry.Fingerprint(name, secret.Ref(ref))
+		return nil
+	}
+	rendered, err := r.RenderString("registry."+name+".password", spec.Password)
+	if err != nil {
+		if strict {
+			return err
+		}
+		return nil // leave the template; no fingerprint
+	}
+	spec.Password = rendered
+	if !strings.Contains(rendered, "{{") {
+		spec.PasswordFP = registry.Fingerprint(name, rendered)
+	}
+	return nil
 }
 
 // renderAppEnv resolves an application's env templates at execution time, against
@@ -567,6 +609,32 @@ func (s *Service) snapshot(ctx context.Context, workspaceID uint) (*declarative.
 		})
 	}
 
+	// Registry credentials before apps, for the same reason as volumes: an app
+	// references one by name, so the id -> name map has to exist first. Their
+	// password fingerprints let the plan see a rotation without ever handling the
+	// token (see registry.Fingerprints).
+	regs, err := s.registries.List(workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot registries: %w", err)
+	}
+	fps, err := s.registries.Fingerprints(workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot registry fingerprints: %w", err)
+	}
+	regNameByID := make(map[uint]string, len(regs))
+	for i := range regs {
+		regNameByID[regs[i].ID] = regs[i].Name
+		set.Add(declarative.Resource{
+			APIVersion: declarative.APIVersion, Kind: declarative.KindRegistry,
+			Metadata: metaA(regs[i].UID, regs[i].Name, regs[i].Metadata, regs[i].Annotations),
+			Registry: &declarative.RegistrySpec{
+				Server:     regs[i].Server,
+				Username:   regs[i].Username,
+				PasswordFP: fps[regs[i].Name],
+			},
+		})
+	}
+
 	apps, err := s.apps.List(workspaceID)
 	if err != nil {
 		return nil, fmt.Errorf("snapshot apps: %w", err)
@@ -578,7 +646,7 @@ func (s *Service) snapshot(ctx context.Context, workspaceID uint) (*declarative.
 			continue
 		}
 		ext, pub := s.exposedPorts(workspaceID, full.ID)
-		set.Add(appResource(full, ext, pub, volNameByID))
+		set.Add(appResource(full, ext, pub, volNameByID, regNameByID))
 	}
 
 	instances, err := s.dbs.List(workspaceID)
@@ -720,7 +788,7 @@ func metaA(uid, name string, m, annotations models.Metadata) declarative.Meta {
 // appResource maps a live application to its declarative form for diffing. ext
 // and pub are the container ports currently exposed externally (generated route)
 // and published (host-port binding), so per-port exposure converges idempotently.
-func appResource(app *models.Application, ext, pub map[int]bool, volNameByID map[uint]string) declarative.Resource {
+func appResource(app *models.Application, ext, pub map[int]bool, volNameByID, regNameByID map[uint]string) declarative.Resource {
 	spec := &declarative.ApplicationSpec{
 		Image:           app.Image,
 		Tag:             app.Tag,
@@ -728,6 +796,12 @@ func appResource(app *models.Application, ext, pub map[int]bool, volNameByID map
 		Command:         app.Command,
 		ContainerLabels: app.ContainerLabels,
 		ExternalLabel:   app.ExternalLabel,
+	}
+	// The pull credential, by its manifest name. A credential deleted out from
+	// under the app leaves RegistryID dangling only until the FK nulls it, so an
+	// unresolved id reads as "anonymous" rather than inventing a name.
+	if app.RegistryID != nil {
+		spec.Registry = regNameByID[*app.RegistryID]
 	}
 	// Managed volume mounts, by the volume's manifest name. Privileged host-preset
 	// binds (VolumeID 0) aren't manifest-expressible, so they're omitted.
@@ -813,6 +887,8 @@ func (s *Service) execute(ctx context.Context, workspaceID uint, ch declarative.
 		return s.applyRoute(ctx, workspaceID, ch, desired)
 	case declarative.KindDomain:
 		return s.applyDomain(workspaceID, ch, desired)
+	case declarative.KindRegistry:
+		return s.applyRegistry(ctx, workspaceID, ch, desired)
 	default:
 		return fmt.Errorf("%w: %s", ErrUnsupportedKind, ch.Kind)
 	}
@@ -915,6 +991,63 @@ func (s *Service) applySecret(workspaceID uint, ch declarative.Change, desired d
 		return s.secrets.Delete(workspaceID, sec.ID)
 	}
 	// Secret values are write-only and never diffed, so update is a no-op here.
+	return nil
+}
+
+// applyRegistry converges a container-registry credential. The password is
+// re-rendered strictly here — a bundle that pulls its token from the vault
+// ({{ .secrets.x }}) must resolve against the secrets that exist now, including
+// one declared earlier in the same bundle (Secret ranks below Registry, so it is
+// created first).
+func (s *Service) applyRegistry(ctx context.Context, workspaceID uint, ch declarative.Change, desired declarative.Resource) error {
+	switch ch.Action {
+	case declarative.ActionCreate, declarative.ActionUpdate:
+		spec := desired.Registry
+		if spec == nil {
+			return fmt.Errorf("%w: registry %q: spec is required", ErrInvalidManifest, ch.Name)
+		}
+		r := declarative.NewRenderer(declarative.RenderContext{Secrets: s.secretViews(workspaceID)})
+		if err := s.renderRegistryPassword(r, ch.Name, spec, true); err != nil {
+			return fmt.Errorf("%w: registry %q: %v", ErrInvalidManifest, ch.Name, err)
+		}
+		in := registry.Input{
+			Name:     ch.Name,
+			Server:   spec.Server,
+			Username: spec.Username,
+			Secret:   spec.Password,
+			// Labels are sanitized so a manifest can never spoof provenance; the
+			// managed-by label is what scopes a later prune to this engine's own
+			// credentials.
+			Metadata: tagSource(ctx, models.SetBuiltin(models.SanitizeUserMetadata(desired.Metadata.Labels),
+				models.MetaManagedBy, ManagedByGitOps,
+			)),
+			Annotations: desired.Metadata.Annotations,
+		}
+		if ch.Action == declarative.ActionCreate {
+			if spec.Password == "" {
+				return fmt.Errorf("%w: registry %q: password is required to create the credential (set spec.password, or create it once in the UI and drop the field)", ErrInvalidManifest, ch.Name)
+			}
+			_, err := s.registries.Create(workspaceID, in)
+			return err
+		}
+		reg, err := s.registries.FindByName(workspaceID, ch.Name)
+		if err != nil {
+			return fmt.Errorf("registry %q: %w", ch.Name, err)
+		}
+		// An empty password leaves the stored one untouched (registry.Update only
+		// rotates on a non-empty value), which is what lets a token be managed
+		// out-of-band while the rest of the credential stays declarative.
+		_, err = s.registries.Update(workspaceID, reg.ID, in)
+		return err
+	case declarative.ActionDelete:
+		reg, err := s.registries.FindByName(workspaceID, ch.Name)
+		if err != nil {
+			return fmt.Errorf("registry %q: %w", ch.Name, err)
+		}
+		// Applications referencing it keep running: the FK nulls their RegistryID
+		// (ON DELETE SET NULL), so they fall back to an anonymous pull.
+		return s.registries.Delete(workspaceID, reg.ID)
+	}
 	return nil
 }
 
@@ -1048,9 +1181,17 @@ func (s *Service) applyApplication(ctx context.Context, workspaceID uint, ch dec
 	if err := s.renderAppEnv(workspaceID, spec); err != nil {
 		return fmt.Errorf("%w: application %q: %v", ErrInvalidManifest, ch.Name, err)
 	}
+	// Resolve the pull credential before anything is created, so a typo'd name
+	// fails the change instead of deploying an app that cannot pull its image.
+	regID, err := s.resolveRegistry(workspaceID, ch.Name, spec)
+	if err != nil {
+		return err
+	}
 	switch ch.Action {
 	case declarative.ActionCreate:
-		app, err := s.apps.Create(workspaceID, s.createInput(ctx, desired.Metadata, spec))
+		in := s.createInput(ctx, desired.Metadata, spec)
+		in.RegistryID = regID
+		app, err := s.apps.Create(workspaceID, in)
 		if err != nil {
 			return err
 		}
@@ -1077,6 +1218,10 @@ func (s *Service) applyApplication(ctx context.Context, workspaceID uint, ch dec
 		app.Image = spec.Image
 		app.Tag = spec.Tag
 		app.Command = spec.Command
+		// Dropping spec.registry clears the credential (regID is nil), so the app
+		// converges back to an anonymous pull instead of silently keeping the old
+		// one.
+		app.RegistryID = regID
 		if spec.Resources != nil {
 			mb, _ := spec.Resources.MemoryBytes()
 			nc, _ := spec.Resources.NanoCPUs()
@@ -1123,6 +1268,29 @@ func (s *Service) applyApplication(ctx context.Context, workspaceID uint, ch dec
 		return s.apps.Delete(ctx, app)
 	}
 	return nil
+}
+
+// resolveRegistry maps an application's spec.registry to the id of the workspace
+// credential it names. Nil (anonymous pull) when the field is empty.
+//
+// The credential does not have to be declared in the same bundle — a token
+// created once in the UI is referenced by name from every manifest — so this
+// resolves against the live workspace rather than the desired set. A name that
+// matches nothing is a manifest error, not a silent fallback to an anonymous
+// pull: a private image would otherwise fail much later, at deploy, with an
+// opaque "manifest unknown" from the registry.
+func (s *Service) resolveRegistry(workspaceID uint, appName string, spec *declarative.ApplicationSpec) (*uint, error) {
+	// A delete carries no desired spec (a pruned resource is absent from the
+	// manifest by definition), so nil is normal here, not a caller error.
+	if spec == nil || spec.Registry == "" {
+		return nil, nil
+	}
+	reg, err := s.registries.FindByName(workspaceID, spec.Registry)
+	if err != nil {
+		return nil, fmt.Errorf("%w: application %q: unknown registry %q (declare it as a Registry resource, or create the credential in the workspace first)",
+			ErrInvalidManifest, appName, spec.Registry)
+	}
+	return &reg.ID, nil
 }
 
 // reconcileExposure converges an app's per-port exposure to the manifest: pins

--- a/internal/services/apply/delete_nilspec_test.go
+++ b/internal/services/apply/delete_nilspec_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package apply
+
+import "testing"
+
+// A prune-delete (and DeleteResource) drives execute with a zero Resource: the
+// pruned resource is, by definition, absent from the desired manifest. Anything
+// reading the desired spec on that path has to tolerate a nil.
+func TestResolveRegistryToleratesAbsentSpec(t *testing.T) {
+	s := &Service{} // registries deliberately unwired: a nil spec must not reach it
+	id, err := s.resolveRegistry(1, "api", nil)
+	if err != nil || id != nil {
+		t.Fatalf("resolveRegistry(nil spec) = (%v, %v), want (nil, nil)", id, err)
+	}
+}

--- a/internal/services/apply/mounts_test.go
+++ b/internal/services/apply/mounts_test.go
@@ -20,7 +20,7 @@ func TestAppResourceEmitsMounts(t *testing.T) {
 	}
 	volNameByID := map[uint]string{7: "guestbook-data"}
 
-	res := appResource(app, map[int]bool{}, map[int]bool{}, volNameByID)
+	res := appResource(app, map[int]bool{}, map[int]bool{}, volNameByID, nil)
 	got := res.Application.Mounts
 	if len(got) != 1 {
 		t.Fatalf("want 1 mount (host-preset omitted), got %d: %+v", len(got), got)

--- a/internal/services/apply/registry_test.go
+++ b/internal/services/apply/registry_test.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package apply
+
+import (
+	"testing"
+
+	"github.com/miabi-io/miabi/internal/models"
+)
+
+func TestAppResourceEmitsRegistryName(t *testing.T) {
+	regID := uint(3)
+	app := &models.Application{Name: "api", Image: "ghcr.io/org/api", RegistryID: &regID}
+	regNameByID := map[uint]string{3: "ghcr"}
+
+	res := appResource(app, map[int]bool{}, map[int]bool{}, nil, regNameByID)
+	if res.Application.Registry != "ghcr" {
+		t.Errorf("registry = %q, want ghcr", res.Application.Registry)
+	}
+
+	// An anonymous pull carries no credential name...
+	res = appResource(&models.Application{Name: "api"}, map[int]bool{}, map[int]bool{}, nil, regNameByID)
+	if res.Application.Registry != "" {
+		t.Errorf("an app with no credential should emit an empty registry, got %q", res.Application.Registry)
+	}
+	// ...and neither does one whose credential vanished from under it, rather
+	// than inventing a name the manifest could never match.
+	res = appResource(app, map[int]bool{}, map[int]bool{}, nil, map[uint]string{})
+	if res.Application.Registry != "" {
+		t.Errorf("an unresolved credential id should read as anonymous, got %q", res.Application.Registry)
+	}
+}

--- a/internal/services/apply/topology.go
+++ b/internal/services/apply/topology.go
@@ -261,5 +261,9 @@ func (s *Service) resolveLive(workspaceID uint, kind declarative.Kind, name stri
 		if sec, err := s.findSecret(workspaceID, name); err == nil {
 			node.LiveID = sec.ID
 		}
+	case declarative.KindRegistry:
+		if reg, err := s.registries.FindByName(workspaceID, name); err == nil {
+			node.LiveID, node.Slug = reg.ID, reg.Name
+		}
 	}
 }

--- a/internal/services/gitops/gitops.go
+++ b/internal/services/gitops/gitops.go
@@ -59,12 +59,18 @@ type Service struct {
 	repo     *repositories.GitSourceRepository
 	gitRepos *repositories.GitRepoRepository
 	applier  Applier
+	secrets  gitrepo.Secrets
 }
 
 // NewService wires the GitOps service.
 func NewService(repo *repositories.GitSourceRepository, gitRepos *repositories.GitRepoRepository, applier Applier) *Service {
 	return &Service{repo: repo, gitRepos: gitRepos, applier: applier}
 }
+
+// SetSecrets wires the vault, so a Git credential that references a workspace
+// Secret (rather than storing its own copy of the token) can be resolved when a
+// source is fetched. nil = literal credentials only.
+func (s *Service) SetSecrets(v gitrepo.Secrets) { s.secrets = v }
 
 // Input is the create/update payload for a GitSource. Name is the desired unique
 // slug handle; DisplayName is the free-text label (falls back to Name when blank).
@@ -440,7 +446,7 @@ func (s *Service) auth(src *models.GitSource) (transport.AuthMethod, string, err
 	if err != nil {
 		return nil, "", fmt.Errorf("git credential %d: %w", *src.GitRepositoryID, err)
 	}
-	auth, err := gitrepo.AuthFor(gr)
+	auth, err := gitrepo.AuthFor(gr, s.secrets)
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/services/gitrepo/credentialurl_test.go
+++ b/internal/services/gitrepo/credentialurl_test.go
@@ -19,13 +19,13 @@ func TestCredentialURL(t *testing.T) {
 	}
 
 	// Public / nil credential: URL unchanged (normalized to .git).
-	if got, err := CredentialURL("https://github.com/acme/web", nil); err != nil || got != "https://github.com/acme/web.git" {
+	if got, err := CredentialURL("https://github.com/acme/web", nil, nil); err != nil || got != "https://github.com/acme/web.git" {
 		t.Errorf("public: got %q err %v", got, err)
 	}
 
 	// Token: credential embedded as https://user:token@host/….
 	g := &models.GitRepository{AuthType: models.GitAuthToken, Username: "x-access-token", Secret: tok}
-	got, err := CredentialURL("https://github.com/acme/web.git", g)
+	got, err := CredentialURL("https://github.com/acme/web.git", g, nil)
 	if err != nil {
 		t.Fatalf("token: %v", err)
 	}
@@ -35,13 +35,13 @@ func TestCredentialURL(t *testing.T) {
 
 	// Empty username defaults to the provider-agnostic x-access-token.
 	g2 := &models.GitRepository{AuthType: models.GitAuthToken, Secret: tok}
-	if got2, _ := CredentialURL("https://github.com/acme/web.git", g2); !strings.Contains(got2, "x-access-token:ghp_secrettoken@") {
+	if got2, _ := CredentialURL("https://github.com/acme/web.git", g2, nil); !strings.Contains(got2, "x-access-token:ghp_secrettoken@") {
 		t.Errorf("default username not applied: %q", got2)
 	}
 
 	// SSH key: can't be embedded in a URL — clear error.
 	gs := &models.GitRepository{AuthType: models.GitAuthSSH, Secret: tok}
-	if _, err := CredentialURL("git@github.com:acme/web.git", gs); err != ErrSSHUnsupportedOnRunner {
+	if _, err := CredentialURL("git@github.com:acme/web.git", gs, nil); err != ErrSSHUnsupportedOnRunner {
 		t.Errorf("ssh: want ErrSSHUnsupportedOnRunner, got %v", err)
 	}
 }

--- a/internal/services/gitrepo/gitrepo.go
+++ b/internal/services/gitrepo/gitrepo.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/miabi-io/miabi/internal/models"
 	"github.com/miabi-io/miabi/internal/services/crypto"
+	"github.com/miabi-io/miabi/internal/services/secret"
 	"github.com/miabi-io/miabi/internal/slug"
 	"github.com/miabi-io/miabi/internal/storage/repositories"
 )
@@ -33,13 +34,52 @@ var (
 	ErrSecretRequired = errors.New("git credential secret is required")
 	ErrNameTaken      = errors.New("a git repository with this name already exists")
 	ErrNotFound       = errors.New("git repository not found")
+	ErrUnknownSecret  = errors.New("the referenced secret does not exist in this workspace")
 )
 
+// Secrets resolves a stored credential's secret: its own encrypted value, or the
+// current value of the workspace Secret it references. Implemented by the secret
+// service.
+//
+// It is threaded explicitly into AuthFor/CredentialURL rather than held only on
+// the Service, because the deploy worker, the pipeline runner and GitOps each
+// reach those from their own repositories.
+type Secrets interface {
+	CredentialSecret(workspaceID uint, enc, ref string) (string, error)
+}
+
+// Vault is the fuller access the Service itself needs: resolution plus the
+// existence check that validates a reference when a credential is saved.
+type Vault interface {
+	Secrets
+	ExistsByName(workspaceID uint, name string) bool
+}
+
 type Service struct {
-	repo *repositories.GitRepoRepository
+	repo    *repositories.GitRepoRepository
+	secrets Vault
 }
 
 func NewService(repo *repositories.GitRepoRepository) *Service { return &Service{repo: repo} }
+
+// SetSecrets wires the vault, enabling credentials that reference a Secret
+// rather than storing their own copy of the token or key.
+func (s *Service) SetSecrets(v Vault) { s.secrets = v }
+
+// storeSecret decides where an incoming secret lands: a `${{ secrets.NAME }}`
+// value becomes a reference to the vault, anything else is encrypted here. The
+// two are mutually exclusive, so switching a credential from one form to the
+// other always clears the other.
+func (s *Service) storeSecret(workspaceID uint, value string) (enc, ref string, err error) {
+	if name := secret.RefName(value); name != "" {
+		if s.secrets != nil && !s.secrets.ExistsByName(workspaceID, name) {
+			return "", "", fmt.Errorf("%w: %q", ErrUnknownSecret, name)
+		}
+		return "", name, nil
+	}
+	enc, err = crypto.EncryptWS(workspaceID, value)
+	return enc, "", err
+}
 
 // Input describes a git credential to create or update. Name is the desired
 // unique slug handle; DisplayName is the free-text label (falls back to Name).
@@ -49,7 +89,11 @@ type Input struct {
 	URL         string
 	AuthType    models.GitAuthType
 	Username    string
-	Secret      string // plaintext token or SSH private key; encrypted before storage
+	// Secret is either the token / SSH private key itself (encrypted before
+	// storage) or a `${{ secrets.NAME }}` reference to a workspace Secret, which
+	// is stored as a reference and resolved at every clone. Blank on update =
+	// keep what is stored.
+	Secret string
 }
 
 func (s *Service) Create(workspaceID uint, in Input) (*models.GitRepository, error) {
@@ -73,9 +117,9 @@ func (s *Service) Create(workspaceID uint, in Input) (*models.GitRepository, err
 	}
 	authType := normalizeAuthType(in.AuthType)
 	// Public repos (and a blank secret) are cloned anonymously — no stored secret.
-	enc := ""
+	enc, ref := "", ""
 	if authType != models.GitAuthPublic && strings.TrimSpace(in.Secret) != "" {
-		enc, err = crypto.EncryptWS(workspaceID, in.Secret)
+		enc, ref, err = s.storeSecret(workspaceID, in.Secret)
 		if err != nil {
 			return nil, err
 		}
@@ -88,6 +132,7 @@ func (s *Service) Create(workspaceID uint, in Input) (*models.GitRepository, err
 		AuthType:    authType,
 		Username:    in.Username,
 		Secret:      enc,
+		SecretRef:   ref,
 	}
 	if err := s.repo.Create(g); err != nil {
 		return nil, err
@@ -122,13 +167,15 @@ func (s *Service) Update(workspaceID, id uint, in Input) (*models.GitRepository,
 	g.Username = in.Username
 	switch {
 	case g.AuthType == models.GitAuthPublic:
-		g.Secret = "" // public repo carries no credential
+		g.Secret, g.SecretRef = "", "" // public repo carries no credential
 	case strings.TrimSpace(in.Secret) != "":
-		enc, err := crypto.EncryptWS(workspaceID, in.Secret)
+		// Switching between a stored token and a vault reference always clears the
+		// other form.
+		enc, ref, err := s.storeSecret(workspaceID, in.Secret)
 		if err != nil {
 			return nil, err
 		}
-		g.Secret = enc
+		g.Secret, g.SecretRef = enc, ref
 	}
 	if err := s.repo.Update(g); err != nil {
 		return nil, err
@@ -155,6 +202,28 @@ func (s *Service) List(workspaceID uint) ([]models.GitRepository, error) {
 	return repos, nil
 }
 
+// BundleSecret returns what a portable workspace bundle should carry for a
+// credential: its vault reference when it has one — the referenced Secret
+// travels in the same bundle, so the indirection (and later rotations on the
+// target) is preserved — else the decrypted token or key.
+//
+// It re-reads the row from the repository because List/Get strip the secret for
+// safe responses; taking it from a listed record would silently export a blank
+// credential.
+func (s *Service) BundleSecret(workspaceID, id uint) (string, error) {
+	g, err := s.repo.FindInWorkspace(workspaceID, id)
+	if err != nil {
+		return "", ErrNotFound
+	}
+	if g.SecretRef != "" {
+		return secret.Ref(g.SecretRef), nil
+	}
+	if g.Secret == "" {
+		return "", nil
+	}
+	return crypto.Decrypt(g.Secret)
+}
+
 func (s *Service) Delete(workspaceID, id uint) error {
 	g, err := s.repo.FindInWorkspace(workspaceID, id)
 	if err != nil {
@@ -169,7 +238,7 @@ func (s *Service) TestConnection(ctx context.Context, workspaceID, id uint) erro
 	if err != nil {
 		return ErrNotFound
 	}
-	auth, err := AuthFor(g)
+	auth, err := AuthFor(g, s.secrets)
 	if err != nil {
 		return err
 	}
@@ -205,7 +274,7 @@ func (s *Service) CloneURLAuth(workspaceID uint, rawURL string, credentialID *ui
 	if strings.TrimSpace(rawURL) == "" {
 		return "", nil, ErrURLRequired
 	}
-	auth, err := AuthFor(g)
+	auth, err := AuthFor(g, s.secrets)
 	if err != nil {
 		return "", nil, err
 	}
@@ -253,20 +322,13 @@ func Checkout(ctx context.Context, dir, url, ref string, auth transport.AuthMeth
 	return hash.String(), nil
 }
 
-// AuthFor builds a go-git auth method from a stored credential, decrypting the
-// secret. Returns nil auth (anonymous) when g is nil. Shared by the deploy
-// worker and the test-connection check.
-func AuthFor(g *models.GitRepository) (transport.AuthMethod, error) {
-	if g == nil {
-		return nil, nil
-	}
-	// Public repos, or any repo with no stored secret, clone anonymously.
-	if normalizeAuthType(g.AuthType) == models.GitAuthPublic || strings.TrimSpace(g.Secret) == "" {
-		return nil, nil
-	}
-	secret, err := crypto.Decrypt(g.Secret)
-	if err != nil {
-		return nil, fmt.Errorf("decrypt git secret: %w", err)
+// AuthFor builds a go-git auth method from a stored credential, resolving its
+// secret through vault. Returns nil auth (anonymous) when g is nil. Shared by
+// the deploy worker, GitOps, and the test-connection check.
+func AuthFor(g *models.GitRepository, vault Secrets) (transport.AuthMethod, error) {
+	secretValue, err := credentialSecret(g, vault)
+	if err != nil || secretValue == "" {
+		return nil, err // no secret => anonymous clone
 	}
 	switch normalizeAuthType(g.AuthType) {
 	case models.GitAuthSSH:
@@ -274,7 +336,7 @@ func AuthFor(g *models.GitRepository) (transport.AuthMethod, error) {
 		if user == "" {
 			user = "git"
 		}
-		keys, err := gitssh.NewPublicKeys(user, []byte(secret), "")
+		keys, err := gitssh.NewPublicKeys(user, []byte(secretValue), "")
 		if err != nil {
 			return nil, fmt.Errorf("parse ssh key: %w", err)
 		}
@@ -284,8 +346,36 @@ func AuthFor(g *models.GitRepository) (transport.AuthMethod, error) {
 		if user == "" {
 			user = "x-access-token" // provider-agnostic default for PAT auth
 		}
-		return &githttp.BasicAuth{Username: user, Password: secret}, nil
+		return &githttp.BasicAuth{Username: user, Password: secretValue}, nil
 	}
+}
+
+// credentialSecret resolves the token or key a credential authenticates with,
+// from its own encrypted value or from the workspace Secret it references.
+// Returns "" for an anonymous clone: a nil credential, a public repo, or one
+// with nothing stored.
+//
+// A credential that references the vault with no vault wired is an error rather
+// than a silent anonymous clone — that would turn a private repo into a
+// confusing "repository not found" much further downstream.
+func credentialSecret(g *models.GitRepository, vault Secrets) (string, error) {
+	if g == nil || normalizeAuthType(g.AuthType) == models.GitAuthPublic {
+		return "", nil
+	}
+	if g.SecretRef != "" {
+		if vault == nil {
+			return "", fmt.Errorf("git credential %q references secret %q but the vault is unavailable", g.Name, g.SecretRef)
+		}
+		return vault.CredentialSecret(g.WorkspaceID, "", g.SecretRef)
+	}
+	if strings.TrimSpace(g.Secret) == "" {
+		return "", nil
+	}
+	value, err := crypto.Decrypt(g.Secret)
+	if err != nil {
+		return "", fmt.Errorf("decrypt git secret: %w", err)
+	}
+	return value, nil
 }
 
 // ErrSSHUnsupportedOnRunner is returned when a repo authenticates by SSH key but
@@ -302,17 +392,20 @@ var ErrSSHUnsupportedOnRunner = errors.New("SSH-key git credentials can't be use
 // The credential lands only in the runner's ephemeral per-job workspace git
 // config (removed when the job ends) and is never logged (the runner treats the
 // source URL as opaque/secret).
-func CredentialURL(rawURL string, g *models.GitRepository) (string, error) {
+func CredentialURL(rawURL string, g *models.GitRepository, vault Secrets) (string, error) {
 	rawURL = normalizeGitURL(rawURL)
-	if g == nil || normalizeAuthType(g.AuthType) == models.GitAuthPublic || strings.TrimSpace(g.Secret) == "" {
+	if g == nil || normalizeAuthType(g.AuthType) == models.GitAuthPublic {
 		return rawURL, nil
 	}
 	if normalizeAuthType(g.AuthType) == models.GitAuthSSH {
 		return "", ErrSSHUnsupportedOnRunner
 	}
-	secret, err := crypto.Decrypt(g.Secret)
+	secretValue, err := credentialSecret(g, vault)
 	if err != nil {
-		return "", fmt.Errorf("decrypt git secret: %w", err)
+		return "", err
+	}
+	if secretValue == "" {
+		return rawURL, nil // nothing stored: an anonymous clone
 	}
 	u, err := url.Parse(rawURL)
 	if err != nil {
@@ -325,12 +418,14 @@ func CredentialURL(rawURL string, g *models.GitRepository) (string, error) {
 	if user == "" {
 		user = "x-access-token" // provider-agnostic default for PAT auth
 	}
-	u.User = url.UserPassword(user, secret) // url-encodes tokens with special chars
+	u.User = url.UserPassword(user, secretValue) // url-encodes tokens with special chars
 	return u.String(), nil
 }
 
+// strip clears the ciphertext and flags secret presence for safe responses. A
+// vault reference is a name, not a secret, so it is left in place for the UI.
 func strip(g *models.GitRepository) *models.GitRepository {
-	g.HasSecret = g.Secret != ""
+	g.HasSecret = g.Secret != "" || g.SecretRef != ""
 	g.Secret = ""
 	return g
 }

--- a/internal/services/gitrepo/secretref_test.go
+++ b/internal/services/gitrepo/secretref_test.go
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gitrepo
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/miabi-io/miabi/internal/models"
+	"github.com/miabi-io/miabi/internal/services/crypto"
+)
+
+// fakeVault stands in for the secret service: name -> current value.
+type fakeVault map[string]string
+
+func (v fakeVault) CredentialSecret(_ uint, enc, ref string) (string, error) {
+	if ref != "" {
+		val, ok := v[ref]
+		if !ok {
+			return "", errors.New("secret not found: " + ref)
+		}
+		return val, nil
+	}
+	if enc == "" {
+		return "", nil
+	}
+	return crypto.Decrypt(enc)
+}
+
+func (v fakeVault) ExistsByName(_ uint, name string) bool {
+	_, ok := v[name]
+	return ok
+}
+
+func TestAuthForResolvesVaultReference(t *testing.T) {
+	crypto.Init("test-master-key-for-gitrepo-ref")
+	vault := fakeVault{"GH_TOKEN": "ghp_from_the_vault"}
+
+	g := &models.GitRepository{
+		Name: "acme-api", AuthType: models.GitAuthToken,
+		Username: "x-access-token", SecretRef: "GH_TOKEN",
+	}
+	auth, err := AuthFor(g, vault)
+	if err != nil {
+		t.Fatalf("AuthFor: %v", err)
+	}
+	basic, ok := auth.(*githttp.BasicAuth)
+	if !ok {
+		t.Fatalf("want basic auth, got %T", auth)
+	}
+	if basic.Password != "ghp_from_the_vault" {
+		t.Errorf("password = %q, want the current vault value", basic.Password)
+	}
+
+	// The credential holds no copy, so rotating the secret rotates the credential
+	// with no edit to it at all.
+	vault["GH_TOKEN"] = "ghp_rotated"
+	auth, _ = AuthFor(g, vault)
+	if basic := auth.(*githttp.BasicAuth); basic.Password != "ghp_rotated" {
+		t.Errorf("password = %q, want the rotated value", basic.Password)
+	}
+}
+
+// A dangling or unresolvable reference must fail loudly. Cloning anonymously
+// instead would surface as a confusing "repository not found" much later.
+func TestAuthForFailsOnUnresolvableReference(t *testing.T) {
+	g := &models.GitRepository{Name: "acme-api", AuthType: models.GitAuthToken, SecretRef: "GONE"}
+
+	if _, err := AuthFor(g, fakeVault{}); err == nil {
+		t.Error("a reference to a missing secret must be an error, not an anonymous clone")
+	}
+	_, err := AuthFor(g, nil)
+	if err == nil || !strings.Contains(err.Error(), "vault is unavailable") {
+		t.Errorf("a reference with no vault wired must error, got %v", err)
+	}
+}
+
+func TestCredentialURLResolvesVaultReference(t *testing.T) {
+	crypto.Init("test-master-key-for-gitrepo-ref")
+	vault := fakeVault{"GH_TOKEN": "ghp_from_the_vault"}
+
+	g := &models.GitRepository{Name: "acme-api", AuthType: models.GitAuthToken, SecretRef: "GH_TOKEN"}
+	got, err := CredentialURL("https://github.com/acme/api.git", g, vault)
+	if err != nil {
+		t.Fatalf("CredentialURL: %v", err)
+	}
+	if got != "https://x-access-token:ghp_from_the_vault@github.com/acme/api.git" {
+		t.Errorf("URL = %q", got)
+	}
+}
+
+// A public repo never authenticates, whichever form its (leftover) secret takes.
+func TestPublicRepoIgnoresCredential(t *testing.T) {
+	g := &models.GitRepository{AuthType: models.GitAuthPublic, SecretRef: "GH_TOKEN"}
+	auth, err := AuthFor(g, fakeVault{})
+	if err != nil || auth != nil {
+		t.Errorf("public repo: got auth %v err %v, want anonymous", auth, err)
+	}
+}

--- a/internal/services/registry/fingerprint_test.go
+++ b/internal/services/registry/fingerprint_test.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package registry
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFingerprint(t *testing.T) {
+	const pw = "ghp_secret_token"
+
+	if got := Fingerprint("ghcr", pw); got != Fingerprint("ghcr", pw) {
+		t.Error("fingerprint must be stable for the same name+password")
+	}
+	if Fingerprint("ghcr", pw) == Fingerprint("ghcr", pw+"!") {
+		t.Error("a rotated password must change the fingerprint")
+	}
+	// Salted by name: the same password under two credentials must not collide,
+	// so a plan can't correlate them.
+	if Fingerprint("ghcr", pw) == Fingerprint("dockerhub", pw) {
+		t.Error("fingerprints must be salted by the credential name")
+	}
+	// Nothing recoverable, and an unset password is distinguishable from a set one.
+	if fp := Fingerprint("ghcr", pw); strings.Contains(fp, pw) || len(fp) != 16 {
+		t.Errorf("fingerprint = %q, want a 16-char digest containing no plaintext", fp)
+	}
+	if Fingerprint("ghcr", "") != "" {
+		t.Error("an unset password must fingerprint to the empty string")
+	}
+}

--- a/internal/services/registry/registry.go
+++ b/internal/services/registry/registry.go
@@ -7,6 +7,8 @@ package registry
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/http"
@@ -15,6 +17,7 @@ import (
 
 	"github.com/miabi-io/miabi/internal/models"
 	"github.com/miabi-io/miabi/internal/services/crypto"
+	"github.com/miabi-io/miabi/internal/services/secret"
 	"github.com/miabi-io/miabi/internal/storage/repositories"
 )
 
@@ -23,23 +26,79 @@ var (
 	ErrSecretRequired = errors.New("registry secret is required")
 	ErrNameTaken      = errors.New("a registry with this name already exists")
 	ErrNotFound       = errors.New("registry not found")
+	ErrUnknownSecret  = errors.New("the referenced secret does not exist in this workspace")
 )
 
 // DefaultServer is the implicit registry when none is given (Docker Hub).
 const DefaultServer = "registry-1.docker.io"
 
+// Vault is the vault access a registry credential needs: resolving a stored
+// credential (its own encrypted value, or the secret it references) and checking
+// that a reference points at something. Implemented by the secret service;
+// optional (nil = literal secrets only).
+type Vault interface {
+	CredentialSecret(workspaceID uint, enc, ref string) (string, error)
+	ExistsByName(workspaceID uint, name string) bool
+}
+
 type Service struct {
-	repo *repositories.RegistryRepository
+	repo    *repositories.RegistryRepository
+	secrets Vault
 }
 
 func NewService(repo *repositories.RegistryRepository) *Service { return &Service{repo: repo} }
+
+// SetSecrets wires the vault, enabling credentials that reference a Secret
+// rather than storing their own copy of the password.
+func (s *Service) SetSecrets(v Vault) { s.secrets = v }
+
+// Secret resolves a credential's password: the vault value when it references a
+// Secret, else its own decrypted literal. This is the only way the plaintext
+// leaves this package.
+func (s *Service) Secret(reg *models.Registry) (string, error) {
+	if reg.SecretRef != "" {
+		if s.secrets == nil {
+			return "", fmt.Errorf("registry %q references secret %q but the vault is unavailable", reg.Name, reg.SecretRef)
+		}
+		return s.secrets.CredentialSecret(reg.WorkspaceID, "", reg.SecretRef)
+	}
+	if reg.Secret == "" {
+		return "", nil
+	}
+	return crypto.Decrypt(reg.Secret)
+}
+
+// storeSecret decides where an incoming secret lands: a `${{ secrets.NAME }}`
+// value becomes a reference to the vault, anything else is encrypted here. The
+// two are mutually exclusive, so switching a credential from one form to the
+// other always clears the other. A blank value means "leave as-is" and is the
+// caller's business — this is only called with a non-blank one.
+func (s *Service) storeSecret(workspaceID uint, value string) (enc, ref string, err error) {
+	if name := secret.RefName(value); name != "" {
+		if s.secrets != nil && !s.secrets.ExistsByName(workspaceID, name) {
+			return "", "", fmt.Errorf("%w: %q", ErrUnknownSecret, name)
+		}
+		return "", name, nil
+	}
+	enc, err = crypto.EncryptWS(workspaceID, value)
+	return enc, "", err
+}
 
 // Input describes a registry credential to create or update.
 type Input struct {
 	Name     string
 	Server   string
 	Username string
-	Secret   string // plaintext; encrypted before storage
+	// Secret is either the password itself (encrypted before storage) or a
+	// `${{ secrets.NAME }}` reference to a workspace Secret, which is stored as a
+	// reference and resolved at every use. Blank on update = keep what is stored.
+	Secret string
+	// Metadata / Annotations carry provenance labels and free-form notes. Set by
+	// the declarative apply engine (managed-by, gitops-source) so a prune can tell
+	// its own credentials from hand-created ones; nil leaves them untouched on
+	// update.
+	Metadata    models.Metadata
+	Annotations models.Metadata
 }
 
 func (s *Service) Create(workspaceID uint, in Input) (*models.Registry, error) {
@@ -56,7 +115,7 @@ func (s *Service) Create(workspaceID uint, in Input) (*models.Registry, error) {
 	if taken {
 		return nil, ErrNameTaken
 	}
-	enc, err := crypto.EncryptWS(workspaceID, in.Secret)
+	enc, ref, err := s.storeSecret(workspaceID, in.Secret)
 	if err != nil {
 		return nil, err
 	}
@@ -66,6 +125,9 @@ func (s *Service) Create(workspaceID uint, in Input) (*models.Registry, error) {
 		Server:      normalizeServer(in.Server),
 		Username:    in.Username,
 		Secret:      enc,
+		SecretRef:   ref,
+		Metadata:    in.Metadata,
+		Annotations: in.Annotations,
 	}
 	if err := s.repo.Create(reg); err != nil {
 		return nil, err
@@ -83,18 +145,104 @@ func (s *Service) Update(workspaceID, id uint, in Input) (*models.Registry, erro
 	}
 	reg.Server = normalizeServer(in.Server)
 	reg.Username = in.Username
-	// Only rotate the secret when a new value is supplied.
+	// Only rotate the secret when a new value is supplied. Switching between a
+	// stored password and a vault reference always clears the other form.
 	if strings.TrimSpace(in.Secret) != "" {
-		enc, err := crypto.EncryptWS(workspaceID, in.Secret)
+		enc, ref, err := s.storeSecret(workspaceID, in.Secret)
 		if err != nil {
 			return nil, err
 		}
-		reg.Secret = enc
+		reg.Secret, reg.SecretRef = enc, ref
+	}
+	if in.Metadata != nil {
+		reg.Metadata = in.Metadata
+	}
+	if in.Annotations != nil {
+		reg.Annotations = in.Annotations
 	}
 	if err := s.repo.Update(reg); err != nil {
 		return nil, err
 	}
 	return strip(reg), nil
+}
+
+// BundleSecret returns what a portable workspace bundle should carry for a
+// credential: its vault reference when it has one — the referenced Secret
+// travels in the same bundle, so the indirection (and later rotations on the
+// target) is preserved — else the decrypted password.
+//
+// It re-reads the row from the repository because List/Get strip the secret for
+// safe responses; taking it from a listed record would silently export a blank
+// credential.
+func (s *Service) BundleSecret(workspaceID, id uint) (string, error) {
+	reg, err := s.repo.FindInWorkspace(workspaceID, id)
+	if err != nil {
+		return "", ErrNotFound
+	}
+	if reg.SecretRef != "" {
+		return secret.Ref(reg.SecretRef), nil
+	}
+	if reg.Secret == "" {
+		return "", nil
+	}
+	return crypto.Decrypt(reg.Secret)
+}
+
+// FindByName resolves a credential by its workspace-scoped name handle — how a
+// manifest references one (an Application's spec.registry).
+func (s *Service) FindByName(workspaceID uint, name string) (*models.Registry, error) {
+	regs, err := s.repo.ListByWorkspace(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	for i := range regs {
+		if regs[i].Name == name {
+			return strip(&regs[i]), nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+// Fingerprints returns a non-reversible fingerprint of every credential's stored
+// password, keyed by registry name. It lets the declarative plan engine detect a
+// rotated password — and converge it — without the plaintext ever leaving this
+// package or appearing in a plan. A credential whose secret cannot be decrypted
+// is omitted, so it reads as "unknown" rather than "empty" (which would look like
+// a rotation on every plan).
+func (s *Service) Fingerprints(workspaceID uint) (map[string]string, error) {
+	regs, err := s.repo.ListByWorkspace(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]string, len(regs))
+	for i := range regs {
+		// A vault-backed credential is fingerprinted by its *reference*, not by the
+		// value behind it: the credential says "whatever secret X holds", so
+		// rotating X is not a change to this credential (the next pull just reads
+		// the new value). Pointing it at a different secret is.
+		if regs[i].SecretRef != "" {
+			out[regs[i].Name] = Fingerprint(regs[i].Name, secret.Ref(regs[i].SecretRef))
+			continue
+		}
+		plain, dErr := crypto.Decrypt(regs[i].Secret)
+		if dErr != nil {
+			continue
+		}
+		out[regs[i].Name] = Fingerprint(regs[i].Name, plain)
+	}
+	return out, nil
+}
+
+// Fingerprint derives the stable fingerprint of a registry password. It is salted
+// with the credential's name so the same password under two names does not
+// produce the same digest (no cross-registry correlation, no shared rainbow
+// table), and truncated because it is only ever compared for equality.
+func Fingerprint(name, password string) string {
+	if password == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte("miabi-registry-fp\x00" + name + "\x00" + password))
+	return hex.EncodeToString(sum[:8])
 }
 
 func (s *Service) Get(workspaceID, id uint) (*models.Registry, error) {
@@ -131,16 +279,19 @@ func (s *Service) TestConnection(ctx context.Context, workspaceID, id uint) erro
 	if err != nil {
 		return ErrNotFound
 	}
-	secret, err := crypto.Decrypt(reg.Secret)
+	// Resolves the vault reference when there is one, so "Test connection" checks
+	// the credential the deploy will actually use.
+	password, err := s.Secret(reg)
 	if err != nil {
-		return fmt.Errorf("decrypt secret: %w", err)
+		return err
 	}
-	return checkRegistryAuth(ctx, reg.Server, reg.Username, secret)
+	return checkRegistryAuth(ctx, reg.Server, reg.Username, password)
 }
 
-// strip clears the ciphertext and flags secret presence for safe responses.
+// strip clears the ciphertext and flags secret presence for safe responses. A
+// vault reference is a name, not a secret, so it is left in place for the UI.
 func strip(reg *models.Registry) *models.Registry {
-	reg.HasSecret = reg.Secret != ""
+	reg.HasSecret = reg.Secret != "" || reg.SecretRef != ""
 	reg.Secret = ""
 	return reg
 }

--- a/internal/services/registry/secretref_test.go
+++ b/internal/services/registry/secretref_test.go
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package registry
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/miabi-io/miabi/internal/models"
+	"github.com/miabi-io/miabi/internal/services/crypto"
+	"github.com/miabi-io/miabi/internal/services/secret"
+)
+
+// fakeVault stands in for the secret service: name -> current value.
+type fakeVault map[string]string
+
+func (v fakeVault) CredentialSecret(_ uint, enc, ref string) (string, error) {
+	if ref != "" {
+		val, ok := v[ref]
+		if !ok {
+			return "", errors.New("secret not found: " + ref)
+		}
+		return val, nil
+	}
+	if enc == "" {
+		return "", nil
+	}
+	return crypto.Decrypt(enc)
+}
+
+func (v fakeVault) ExistsByName(_ uint, name string) bool {
+	_, ok := v[name]
+	return ok
+}
+
+func TestStoreSecretRoutesReferenceToTheVault(t *testing.T) {
+	crypto.Init("test-master-key-for-registry-ref")
+	s := &Service{secrets: fakeVault{"GHCR_TOKEN": "ghp_live"}}
+
+	// A reference is stored by name — nothing is copied here.
+	enc, ref, err := s.storeSecret(1, secret.Ref("GHCR_TOKEN"))
+	if err != nil {
+		t.Fatalf("storeSecret(ref): %v", err)
+	}
+	if ref != "GHCR_TOKEN" || enc != "" {
+		t.Errorf("reference stored as enc=%q ref=%q, want the reference alone", enc, ref)
+	}
+
+	// A literal is encrypted here and holds no reference.
+	enc, ref, err = s.storeSecret(1, "ghp_pasted_in")
+	if err != nil {
+		t.Fatalf("storeSecret(literal): %v", err)
+	}
+	if ref != "" || enc == "" || enc == "ghp_pasted_in" {
+		t.Errorf("literal stored as enc=%q ref=%q, want an encrypted value and no reference", enc, ref)
+	}
+
+	// A reference to a secret that does not exist is rejected at save time, not
+	// left to fail at the next pull.
+	if _, _, err = s.storeSecret(1, secret.Ref("NOPE")); !errors.Is(err, ErrUnknownSecret) {
+		t.Errorf("dangling reference error = %v, want ErrUnknownSecret", err)
+	}
+}
+
+func TestSecretResolvesReferenceAtEveryUse(t *testing.T) {
+	crypto.Init("test-master-key-for-registry-ref")
+	vault := fakeVault{"GHCR_TOKEN": "ghp_live"}
+	s := &Service{secrets: vault}
+
+	reg := &models.Registry{WorkspaceID: 1, Name: "ghcr", SecretRef: "GHCR_TOKEN"}
+	got, err := s.Secret(reg)
+	if err != nil || got != "ghp_live" {
+		t.Fatalf("Secret() = (%q, %v), want the current vault value", got, err)
+	}
+
+	// The credential holds no copy, so rotating the secret rotates it.
+	vault["GHCR_TOKEN"] = "ghp_rotated"
+	if got, _ = s.Secret(reg); got != "ghp_rotated" {
+		t.Errorf("Secret() = %q after rotation, want ghp_rotated", got)
+	}
+
+	// A literal credential still resolves through the same call.
+	enc, _ := crypto.EncryptWS(1, "ghp_literal")
+	if got, err = s.Secret(&models.Registry{WorkspaceID: 1, Name: "dh", Secret: enc}); err != nil || got != "ghp_literal" {
+		t.Errorf("Secret(literal) = (%q, %v)", got, err)
+	}
+}
+
+// A vault-backed credential is identified by its reference, so rotating the
+// secret behind it is not drift in a declarative plan — the next pull simply
+// reads the new value. Pointing it at a different secret is a real change.
+func TestFingerprintOfAReferenceTracksTheNameNotTheValue(t *testing.T) {
+	a := Fingerprint("ghcr", secret.Ref("GHCR_TOKEN"))
+	if a != Fingerprint("ghcr", secret.Ref("GHCR_TOKEN")) {
+		t.Error("the same reference must fingerprint the same")
+	}
+	if a == Fingerprint("ghcr", secret.Ref("OTHER_TOKEN")) {
+		t.Error("a different referenced secret must change the fingerprint")
+	}
+	if a == Fingerprint("ghcr", "ghp_literal") {
+		t.Error("a reference and a literal must not collide")
+	}
+}

--- a/internal/services/registryserver/hostlock_test.go
+++ b/internal/services/registryserver/hostlock_test.go
@@ -20,27 +20,34 @@ func (b baseDomain) String(_, def string) string {
 	return string(b)
 }
 
-// Enablement follows MIABI_REGISTRY_ENABLED and nothing else — in particular not
-// the stored row, which is what the admin UI used to write.
-func TestEnabledIsEnvOnly(t *testing.T) {
+// MIABI_REGISTRY_ENABLED pins enablement when it is set, and only then. An
+// absent variable leaves the switch to the stored row — i.e. to the admin UI —
+// so an install that configures nothing in the environment is driven entirely
+// from the console.
+func TestEnablementFollowsEnvOnlyWhenSet(t *testing.T) {
 	cases := []struct {
 		name   string
 		env    bool
+		envSet bool
 		stored bool
 		want   bool
 	}{
-		{"env on", true, false, true},
-		{"env off beats a stored on", false, true, false},
-		{"env off", false, false, false},
-		{"env on with stored on", true, true, true},
+		{"env on", true, true, false, true},
+		{"env off beats a stored on", false, true, true, false},
+		{"env on beats a stored off", true, true, false, true},
+		{"unset: the stored value decides", false, false, true, true},
+		{"unset and never enabled", false, false, false, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			st := &models.RegistrySettings{Enabled: tc.stored}
-			svc := &Service{cfg: config.RegistryConfig{Enabled: tc.env}}
+			svc := &Service{cfg: config.RegistryConfig{Enabled: tc.env, EnabledSet: tc.envSet}}
 			svc.applyEnvConfig(st)
 			if st.Enabled != tc.want {
 				t.Errorf("Enabled = %v, want %v", st.Enabled, tc.want)
+			}
+			if got := svc.Locks().Enabled; got != tc.envSet {
+				t.Errorf("Locks().Enabled = %v, want %v", got, tc.envSet)
 			}
 		})
 	}
@@ -85,16 +92,36 @@ func TestHostResolution(t *testing.T) {
 	}
 }
 
-// Save must not be a back door onto the two locked fields: whatever the row held,
-// what comes back is what the environment says.
-func TestSaveCannotChangeEnablement(t *testing.T) {
-	svc := &Service{cfg: config.RegistryConfig{Enabled: false, Host: "registry.env.test"}, settings: baseDomain("")}
-	st := &models.RegistrySettings{Enabled: true, Host: "registry.attacker.test"}
+// A field the environment pins can never be written from the API: the value the
+// operator declared must survive whatever the row holds, or a compose file would
+// stop describing the install it deploys.
+func TestEnvPinnedFieldsBeatStoredValues(t *testing.T) {
+	svc := &Service{
+		cfg:      config.RegistryConfig{Enabled: false, EnabledSet: true, Host: "registry.env.test", StorageType: "filesystem"},
+		settings: baseDomain(""),
+	}
+	st := &models.RegistrySettings{Enabled: true, Host: "registry.stale.test", StorageType: models.RegistryStorageS3}
 	svc.applyEnvConfig(st)
+
 	if st.Enabled {
-		t.Error("a stored enabled=true survived an env that says disabled")
+		t.Error("a stored enabled=true survived an env that pins it off")
 	}
 	if st.Host != "registry.env.test" {
 		t.Errorf("Host = %q, want the env value to win", st.Host)
+	}
+	if st.StorageType != models.RegistryStorageFilesystem {
+		t.Errorf("StorageType = %q, want the env value to win", st.StorageType)
+	}
+	locks := svc.Locks()
+	if !locks.Enabled || !locks.Host || !locks.Storage {
+		t.Errorf("Locks = %+v, want enablement, host and storage all pinned", locks)
+	}
+}
+
+// With nothing in the environment, every field is the console's to set.
+func TestNothingIsLockedWithoutEnv(t *testing.T) {
+	svc := &Service{cfg: config.RegistryConfig{}, settings: baseDomain("")}
+	if locks := svc.Locks(); locks.Any() {
+		t.Errorf("Locks = %+v, want nothing pinned", locks)
 	}
 }

--- a/internal/services/registryserver/registryserver.go
+++ b/internal/services/registryserver/registryserver.go
@@ -156,23 +156,79 @@ func (s *Service) Get() (*models.RegistrySettings, error) {
 	return st, nil
 }
 
-// SaveInput carries an update: the two operational settings an admin may change
-// at runtime.
-//
-// Enablement, the hostname, and the whole storage configuration are deliberately
-// absent — all of them are boot-time, environment-only (see applyEnvConfig).
-// Accepting any of them here would give the admin API a way to move the
-// registry's identity or its storage backend at runtime, and would let the S3
-// driver be selected without the entitlement the environment path is checked
-// against.
+// SaveInput carries a settings update. Every field is optional in the sense that
+// an environment-pinned one is ignored — see Locks. Pointers mark "the client
+// sent this"; nil leaves the stored value alone.
 type SaveInput struct {
 	DeleteEnabled       bool
 	PerWorkspaceQuotaMB int
+
+	// Platform configuration. Written only where the environment is silent.
+	Enabled     *bool
+	Host        *string
+	StorageType *string
+
+	S3Endpoint       *string
+	S3Bucket         *string
+	S3Region         *string
+	S3AccessKey      *string
+	S3ForcePathStyle *bool
+	// S3SecretKey rotates the stored secret. Empty (or nil) keeps the current one,
+	// so a form that never reads the value back can be saved without wiping it.
+	S3SecretKey *string
 }
 
-// Save persists the two mutable settings. Storage — driver, bucket, credentials
-// — is never written here: it is read from the environment on every load, so a
-// stored value could only ever go stale against it.
+// Locks reports which fields the environment has pinned. A locked field is
+// read-only: Save ignores it, and the admin UI renders it as fixed with the
+// variable that owns it, rather than offering an input whose value the server
+// would discard.
+type Locks struct {
+	Enabled bool `json:"enabled"`
+	Host    bool `json:"host"`
+	Storage bool `json:"storage"`
+	// S3 is per-field: an install may pin the bucket in the environment and leave
+	// the credentials to the UI, or the reverse.
+	S3Endpoint  bool `json:"s3_endpoint"`
+	S3Bucket    bool `json:"s3_bucket"`
+	S3Region    bool `json:"s3_region"`
+	S3AccessKey bool `json:"s3_access_key"`
+	S3SecretKey bool `json:"s3_secret_key"`
+	S3ForcePath bool `json:"s3_force_path_style"`
+}
+
+// Any reports whether the environment pins anything at all.
+func (l Locks) Any() bool {
+	return l.Enabled || l.Host || l.Storage || l.S3Endpoint || l.S3Bucket ||
+		l.S3Region || l.S3AccessKey || l.S3SecretKey || l.S3ForcePath
+}
+
+// Locks returns the environment-pinned fields for this install.
+func (s *Service) Locks() Locks {
+	c := s.cfg
+	return Locks{
+		Enabled:     c.EnabledSet,
+		Host:        strings.TrimSpace(c.Host) != "",
+		Storage:     strings.TrimSpace(c.StorageType) != "",
+		S3Endpoint:  c.S3Endpoint != "",
+		S3Bucket:    c.S3Bucket != "",
+		S3Region:    c.S3Region != "",
+		S3AccessKey: c.S3AccessKey != "",
+		S3SecretKey: c.S3SecretKey != "",
+		S3ForcePath: c.S3ForcePath,
+	}
+}
+
+// Save persists the settings an admin may change, skipping every field the
+// environment pins.
+//
+// The environment stays authoritative where it speaks — an install configured
+// by docker-compose or a Helm chart keeps behaving exactly as before, and its
+// values can't drift out from under the file that declares them. Where it is
+// silent, the database is the source of truth and this is what writes it.
+//
+// Validation of a *change* (does this install may use S3, is the host a usable
+// hostname, does switching storage strand existing blobs) belongs to the caller:
+// it is where the operator can be asked to confirm.
 func (s *Service) Save(in SaveInput) (*models.RegistrySettings, error) {
 	st, err := s.repo.Get()
 	if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -180,11 +236,43 @@ func (s *Service) Save(in SaveInput) (*models.RegistrySettings, error) {
 	} else if err != nil {
 		return nil, err
 	}
+	locks := s.Locks()
 
-	st.Enabled = s.cfg.Enabled
-	if host := s.envHost(); host != "" {
+	if in.Enabled != nil && !locks.Enabled {
+		st.Enabled = *in.Enabled
+	}
+	if in.Host != nil && !locks.Host {
+		host, hErr := NormalizeHost(*in.Host)
+		if hErr != nil {
+			return nil, fmt.Errorf("host: %w", hErr)
+		}
 		st.Host = host
 	}
+	if in.StorageType != nil && !locks.Storage {
+		st.StorageType = normalizeStorage(*in.StorageType)
+	}
+	setStr := func(dst *string, src *string, locked bool) {
+		if src != nil && !locked {
+			*dst = strings.TrimSpace(*src)
+		}
+	}
+	setStr(&st.S3Endpoint, in.S3Endpoint, locks.S3Endpoint)
+	setStr(&st.S3Bucket, in.S3Bucket, locks.S3Bucket)
+	setStr(&st.S3Region, in.S3Region, locks.S3Region)
+	setStr(&st.S3AccessKey, in.S3AccessKey, locks.S3AccessKey)
+	if in.S3ForcePathStyle != nil && !locks.S3ForcePath {
+		st.S3ForcePathStyle = *in.S3ForcePathStyle
+	}
+	// A blank secret means "keep what is stored": the API never returns the value,
+	// so a form round-trip carries nothing to re-send.
+	if in.S3SecretKey != nil && !locks.S3SecretKey && strings.TrimSpace(*in.S3SecretKey) != "" {
+		enc, eErr := crypto.Encrypt(strings.TrimSpace(*in.S3SecretKey))
+		if eErr != nil {
+			return nil, fmt.Errorf("encrypt S3 secret key: %w", eErr)
+		}
+		st.S3SecretKeyEnc = enc
+	}
+
 	// The data volume is a fixed platform name, not admin-configurable.
 	st.VolumeName = models.DefaultRegistryVolume
 	st.DeleteEnabled = in.DeleteEnabled
@@ -194,7 +282,7 @@ func (s *Service) Save(in SaveInput) (*models.RegistrySettings, error) {
 		return nil, err
 	}
 	// Return the same env-layered view a read would give, so the caller renders
-	// the effective storage rather than the bare row.
+	// the effective configuration rather than the bare row.
 	s.applyEnvConfig(st)
 	st.S3SecretSet = st.S3SecretKeyEnc != ""
 	return st, nil
@@ -228,23 +316,21 @@ func (s *Service) envHost() string {
 
 // applyEnvConfig layers the boot environment over the stored settings.
 //
-// Enablement, the hostname, and the storage configuration are all
-// environment-derived: nothing in the admin API writes them (see SaveInput).
-// They define whether the registry exists, what name every image reference is
-// anchored to, and where the bytes live — none of which may change under a
-// running platform. The gateway route, its TLS certificate, the references
-// recorded on past deployments, and the namespace check at pull time all key off
-// the host; every pushed blob keys off the storage backend. Changing any of them
-// takes an env change and a restart, so every process in the install agrees on
-// the answer.
+// The environment wins wherever it speaks, and only there. That is what lets an
+// install declared by docker-compose or a Helm chart stay authoritative — its
+// values can't be edited out from under the file that declares them — while an
+// install that sets none of these is configured entirely from the admin UI.
 //
-// A stored value survives only where the environment is silent, and only as a
-// legacy carry-over from when these fields were UI-editable — an upgraded
-// install must keep answering on the host and reading from the bucket its
-// existing images already live behind. Nothing can write a new one.
+// Which fields are pinned is reported by Locks, so the UI can render an
+// env-managed field as fixed and name the variable that owns it, and Save can
+// ignore it rather than writing a value that the next read would overwrite.
 func (s *Service) applyEnvConfig(st *models.RegistrySettings) {
 	c := s.cfg
-	st.Enabled = c.Enabled
+	// Only an explicitly-set variable pins enablement: absent means the stored
+	// value (i.e. the admin UI's switch) decides.
+	if c.EnabledSet {
+		st.Enabled = c.Enabled
+	}
 	if host := s.envHost(); host != "" {
 		st.Host = host
 	}
@@ -279,10 +365,10 @@ func (s *Service) applyEnvConfig(st *models.RegistrySettings) {
 	}
 }
 
-// StorageSource names where the effective storage driver came from, for the
-// admin UI's read-only explanation of why the fields cannot be edited:
-// "env" (MIABI_REGISTRY_STORAGE), "stored" (a value saved while the driver was
-// UI-editable), or "default" (the filesystem driver, nothing configured).
+// StorageSource names where the effective storage driver came from, so the admin
+// UI can say why a field is fixed or which value it is editing: "env"
+// (MIABI_REGISTRY_STORAGE pins it), "stored" (configured in the console), or
+// "default" (the filesystem driver, nothing configured).
 func (s *Service) StorageSource(st *models.RegistrySettings) string {
 	if strings.TrimSpace(s.cfg.StorageType) != "" {
 		return "env"
@@ -295,21 +381,16 @@ func (s *Service) StorageSource(st *models.RegistrySettings) string {
 
 // StorageUnavailableReason returns "" when the configured storage driver can be
 // used, else a sentence naming exactly what is wrong.
-//
-// This is where the S3 entitlement is actually enforced. The admin API cannot
-// select the driver any more, so a check there would guard a door nobody uses:
-// the configuration arrives from the environment, and the environment is only
-// read here, on the paths that start a container against that storage.
 func (s *Service) StorageUnavailableReason(st *models.RegistrySettings) string {
 	if st == nil || !st.UsesS3() {
 		return ""
 	}
 	if !s.S3Entitled() {
 		return "S3/MinIO storage for the built-in registry requires an Enterprise license (the registry_s3 entitlement); " +
-			"install a license, or set MIABI_REGISTRY_STORAGE=filesystem to use a local volume"
+			"install a license, or switch the storage driver back to a local volume"
 	}
 	if strings.TrimSpace(st.S3Bucket) == "" {
-		return "S3 storage is selected but no bucket is configured (set MIABI_REGISTRY_S3_BUCKET)"
+		return "S3 storage is selected but no bucket is configured"
 	}
 	return ""
 }
@@ -346,8 +427,9 @@ func (s *Service) HostFor(st *models.RegistrySettings) string {
 	return host
 }
 
-// HostSource names where the effective host came from, for the admin UI's
-// read-only explanation of why the field cannot be edited.
+// HostSource names where the effective host came from: "env" (pinned by
+// MIABI_REGISTRY_HOST), "stored" (set in the console), "base_domain" (derived
+// from the platform's external base domain), or "unset".
 func (s *Service) HostSource(st *models.RegistrySettings) string {
 	if s.envHost() != "" {
 		return "env"
@@ -466,22 +548,24 @@ func (s *Service) Ensure(ctx context.Context, dc docker.Client) error {
 	return nil
 }
 
-// warnIfDisabledByLock reports an install that had the registry switched on from
-// the admin UI before enablement became environment-only. Tearing it down on the
-// first boot after the upgrade is correct — the environment is now the only
-// answer — but silently is not: git-source deploys stop working, and nothing on
-// the settings page would explain why. Say exactly what to set.
+// warnIfDisabledByLock reports a registry switched on in the console but held
+// off by the environment. Honouring the environment is correct — an operator who
+// pinned MIABI_REGISTRY_ENABLED=false means it — but doing so silently is not:
+// the console shows a registry that never comes up, and git-source deploys fail
+// with no clue why. Say exactly which variable decided.
+//
+// Only fires when the variable is explicitly set to false; an absent variable
+// leaves the switch to the console and is not an override at all.
 func (s *Service) warnIfDisabledByLock() {
-	if s.cfg.Enabled || s.repo == nil {
+	if !s.cfg.EnabledSet || s.cfg.Enabled || s.repo == nil {
 		return
 	}
 	stored, err := s.repo.Get()
 	if err != nil || stored == nil || !stored.Enabled {
 		return
 	}
-	logger.Error("internal registry was enabled in the database but MIABI_REGISTRY_ENABLED is not set — " +
-		"enablement and the registry hostname are now environment-only and take a restart to change. " +
-		"The registry has been torn down; set MIABI_REGISTRY_ENABLED=true (and MIABI_REGISTRY_HOST, if you had a custom host) and restart Miabi to bring it back.")
+	logger.Error("internal registry is enabled in the console but MIABI_REGISTRY_ENABLED=false pins it off — " +
+		"the environment wins where it is set. Remove the variable to let the console own the switch, or set it to true.")
 }
 
 // volumeMounts is the registry's data-volume mount (filesystem driver only). The

--- a/internal/services/registryserver/runtime.go
+++ b/internal/services/registryserver/runtime.go
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package registryserver
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/miabi-io/miabi/internal/docker"
+)
+
+// Runtime is the live state of the registry container: whether it is running,
+// and what it is costing. The registry is infrastructure an admin can't see with
+// the app-level tooling — it belongs to no workspace — so this is the only place
+// its resource usage surfaces.
+type Runtime struct {
+	// Running is the single question the UI leads with: is the registry actually
+	// serving? Configured-and-enabled says nothing about that.
+	Running bool `json:"running"`
+	// State / Status are Docker's own words ("running", "Up 3 days"), shown as-is
+	// so a stuck container is recognisable rather than flattened to "not running".
+	State  string `json:"state,omitempty"`
+	Status string `json:"status,omitempty"`
+	Health string `json:"health,omitempty"`
+	// RestartCount surfaces a crash-looping registry, which otherwise looks
+	// healthy in snapshots taken between restarts.
+	RestartCount int    `json:"restart_count,omitempty"`
+	StartedAt    string `json:"started_at,omitempty"`
+	Image        string `json:"image,omitempty"`
+
+	// Stats is a live sample; zero when the container is not running.
+	Stats *docker.StatsSample `json:"stats,omitempty"`
+	// StatsError explains a sample that could not be taken, so the UI can say
+	// "usage unavailable" instead of rendering a confident 0%.
+	StatsError string `json:"stats_error,omitempty"`
+}
+
+// errStopStream ends the stats stream once enough samples have been read.
+var errStopStream = errors.New("stop")
+
+// statsTimeout bounds a sample. Two readings are needed for a CPU percentage, and
+// the daemon emits one per second.
+const statsTimeout = 5 * time.Second
+
+// RuntimeStatus inspects the registry container and samples its resource usage.
+//
+// A missing container is not an error: a registry that is disabled, or enabled
+// but held down by a storage problem, simply reports Running=false. Only a
+// Docker failure is surfaced as one.
+func (s *Service) RuntimeStatus(ctx context.Context, dc docker.Client) (*Runtime, error) {
+	if dc == nil {
+		return nil, errors.New("docker is unavailable on the control plane")
+	}
+	c, err := dc.InspectContainer(ctx, ContainerName)
+	if err != nil {
+		if errors.Is(err, docker.ErrNotFound) {
+			return &Runtime{}, nil // not created: disabled, or never started
+		}
+		return nil, err
+	}
+	rt := &Runtime{
+		Running:      c.State == "running",
+		State:        c.State,
+		Status:       c.Status,
+		Health:       c.Health,
+		RestartCount: c.RestartCount,
+		StartedAt:    c.StartedAt,
+		Image:        c.Image,
+	}
+	if !rt.Running {
+		return rt, nil
+	}
+	sample, sErr := s.sample(ctx, dc, c.ID)
+	if sErr != nil {
+		rt.StatsError = sErr.Error()
+		return rt, nil
+	}
+	rt.Stats = &sample
+	return rt, nil
+}
+
+// RepositoryCount is the number of repositories the registry holds across every
+// workspace. It answers one question: would changing where blobs live strand
+// anything? A registry that is down or empty reports 0, which is the same answer
+// for that purpose.
+func (s *Service) RepositoryCount(ctx context.Context) (int, error) {
+	if s.reg == nil {
+		return 0, nil
+	}
+	repos, err := s.reg.Catalog(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return len(repos), nil
+}
+
+// sample reads two stream samples so CPU is computed against a prior reading — a
+// single one-shot sample always reports ~0%.
+func (s *Service) sample(ctx context.Context, dc docker.Client, containerID string) (docker.StatsSample, error) {
+	sctx, cancel := context.WithTimeout(ctx, statsTimeout)
+	defer cancel()
+	var last docker.StatsSample
+	n := 0
+	err := dc.StreamStats(sctx, containerID, func(x docker.StatsSample) error {
+		last = x
+		n++
+		if n >= 2 {
+			return errStopStream
+		}
+		return nil
+	})
+	if n == 0 {
+		return last, err
+	}
+	return last, nil
+}

--- a/internal/services/registryserver/storagelock_test.go
+++ b/internal/services/registryserver/storagelock_test.go
@@ -20,10 +20,9 @@ func (f fakeEE) Has(flag string) bool { return f[flag] }
 func licensed() fakeEE   { return fakeEE{enterprise.FlagRegistryS3: true} }
 func unlicensed() fakeEE { return fakeEE{} }
 
-// The storage driver follows the environment. A stored value survives only where
-// the environment is silent — the legacy carry-over for installs upgraded from
-// when the admin UI could write it.
-func TestStorageIsEnvOnly(t *testing.T) {
+// MIABI_REGISTRY_STORAGE pins the driver when it is set; where the environment
+// is silent the stored value — what the console writes — decides.
+func TestStorageFollowsEnvOnlyWhenSet(t *testing.T) {
 	cases := []struct {
 		name       string
 		env        string
@@ -122,10 +121,12 @@ func TestStorageUnavailableReason(t *testing.T) {
 			true, "Enterprise license",
 		},
 		{
+			// The bucket can be set from the console or the environment, so the
+			// reason names the missing thing rather than one way to supply it.
 			"licensed s3 without a bucket is refused",
 			licensed(),
 			&models.RegistrySettings{StorageType: models.RegistryStorageS3},
-			true, "MIABI_REGISTRY_S3_BUCKET",
+			true, "no bucket is configured",
 		},
 		{
 			"licensed s3 with a bucket is allowed",
@@ -184,7 +185,7 @@ func TestRenderEnvFilesystemNeedsNoLicense(t *testing.T) {
 func TestDistributionReportsUnlicensedStorage(t *testing.T) {
 	svc := &Service{
 		ee:       unlicensed(),
-		cfg:      config.RegistryConfig{Enabled: true, Host: "registry.example.com", StorageType: "s3", S3Bucket: "b"},
+		cfg:      config.RegistryConfig{Enabled: true, EnabledSet: true, Host: "registry.example.com", StorageType: "s3", S3Bucket: "b"},
 		settings: baseDomain(""),
 	}
 	reason := svc.DistributionUnavailableReason()

--- a/internal/services/secret/ref_test.go
+++ b/internal/services/secret/ref_test.go
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package secret
+
+import "testing"
+
+func TestRefName(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"${{ secrets.GHCR_TOKEN }}", "GHCR_TOKEN"},
+		{"${{secrets.GHCR_TOKEN}}", "GHCR_TOKEN"}, // spacing is not significant
+		{"  ${{ secrets.a-b_c }}  ", "a-b_c"},
+		{"", ""},
+		{"ghp_averyrealtoken", ""},
+		// A credential is opaque, so only a value that is *entirely* a reference
+		// counts. Anything else is the literal secret — a token that happens to
+		// contain the sequence must not be turned into a dangling reference.
+		{"prefix-${{ secrets.TOKEN }}", ""},
+		{"${{ secrets.TOKEN }} suffix", ""},
+		{"${{ secrets.A }}${{ secrets.B }}", ""},
+		{"${{ env.TOKEN }}", ""},
+		{"{{ .secrets.TOKEN }}", ""}, // the manifest render form, not the runtime one
+	} {
+		if got := RefName(tc.in); got != tc.want {
+			t.Errorf("RefName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestRefRoundTrips(t *testing.T) {
+	if got := RefName(Ref("API_KEY")); got != "API_KEY" {
+		t.Errorf("Ref/RefName round trip = %q, want API_KEY", got)
+	}
+}

--- a/internal/services/secret/secret.go
+++ b/internal/services/secret/secret.go
@@ -89,9 +89,10 @@ func (s *Service) List(workspaceID uint) ([]models.Secret, error) {
 }
 
 // ListPaged returns a searchable, paginated page of a workspace's secrets and
-// the total count of matching rows.
-func (s *Service) ListPaged(workspaceID uint, search string, limit, offset int) ([]models.Secret, int64, error) {
-	return s.repo.ListByWorkspacePaged(workspaceID, search, limit, offset)
+// the total count of matching rows. managed narrows to platform-owned secrets
+// (true) or hand-created ones (false); nil returns both.
+func (s *Service) ListPaged(workspaceID uint, search string, managed *bool, limit, offset int) ([]models.Secret, int64, error) {
+	return s.repo.ListByWorkspacePaged(workspaceID, search, managed, limit, offset)
 }
 
 func (s *Service) Get(workspaceID, id uint) (*models.Secret, error) {

--- a/internal/services/secret/secret.go
+++ b/internal/services/secret/secret.go
@@ -41,6 +41,28 @@ var nameRe = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_-]{0,62}$`)
 // refRe matches a `${{ secrets.NAME }}` reference (whitespace-tolerant).
 var refRe = regexp.MustCompile(`\$\{\{\s*secrets\.([A-Za-z][A-Za-z0-9_-]{0,62})\s*\}\}`)
 
+// pureRefRe matches a value that is *only* a reference, with nothing around it.
+// Env values interpolate references inside larger strings; a stored credential
+// (a registry password, a Git token or SSH key) is opaque and can contain any
+// bytes at all, so there it is all-or-nothing: either the field is a reference
+// or it is the literal secret. Anything else would make a token that happens to
+// contain "${{ secrets.x }}" silently unusable.
+var pureRefRe = regexp.MustCompile(`^\s*\$\{\{\s*secrets\.([A-Za-z][A-Za-z0-9_-]{0,62})\s*\}\}\s*$`)
+
+// RefName returns the secret a value references when the value is exactly one
+// `${{ secrets.NAME }}` reference, or "" when it is a literal.
+func RefName(value string) string {
+	m := pureRefRe.FindStringSubmatch(value)
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}
+
+// Ref renders the reference form of a secret name — the value a client stores in
+// a credential field to point at the vault instead of pasting the secret.
+func Ref(name string) string { return "${{ secrets." + name + " }}" }
+
 type Service struct {
 	repo      *repositories.SecretRepository
 	consumers Consumers
@@ -312,6 +334,39 @@ func (s *Service) ResolveAll(workspaceID uint, env []string) ([]string, error) {
 		return nil, missing
 	}
 	return out, nil
+}
+
+// CredentialSecret resolves a stored credential's secret — the one resolution
+// point shared by registry and Git credentials.
+//
+// When ref names a vault secret the *current* value is read from it, so rotating
+// that secret rotates every credential pointing at it with no edit to the
+// credential itself. Otherwise enc is the credential's own encrypted literal.
+// Both empty means the credential has no secret (an anonymous pull/clone), which
+// is not an error.
+//
+// A dangling reference is a hard error: a pull or clone must fail loudly rather
+// than silently authenticate with a blank password.
+func (s *Service) CredentialSecret(workspaceID uint, enc, ref string) (string, error) {
+	if ref != "" {
+		sec, err := s.repo.FindByName(workspaceID, ref)
+		if err != nil {
+			return "", fmt.Errorf("%w: credential references secret %q, which is not defined in this workspace", ErrNotFound, ref)
+		}
+		return crypto.Decrypt(sec.ValueEnc)
+	}
+	if enc == "" {
+		return "", nil
+	}
+	return crypto.Decrypt(enc)
+}
+
+// ExistsByName reports whether a secret of that name exists in the workspace. It
+// backs the validation of a credential's secret reference at create/update time,
+// so a typo surfaces in the form rather than at the next deploy.
+func (s *Service) ExistsByName(workspaceID uint, name string) bool {
+	_, err := s.repo.FindByName(workspaceID, name)
+	return err == nil
 }
 
 // IDByUID resolves a secret's portable uid to its numeric id.

--- a/internal/services/wsbackup/collect.go
+++ b/internal/services/wsbackup/collect.go
@@ -73,9 +73,12 @@ func (s *Service) collectCredentials(workspaceID uint, st *wsbundle.State, repor
 	}
 	for i := range regs {
 		r := &regs[i]
-		sec, err := crypto.Decrypt(r.Secret)
+		// Read the secret through the service: listed records are stripped, and a
+		// vault-backed credential exports as its reference (the Secret it names
+		// travels in the same bundle).
+		sec, err := s.Registry.BundleSecret(workspaceID, r.ID)
 		if err != nil {
-			report.Add("registry", r.Name, "failed", "credential could not be decrypted: "+err.Error())
+			report.Add("registry", r.Name, "failed", "credential could not be read: "+err.Error())
 			continue
 		}
 		st.Registries = append(st.Registries, wsbundle.Registry{
@@ -90,9 +93,9 @@ func (s *Service) collectCredentials(workspaceID uint, st *wsbundle.State, repor
 	}
 	for i := range repos {
 		r := &repos[i]
-		sec, err := crypto.Decrypt(r.Secret)
+		sec, err := s.GitRepo.BundleSecret(workspaceID, r.ID)
 		if err != nil {
-			report.Add("git-credential", r.Name, "failed", "credential could not be decrypted: "+err.Error())
+			report.Add("git-credential", r.Name, "failed", "credential could not be read: "+err.Error())
 			continue
 		}
 		st.GitRepos = append(st.GitRepos, wsbundle.GitRepository{

--- a/internal/storage/repositories/secret_repo.go
+++ b/internal/storage/repositories/secret_repo.go
@@ -43,9 +43,14 @@ func (r *SecretRepository) ListByWorkspace(workspaceID uint) ([]models.Secret, e
 }
 
 // ListByWorkspacePaged returns a page of secrets in a workspace, optionally
-// filtered by a case-insensitive match on name or description, plus the total
-// count of matching rows.
-func (r *SecretRepository) ListByWorkspacePaged(workspaceID uint, search string, limit, offset int) ([]models.Secret, int64, error) {
+// filtered by a case-insensitive match on name or description and by ownership
+// (managed = auto-created by a platform resource), plus the total count of
+// matching rows.
+//
+// Ownership is filtered here rather than in the caller precisely because the
+// result is paged: filtering a page client-side would hide rows the count still
+// claims, and a page could come back empty while later pages hold matches.
+func (r *SecretRepository) ListByWorkspacePaged(workspaceID uint, search string, managed *bool, limit, offset int) ([]models.Secret, int64, error) {
 	var (
 		secrets []models.Secret
 		total   int64
@@ -54,6 +59,9 @@ func (r *SecretRepository) ListByWorkspacePaged(workspaceID uint, search string,
 	if s := strings.TrimSpace(search); s != "" {
 		like := "%" + strings.ToLower(s) + "%"
 		q = q.Where("LOWER(name) LIKE ? OR LOWER(description) LIKE ?", like, like)
+	}
+	if managed != nil {
+		q = q.Where("managed = ?", *managed)
 	}
 	q.Count(&total)
 	if err := q.Order("name ASC").Limit(limit).Offset(offset).Find(&secrets).Error; err != nil {

--- a/internal/storage/repositories/secret_repo_test.go
+++ b/internal/storage/repositories/secret_repo_test.go
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package repositories
+
+import (
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// secretRow is a sqlite-friendly stand-in for models.Secret: the full model
+// carries Postgres-specific column defaults sqlite can't migrate, and the paged
+// listing only reads these columns.
+type secretRow struct {
+	ID          uint `gorm:"primaryKey"`
+	WorkspaceID uint
+	Name        string
+	Description string
+	Managed     bool
+}
+
+func (secretRow) TableName() string { return "secrets" }
+
+func newSecretDB(t *testing.T, rows []secretRow) *SecretRepository {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&secretRow{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	for i := range rows {
+		if err := db.Create(&rows[i]).Error; err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	return NewSecretRepository(db)
+}
+
+func names(t *testing.T, repo *SecretRepository, search string, managed *bool) ([]string, int64) {
+	t.Helper()
+	got, total, err := repo.ListByWorkspacePaged(1, search, managed, 50, 0)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	out := make([]string, 0, len(got))
+	for i := range got {
+		out = append(out, got[i].Name)
+	}
+	return out, total
+}
+
+func TestListByWorkspacePagedFiltersOwnership(t *testing.T) {
+	repo := newSecretDB(t, []secretRow{
+		{ID: 1, WorkspaceID: 1, Name: "APP_KEY"},
+		{ID: 2, WorkspaceID: 1, Name: "DB_SHOP_PASSWORD", Managed: true},
+		{ID: 3, WorkspaceID: 1, Name: "GHCR_TOKEN", Description: "registry token"},
+		{ID: 4, WorkspaceID: 2, Name: "OTHER_WORKSPACE"},
+	})
+
+	yes, no := true, false
+
+	// No filter returns both kinds — and never another workspace's secrets.
+	got, total := names(t, repo, "", nil)
+	if len(got) != 3 || total != 3 {
+		t.Errorf("unfiltered = %v (total %d), want the workspace's 3 secrets", got, total)
+	}
+
+	if got, total = names(t, repo, "", &yes); len(got) != 1 || got[0] != "DB_SHOP_PASSWORD" || total != 1 {
+		t.Errorf("managed = %v (total %d), want [DB_SHOP_PASSWORD]", got, total)
+	}
+	if got, total = names(t, repo, "", &no); len(got) != 2 || total != 2 {
+		t.Errorf("unmanaged = %v (total %d), want the 2 hand-created secrets", got, total)
+	}
+
+	// The count must reflect the filter too — it drives pagination, so a total
+	// that ignored the filter would page into rows that aren't there.
+	if _, total = names(t, repo, "", &yes); total != 1 {
+		t.Errorf("filtered total = %d, want 1", total)
+	}
+
+	// Search and ownership compose, and search still matches the description.
+	if got, _ = names(t, repo, "token", &no); len(got) != 1 || got[0] != "GHCR_TOKEN" {
+		t.Errorf("search+ownership = %v, want [GHCR_TOKEN]", got)
+	}
+	if got, _ = names(t, repo, "token", &yes); len(got) != 0 {
+		t.Errorf("search+ownership = %v, want no matches", got)
+	}
+}

--- a/internal/worker/deploy.go
+++ b/internal/worker/deploy.go
@@ -1384,7 +1384,7 @@ func (h *DeployHandler) gitSourceURL(app *models.Application) (string, error) {
 	if rawURL == "" {
 		return "", fmt.Errorf("git source requires a repository URL")
 	}
-	return gitrepo.CredentialURL(rawURL, gr)
+	return gitrepo.CredentialURL(rawURL, gr, h.secrets)
 }
 
 // deferForRunner queues a deploy that has no available runner: it parks the
@@ -1486,11 +1486,11 @@ func (h *DeployHandler) resolveRegistryAuth(app *models.Application, dep *models
 	if err != nil {
 		return nil, fmt.Errorf("registry %d: %w", *regID, err)
 	}
-	secret, err := crypto.Decrypt(reg.Secret)
+	password, err := h.credentialSecret(app.WorkspaceID, reg.Secret, reg.SecretRef)
 	if err != nil {
-		return nil, fmt.Errorf("decrypt registry secret: %w", err)
+		return nil, fmt.Errorf("registry %q: %w", reg.Name, err)
 	}
-	return &docker.RegistryAuth{Server: reg.Server, Username: reg.Username, Password: secret}, nil
+	return &docker.RegistryAuth{Server: reg.Server, Username: reg.Username, Password: password}, nil
 }
 
 // healthGate waits for the new container to be ready. With no healthcheck it

--- a/internal/worker/job.go
+++ b/internal/worker/job.go
@@ -14,7 +14,6 @@ import (
 	"github.com/miabi-io/miabi/internal/docker"
 	"github.com/miabi-io/miabi/internal/logstore"
 	"github.com/miabi-io/miabi/internal/models"
-	"github.com/miabi-io/miabi/internal/services/crypto"
 	"github.com/miabi-io/miabi/internal/storage/repositories"
 )
 
@@ -170,11 +169,11 @@ func (h *JobHandler) registryAuth(workspaceID uint, registryID *uint) (*docker.R
 	if err != nil {
 		return nil, fmt.Errorf("registry %d: %w", *registryID, err)
 	}
-	secret, err := crypto.Decrypt(reg.Secret)
+	password, err := h.credentialSecret(workspaceID, reg.Secret, reg.SecretRef)
 	if err != nil {
-		return nil, fmt.Errorf("decrypt registry secret: %w", err)
+		return nil, fmt.Errorf("registry %q: %w", reg.Name, err)
 	}
-	return &docker.RegistryAuth{Server: reg.Server, Username: reg.Username, Password: secret}, nil
+	return &docker.RegistryAuth{Server: reg.Server, Username: reg.Username, Password: password}, nil
 }
 
 // finish writes a job's terminal state.

--- a/internal/worker/pipeline.go
+++ b/internal/worker/pipeline.go
@@ -59,6 +59,7 @@ type PipelineHandler struct {
 	bus         *eventbus.Bus
 	producer    *Producer
 	logs        *logstore.Store
+	secrets     SecretResolver
 
 	// Runner dispatch (wired in the process that holds the runner tunnels). Every
 	// pipeline build runs on a registered runner; there is no on-node fallback.
@@ -111,6 +112,11 @@ func (h *PipelineHandler) SetRunnerDispatch(d RunnerDispatcher, workspaces *repo
 // full log is externalized to the store on terminal state and the DB row keeps
 // only a bounded tail + a reference. nil keeps DB-tail-only.
 func (h *PipelineHandler) SetLogStore(s *logstore.Store) { h.logs = s }
+
+// SetSecrets wires the vault, so a Git credential that references a workspace
+// Secret (rather than storing its own copy of the token) can be resolved when
+// the runner clones. nil = literal credentials only.
+func (h *PipelineHandler) SetSecrets(s SecretResolver) { h.secrets = s }
 
 // NewPipelineHandler builds the internal runner handler.
 func NewPipelineHandler(
@@ -286,7 +292,7 @@ func (h *PipelineHandler) sourceURL(app *models.Application) (string, error) {
 	if rawURL == "" {
 		return "", nil // command-only pipeline (no git-backed app)
 	}
-	return gitrepo.CredentialURL(rawURL, gr)
+	return gitrepo.CredentialURL(rawURL, gr, h.secrets)
 }
 
 // PipelineDeployer performs the deploy-by-digest a runner build triggers: it

--- a/internal/worker/runtime.go
+++ b/internal/worker/runtime.go
@@ -19,11 +19,35 @@ import (
 	"github.com/miabi-io/miabi/internal/storage/repositories"
 )
 
-// SecretResolver substitutes `${{ secrets.NAME }}` references in env values with
-// the workspace's stored secret values. Implemented by the secret service;
-// optional (nil = references are left untouched).
+// SecretResolver is the worker's window onto the vault: it substitutes
+// `${{ secrets.NAME }}` references in env values, and resolves the secret behind
+// a stored credential (a registry password or Git token) — which may itself be a
+// reference to a workspace Secret. Implemented by the secret service; optional
+// (nil = references are left untouched).
 type SecretResolver interface {
 	ResolveAll(workspaceID uint, env []string) ([]string, error)
+	CredentialSecret(workspaceID uint, enc, ref string) (string, error)
+}
+
+// credentialSecret resolves the secret behind a stored credential — its own
+// encrypted value, or the workspace Secret it references. Shared by the deploy
+// and job handlers (both embed runtimeBuilder) so a registry password reaches
+// the pull the same way wherever it is needed.
+//
+// A credential that references the vault with no resolver wired is an error, not
+// a silent anonymous pull: that would surface much later as an opaque
+// "manifest unknown" from the registry.
+func (b *runtimeBuilder) credentialSecret(workspaceID uint, enc, ref string) (string, error) {
+	if b.secrets == nil {
+		if ref != "" {
+			return "", fmt.Errorf("credential references secret %q but the vault is unavailable", ref)
+		}
+		if enc == "" {
+			return "", nil
+		}
+		return crypto.Decrypt(enc)
+	}
+	return b.secrets.CredentialSecret(workspaceID, enc, ref)
 }
 
 // Security is the resolved container hardening for a workspace's application and

--- a/web/src/api/registry.ts
+++ b/web/src/api/registry.ts
@@ -20,20 +20,13 @@ export interface RegistrySettings {
   /** Whether S3/MinIO storage is licensed (Enterprise); local storage is free. */
   s3_entitled: boolean
   /**
-   * `enabled` and `host` are read-only: they come from MIABI_REGISTRY_ENABLED /
-   * MIABI_REGISTRY_HOST and take a restart to change. Always true — the flag
-   * exists so the UI explains the fixed fields rather than offering inputs the
-   * server discards.
+   * Fields the environment pins. A locked field is read-only: the server ignores
+   * it on save, so the UI renders it fixed and names the variable that owns it.
+   * Everything unlocked is editable here.
    */
-  host_locked: boolean
+  locks: RegistryLocks
   /** Where the effective host came from. */
   host_source: 'env' | 'stored' | 'base_domain' | 'unset'
-  /**
-   * The storage driver and its S3 settings are read-only: they come from
-   * MIABI_REGISTRY_STORAGE / MIABI_REGISTRY_S3_* and take a restart to change.
-   * Always true, for the same reason as `host_locked`.
-   */
-  storage_locked: boolean
   /** Where the effective storage driver came from. */
   storage_source: 'env' | 'stored' | 'default'
   /**
@@ -43,14 +36,62 @@ export interface RegistrySettings {
   storage_error?: string
 }
 
+export interface RegistryLocks {
+  enabled: boolean
+  host: boolean
+  storage: boolean
+  s3_endpoint: boolean
+  s3_bucket: boolean
+  s3_region: boolean
+  s3_access_key: boolean
+  s3_secret_key: boolean
+  s3_force_path_style: boolean
+}
+
 /**
- * Only the two runtime-mutable settings. Enablement, the host, and the whole
- * storage configuration are environment-only — see `host_locked` /
- * `storage_locked` on RegistrySettings.
+ * A settings update. The platform fields are optional: omitting one leaves it
+ * alone, so a save from one tab never clobbers another's. An env-pinned field is
+ * ignored by the server whatever is sent.
  */
 export interface RegistrySettingsPayload {
   delete_enabled: boolean
   per_workspace_quota_mb: number
+  enabled?: boolean
+  host?: string
+  storage_type?: 'filesystem' | 's3'
+  s3_endpoint?: string
+  s3_bucket?: string
+  s3_region?: string
+  s3_access_key?: string
+  /** Blank keeps the stored secret — the API never returns it to re-send. */
+  s3_secret_key?: string
+  s3_force_path_style?: boolean
+  /**
+   * Acknowledges a change that strands data or breaks stored image references.
+   * Without it the server answers 409 with the prompt to show.
+   */
+  confirm?: boolean
+}
+
+/** Live state and resource usage of the registry container. */
+export interface RegistryRuntime {
+  running: boolean
+  state?: string
+  status?: string
+  health?: string
+  restart_count?: number
+  started_at?: string
+  image?: string
+  stats?: {
+    cpu_percent: number
+    memory_usage_bytes: number
+    memory_limit_bytes: number
+    memory_percent: number
+    network_rx_bytes: number
+    network_tx_bytes: number
+  }
+  /** Set when a sample could not be taken — show "unavailable", not a fake 0%. */
+  stats_error?: string
 }
 
 // RegistryInfo is the per-workspace docker-login guidance.
@@ -98,6 +139,7 @@ export const registryApi = {
   getSettings: () => api.get<ApiResponse<RegistrySettings>>('/admin/registry/settings'),
   updateSettings: (payload: RegistrySettingsPayload) =>
     api.put<ApiResponse<RegistrySettings>>('/admin/registry/settings', payload),
+  runtime: () => api.get<ApiResponse<RegistryRuntime>>('/admin/registry/runtime'),
   runGc: () => api.post<ApiResponse<{ message: string }>>('/admin/registry/gc'),
 
   // Workspace

--- a/web/src/api/secrets.ts
+++ b/web/src/api/secrets.ts
@@ -9,9 +9,19 @@ export interface SecretInput {
 
 const base = (ws: number) => `/workspaces/${ws}/secrets`
 
+/** Ownership filter: platform-owned secrets, hand-created ones, or both. */
+export type SecretOwnership = 'all' | 'managed' | 'unmanaged'
+
+/** The API takes a tri-state `managed`; omitting it means "both". */
+function managedParam(o: SecretOwnership): boolean | undefined {
+  return o === 'all' ? undefined : o === 'managed'
+}
+
 export const secretApi = {
-  list: (ws: number, search = '', page = 0, size = 20) =>
-    api.get<PageableResponse<Secret>>(base(ws), { params: { search: search || undefined, page, size } }),
+  list: (ws: number, search = '', page = 0, size = 20, ownership: SecretOwnership = 'all') =>
+    api.get<PageableResponse<Secret>>(base(ws), {
+      params: { search: search || undefined, page, size, managed: managedParam(ownership) },
+    }),
   create: (ws: number, input: SecretInput) => api.post<ApiResponse<Secret>>(base(ws), input),
   update: (ws: number, id: number, input: SecretInput) => api.put<ApiResponse<Secret>>(`${base(ws)}/${id}`, input),
   reveal: (ws: number, id: number) => api.get<ApiResponse<{ value: string }>>(`${base(ws)}/${id}/reveal`),

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -565,6 +565,9 @@ export interface Registry {
   server: string
   username: string
   has_secret: boolean
+  /** Name of the workspace Secret holding the password, when the credential
+   *  references the vault instead of storing its own copy. */
+  secret_ref?: string
   created_at?: string
 }
 
@@ -579,6 +582,9 @@ export interface GitRepository {
   auth_type: GitAuthType
   username: string
   has_secret: boolean
+  /** Name of the workspace Secret holding the token or key, when the credential
+   *  references the vault instead of storing its own copy. */
+  secret_ref?: string
   created_at?: string
 }
 

--- a/web/src/components/CredentialSecretField.vue
+++ b/web/src/components/CredentialSecretField.vue
@@ -1,9 +1,6 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
-import { storeToRefs } from 'pinia'
-import { useWorkspaceStore } from '@/stores/workspace'
-import { secretApi } from '@/api/secrets'
-import type { Secret } from '@/api/types'
+import { computed, ref, watch } from 'vue'
+import SecretPicker from '@/components/SecretPicker.vue'
 
 /**
  * The secret half of a stored credential (a registry password, a Git token or
@@ -31,36 +28,12 @@ const props = withDefaults(
 )
 const emit = defineEmits<{ (e: 'update:modelValue', v: string): void }>()
 
-const ws = useWorkspaceStore()
-const { currentWorkspaceId } = storeToRefs(ws)
-
 type Mode = 'value' | 'secret'
 // A credential that already references a secret opens on that tab, so editing it
 // doesn't silently look like a blank literal.
 const mode = ref<Mode>(props.currentRef ? 'secret' : 'value')
 const literal = ref('')
 const selected = ref(props.currentRef)
-
-const secrets = ref<Secret[]>([])
-const loading = ref(false)
-const loadFailed = ref(false)
-
-async function loadSecrets(wsId: number | null) {
-  if (!wsId) { secrets.value = []; return }
-  loading.value = true
-  loadFailed.value = false
-  try {
-    // One page is plenty for a picker; the vault is a small, named set.
-    secrets.value = (await secretApi.list(wsId, '', 0, 200)).data.data ?? []
-  } catch {
-    loadFailed.value = true
-    secrets.value = []
-  } finally {
-    loading.value = false
-  }
-}
-onMounted(() => loadSecrets(currentWorkspaceId.value))
-watch(currentWorkspaceId, loadSecrets)
 
 // The field owns mode/literal/selected and only ever pushes outward. It is not
 // re-synced from modelValue: the parent echoes what we emit, and reacting to
@@ -116,17 +89,12 @@ const required = computed(() => !props.editing)
     </template>
 
     <template v-else>
-      <select v-model="selected" class="form-select" :required="required" :aria-label="`${label} — secret`">
-        <option value="">Select a secret…</option>
-        <option v-for="s in secrets" :key="s.id" :value="s.name">
-          {{ s.name }}{{ s.managed ? ' (managed)' : '' }}
-        </option>
-      </select>
-      <p v-if="loading" class="form-hint">Loading secrets…</p>
-      <p v-else-if="loadFailed" class="form-hint">Could not load secrets — enter the value instead.</p>
-      <p v-else-if="secrets.length === 0" class="form-hint">
-        No secrets in this workspace yet. Add one under Secrets, or enter the value here.
-      </p>
+      <!-- Defaults to unmanaged: a managed secret is owned by another resource
+           (a provisioned database's password) and rotates with it, so it is
+           rarely the right thing to authenticate a registry or repo with. The
+           filter is right there when it is. -->
+      <SecretPicker v-model="selected" :label="label" default-ownership="unmanaged" />
+      <p v-if="required && !selected" class="form-hint">Choose a secret to continue.</p>
       <p v-else class="form-hint">
         Read from the vault on every use — rotating the secret rotates this credential.
       </p>

--- a/web/src/components/CredentialSecretField.vue
+++ b/web/src/components/CredentialSecretField.vue
@@ -1,0 +1,141 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useWorkspaceStore } from '@/stores/workspace'
+import { secretApi } from '@/api/secrets'
+import type { Secret } from '@/api/types'
+
+/**
+ * The secret half of a stored credential (a registry password, a Git token or
+ * SSH key). Either a value typed in here, or a reference to a workspace Secret.
+ *
+ * v-model is what the API expects in the credential's `secret` field: the literal
+ * value, or `${{ secrets.NAME }}` — the server routes the reference form to the
+ * vault and resolves it at every use, so rotating that Secret rotates every
+ * credential pointing at it.
+ */
+const props = withDefaults(
+  defineProps<{
+    /** Optional because the credential form types carry `secret?: string`. */
+    modelValue?: string
+    label: string
+    /** Editing an existing credential: a blank value keeps what is stored. */
+    editing?: boolean
+    /** The Secret this credential already references, if any. */
+    currentRef?: string
+    /** Render a textarea (an SSH private key) instead of a password input. */
+    multiline?: boolean
+    placeholder?: string
+  }>(),
+  { modelValue: '', editing: false, currentRef: '', multiline: false, placeholder: '' },
+)
+const emit = defineEmits<{ (e: 'update:modelValue', v: string): void }>()
+
+const ws = useWorkspaceStore()
+const { currentWorkspaceId } = storeToRefs(ws)
+
+type Mode = 'value' | 'secret'
+// A credential that already references a secret opens on that tab, so editing it
+// doesn't silently look like a blank literal.
+const mode = ref<Mode>(props.currentRef ? 'secret' : 'value')
+const literal = ref('')
+const selected = ref(props.currentRef)
+
+const secrets = ref<Secret[]>([])
+const loading = ref(false)
+const loadFailed = ref(false)
+
+async function loadSecrets(wsId: number | null) {
+  if (!wsId) { secrets.value = []; return }
+  loading.value = true
+  loadFailed.value = false
+  try {
+    // One page is plenty for a picker; the vault is a small, named set.
+    secrets.value = (await secretApi.list(wsId, '', 0, 200)).data.data ?? []
+  } catch {
+    loadFailed.value = true
+    secrets.value = []
+  } finally {
+    loading.value = false
+  }
+}
+onMounted(() => loadSecrets(currentWorkspaceId.value))
+watch(currentWorkspaceId, loadSecrets)
+
+// The field owns mode/literal/selected and only ever pushes outward. It is not
+// re-synced from modelValue: the parent echoes what we emit, and reacting to
+// that echo would snap the mode back on every keystroke. Re-initializing is
+// unnecessary anyway — the modal is v-if'd, so this component is created fresh
+// each time it opens, with the props of the credential being edited.
+function emitCurrent() {
+  emit('update:modelValue', mode.value === 'secret'
+    ? (selected.value ? `\${{ secrets.${selected.value} }}` : '')
+    : literal.value)
+}
+watch([mode, literal, selected], emitCurrent)
+
+// On create the field is required; on edit, blank means "keep what is stored".
+const required = computed(() => !props.editing)
+</script>
+
+<template>
+  <div class="form-group" style="margin-bottom: 0">
+    <label class="form-label">
+      {{ label }}
+      <span v-if="editing" class="text-muted">(leave blank to keep current)</span>
+    </label>
+
+    <div class="tabs source-tabs">
+      <button type="button" class="tab" :class="{ active: mode === 'value' }" @click="mode = 'value'">
+        Enter value
+      </button>
+      <button type="button" class="tab" :class="{ active: mode === 'secret' }" @click="mode = 'secret'">
+        Use a secret
+      </button>
+    </div>
+
+    <template v-if="mode === 'value'">
+      <textarea
+        v-if="multiline"
+        v-model="literal"
+        class="form-textarea"
+        :placeholder="placeholder"
+        :required="required"
+        :aria-label="label"
+      ></textarea>
+      <input
+        v-else
+        v-model="literal"
+        type="password"
+        class="form-input"
+        :placeholder="placeholder || '••••••••'"
+        autocomplete="new-password"
+        :required="required"
+        :aria-label="label"
+      />
+    </template>
+
+    <template v-else>
+      <select v-model="selected" class="form-select" :required="required" :aria-label="`${label} — secret`">
+        <option value="">Select a secret…</option>
+        <option v-for="s in secrets" :key="s.id" :value="s.name">
+          {{ s.name }}{{ s.managed ? ' (managed)' : '' }}
+        </option>
+      </select>
+      <p v-if="loading" class="form-hint">Loading secrets…</p>
+      <p v-else-if="loadFailed" class="form-hint">Could not load secrets — enter the value instead.</p>
+      <p v-else-if="secrets.length === 0" class="form-hint">
+        No secrets in this workspace yet. Add one under Secrets, or enter the value here.
+      </p>
+      <p v-else class="form-hint">
+        Read from the vault on every use — rotating the secret rotates this credential.
+      </p>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.source-tabs { margin-bottom: 10px; }
+.text-muted { color: var(--text-muted); font-weight: 400; }
+.form-hint { margin: 6px 0 0; font-size: 12px; color: var(--text-muted); }
+</style>

--- a/web/src/components/SecretPicker.vue
+++ b/web/src/components/SecretPicker.vue
@@ -1,0 +1,213 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useWorkspaceStore } from '@/stores/workspace'
+import { secretApi, type SecretOwnership } from '@/api/secrets'
+import type { Secret } from '@/api/types'
+
+/**
+ * Picks one secret by name from the workspace vault.
+ *
+ * A plain <select> does not work here: the vault is paged, so a dropdown can
+ * only ever show the first page and offers no way to reach the rest. This is a
+ * combobox instead — you type, the server searches every page, and the list
+ * shows what matched. The ownership filter is sent to the API for the same
+ * reason: narrowing a single page in the browser would hide secrets that exist
+ * on later ones.
+ */
+const props = withDefaults(
+  defineProps<{
+    /** Selected secret name ('' = nothing chosen). */
+    modelValue?: string
+    label?: string
+    /** Ownership shown first. Callers picking a credential default to
+     *  'unmanaged': a managed secret belongs to another resource and rotates
+     *  with it, so it is rarely what you want to point a credential at. */
+    defaultOwnership?: SecretOwnership
+    disabled?: boolean
+  }>(),
+  { modelValue: '', label: 'Secret', defaultOwnership: 'all', disabled: false },
+)
+const emit = defineEmits<{ (e: 'update:modelValue', v: string): void }>()
+
+const ws = useWorkspaceStore()
+const { currentWorkspaceId } = storeToRefs(ws)
+
+const PAGE_SIZE = 20
+
+const query = ref('')
+const ownership = ref<SecretOwnership>(props.defaultOwnership)
+const results = ref<Secret[]>([])
+const total = ref(0)
+const loading = ref(false)
+const failed = ref(false)
+const open = ref(false)
+const activeIndex = ref(-1)
+const root = ref<HTMLElement | null>(null)
+
+const selected = computed(() => props.modelValue)
+// Everything matching is on screen when the first page covers the total.
+const hiddenCount = computed(() => Math.max(0, total.value - results.value.length))
+
+async function search() {
+  const id = currentWorkspaceId.value
+  if (!id) { results.value = []; total.value = 0; return }
+  loading.value = true
+  failed.value = false
+  try {
+    const res = await secretApi.list(id, query.value.trim(), 0, PAGE_SIZE, ownership.value)
+    results.value = res.data.data ?? []
+    total.value = res.data.pageable?.total_elements ?? results.value.length
+    activeIndex.value = results.value.length ? 0 : -1
+  } catch {
+    failed.value = true
+    results.value = []
+    total.value = 0
+  } finally {
+    loading.value = false
+  }
+}
+
+// Debounced so typing doesn't fire a request per keystroke; the filter chips
+// re-query immediately, since that is a deliberate single action.
+let timer: ReturnType<typeof setTimeout> | undefined
+function onInput() {
+  open.value = true
+  if (timer) clearTimeout(timer)
+  timer = setTimeout(search, 250)
+}
+watch(ownership, search)
+watch(currentWorkspaceId, () => { results.value = []; search() })
+
+onMounted(() => {
+  search()
+  document.addEventListener('click', onDocumentClick)
+})
+onBeforeUnmount(() => {
+  if (timer) clearTimeout(timer)
+  document.removeEventListener('click', onDocumentClick)
+})
+
+function onDocumentClick(e: MouseEvent) {
+  if (root.value && !root.value.contains(e.target as Node)) open.value = false
+}
+
+function choose(s: Secret) {
+  emit('update:modelValue', s.name)
+  query.value = ''
+  open.value = false
+}
+function clear() {
+  emit('update:modelValue', '')
+  open.value = true
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (!open.value && (e.key === 'ArrowDown' || e.key === 'Enter')) { open.value = true; return }
+  if (e.key === 'ArrowDown') { e.preventDefault(); activeIndex.value = Math.min(activeIndex.value + 1, results.value.length - 1) }
+  else if (e.key === 'ArrowUp') { e.preventDefault(); activeIndex.value = Math.max(activeIndex.value - 1, 0) }
+  else if (e.key === 'Enter') {
+    const hit = results.value[activeIndex.value]
+    if (hit) { e.preventDefault(); choose(hit) }
+  } else if (e.key === 'Escape') { open.value = false }
+}
+
+const filters: Array<{ value: SecretOwnership; label: string }> = [
+  { value: 'all', label: 'All' },
+  { value: 'unmanaged', label: 'Not managed' },
+  { value: 'managed', label: 'Managed' },
+]
+</script>
+
+<template>
+  <div ref="root" class="secret-picker">
+    <!-- The chosen secret replaces the input, so the current value is never in
+         doubt and clearing it is one click. -->
+    <div v-if="selected" class="chosen">
+      <span class="mdi mdi-key-variant"></span>
+      <span class="chosen-name">{{ selected }}</span>
+      <button v-if="!disabled" type="button" class="btn-icon btn-icon-muted" title="Choose another secret"
+        aria-label="Choose another secret" @click="clear">
+        <span class="mdi mdi-close"></span>
+      </button>
+    </div>
+
+    <template v-else>
+      <input
+        v-model="query"
+        type="text"
+        class="form-input"
+        :placeholder="`Search ${label.toLowerCase()}s by name or description…`"
+        :aria-label="label"
+        :disabled="disabled"
+        autocomplete="off"
+        role="combobox"
+        :aria-expanded="open"
+        @input="onInput"
+        @focus="open = true"
+        @keydown="onKeydown"
+      />
+
+      <div v-if="open" class="results">
+        <div class="filters">
+          <button v-for="f in filters" :key="f.value" type="button" class="chip"
+            :class="{ active: ownership === f.value }" @click="ownership = f.value">{{ f.label }}</button>
+        </div>
+
+        <div v-if="loading" class="note"><span class="spinner spinner-sm"></span> Searching…</div>
+        <div v-else-if="failed" class="note">Could not load secrets.</div>
+        <div v-else-if="results.length === 0" class="note">
+          {{ query.trim() ? `No secrets match “${query.trim()}”.` : 'No secrets in this workspace yet.' }}
+        </div>
+        <ul v-else class="options" role="listbox">
+          <li v-for="(s, i) in results" :key="s.id" role="option" :aria-selected="i === activeIndex"
+            class="option" :class="{ active: i === activeIndex }"
+            @mouseenter="activeIndex = i" @click="choose(s)">
+            <span class="option-name">{{ s.name }}</span>
+            <span v-if="s.managed" class="badge badge-muted">managed</span>
+            <span v-if="s.description" class="option-desc">{{ s.description }}</span>
+          </li>
+        </ul>
+        <div v-if="hiddenCount > 0" class="note">
+          {{ hiddenCount }} more — keep typing to narrow the list.
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.secret-picker { position: relative; }
+.chosen {
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px 10px; border: 1px solid var(--border); border-radius: 6px;
+  background: var(--bg-subtle, transparent);
+}
+.chosen-name { font-family: monospace; font-size: 13px; flex: 1; overflow-wrap: anywhere; }
+.results {
+  position: absolute; z-index: 20; left: 0; right: 0; margin-top: 4px;
+  border: 1px solid var(--border); border-radius: 6px;
+  background: var(--bg-elevated, var(--bg, #fff));
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  max-height: 320px; overflow-y: auto;
+}
+.filters { display: flex; gap: 6px; padding: 8px; border-bottom: 1px solid var(--border); }
+.chip {
+  padding: 3px 10px; font-size: 12px; border-radius: 999px; cursor: pointer;
+  border: 1px solid var(--border); background: transparent; color: var(--text-muted);
+}
+.chip.active { border-color: var(--primary); color: var(--primary); }
+.options { list-style: none; margin: 0; padding: 4px; }
+.option {
+  display: flex; align-items: center; gap: 8px;
+  padding: 7px 8px; border-radius: 4px; cursor: pointer;
+}
+.option.active { background: var(--bg-hover, rgba(127, 127, 127, 0.12)); }
+.option-name { font-family: monospace; font-size: 13px; }
+.option-desc {
+  font-size: 12px; color: var(--text-muted); margin-left: auto;
+  max-width: 55%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.note { padding: 10px; font-size: 12px; color: var(--text-muted); }
+.spinner-sm { width: 12px; height: 12px; vertical-align: middle; }
+</style>

--- a/web/src/views/admin/Registry.vue
+++ b/web/src/views/admin/Registry.vue
@@ -1,66 +1,139 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
-import { registryApi, type RegistrySettingsPayload } from '@/api/registry'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import {
+  registryApi,
+  type RegistryLocks,
+  type RegistryRuntime,
+  type RegistrySettingsPayload,
+} from '@/api/registry'
+import { apiError as decodeApiError } from '@/api/client'
 import { useNotificationStore } from '@/stores/notification'
 import ConfirmDialog from '@/components/ConfirmDialog.vue'
 
 const notify = useNotificationStore()
 
+type Tab = 'overview' | 'configuration' | 'storage' | 'maintenance'
+const tab = ref<Tab>('overview')
+const tabs: Array<{ id: Tab; label: string; icon: string }> = [
+  { id: 'overview', label: 'Overview', icon: 'mdi-view-dashboard-outline' },
+  { id: 'configuration', label: 'Configuration', icon: 'mdi-cog-outline' },
+  { id: 'storage', label: 'Storage', icon: 'mdi-database-outline' },
+  { id: 'maintenance', label: 'Maintenance', icon: 'mdi-broom' },
+]
+
 const loading = ref(true)
 const saving = ref(false)
 const runningGc = ref(false)
+
 const effectiveHost = ref('')
 const s3Entitled = ref(false)
-
 const volumeName = ref('mb-registry-data')
-
-
-const enabled = ref(false)
 const hostSource = ref<'env' | 'stored' | 'base_domain' | 'unset'>('unset')
+const storageSource = ref<'env' | 'stored' | 'default'>('default')
+const storageError = ref('')
+const locks = ref<RegistryLocks>({
+  enabled: false, host: false, storage: false,
+  s3_endpoint: false, s3_bucket: false, s3_region: false,
+  s3_access_key: false, s3_secret_key: false, s3_force_path_style: false,
+})
+const s3SecretSet = ref(false)
 
-// Storage read-out (never edited here).
-const storage = ref({
-  storage_type: 'filesystem' as 'filesystem' | 's3',
+// The whole editable surface. Sent as one payload — the server ignores whatever
+// the environment pins, so a locked field round-trips harmlessly.
+const form = ref<Required<Omit<RegistrySettingsPayload, 'confirm'>>>({
+  delete_enabled: false,
+  per_workspace_quota_mb: 0,
+  enabled: false,
+  host: '',
+  storage_type: 'filesystem',
   s3_endpoint: '',
   s3_bucket: '',
   s3_region: '',
   s3_access_key: '',
+  s3_secret_key: '',
   s3_force_path_style: false,
-  s3_secret_set: false,
-  storage_source: 'default' as 'env' | 'stored' | 'default',
-  storage_error: '',
 })
 
-const usesS3 = computed(() => storage.value.storage_type === 's3')
+const usesS3 = computed(() => form.value.storage_type === 's3')
+const envManaged = computed(() => Object.values(locks.value).some(Boolean))
 
 const hostOrigin = computed(() => {
   switch (hostSource.value) {
-    case 'env':
-      return 'Set by MIABI_REGISTRY_HOST.'
-    case 'base_domain':
-      return 'Derived from the external base domain (registry.<domain>).'
-    case 'stored':
-      return 'A value saved before the host became environment-only. Set MIABI_REGISTRY_HOST to move it.'
-    default:
-      return 'No usable hostname — set MIABI_REGISTRY_HOST or an external base domain.'
+    case 'env': return 'Pinned by MIABI_REGISTRY_HOST.'
+    case 'base_domain': return 'Derived from the external base domain (registry.<domain>) — set a host here to override it.'
+    case 'stored': return 'Set here.'
+    default: return 'No usable hostname yet — set one here, or configure an external base domain.'
   }
 })
 
-const storageOrigin = computed(() => {
-  switch (storage.value.storage_source) {
-    case 'env':
-      return 'Set by MIABI_REGISTRY_STORAGE.'
-    case 'stored':
-      return 'A value saved before storage became environment-only. Set MIABI_REGISTRY_STORAGE to change it.'
-    default:
-      return 'The default — set MIABI_REGISTRY_STORAGE to change it.'
+// --- runtime -----------------------------------------------------------------
+
+const runtime = ref<RegistryRuntime | null>(null)
+const runtimeError = ref('')
+let poll: ReturnType<typeof setInterval> | undefined
+
+async function loadRuntime() {
+  try {
+    runtime.value = (await registryApi.runtime()).data.data
+    runtimeError.value = ''
+  } catch (e) {
+    runtimeError.value = decodeApiError(e).message
+    runtime.value = null
   }
+}
+
+// Polled only while the Overview tab is open: a stats sample costs the daemon two
+// seconds of streaming, and nothing else on the page reads it.
+function syncPolling() {
+  if (poll) { clearInterval(poll); poll = undefined }
+  if (tab.value === 'overview') {
+    void loadRuntime()
+    poll = setInterval(loadRuntime, 5000)
+  }
+}
+function selectTab(id: Tab) {
+  tab.value = id
+  syncPolling()
+}
+
+const statusLabel = computed(() => {
+  const rt = runtime.value
+  if (!rt) return 'Unknown'
+  if (rt.running) return rt.health === 'unhealthy' ? 'Running (unhealthy)' : 'Running'
+  if (!form.value.enabled) return 'Disabled'
+  if (storageError.value) return 'Blocked'
+  return rt.state ? `Not running (${rt.state})` : 'Not running'
+})
+const statusTone = computed(() => {
+  const rt = runtime.value
+  if (rt?.running) return rt.health === 'unhealthy' ? 'warn' : 'ok'
+  if (!form.value.enabled) return 'muted'
+  return 'bad'
 })
 
-const form = ref<RegistrySettingsPayload>({
-  delete_enabled: false,
-  per_workspace_quota_mb: 0,
+function fmtBytes(n?: number): string {
+  if (!n || n <= 0) return '—'
+  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB']
+  let v = n, i = 0
+  while (v >= 1024 && i < units.length - 1) { v /= 1024; i++ }
+  return `${v < 10 && i > 0 ? v.toFixed(1) : Math.round(v)} ${units[i]}`
+}
+function fmtPercent(n?: number): string {
+  return n === undefined || n === null ? '—' : `${n.toFixed(1)}%`
+}
+const uptime = computed(() => {
+  const started = runtime.value?.started_at
+  if (!started) return '—'
+  const ms = Date.now() - new Date(started).getTime()
+  if (!Number.isFinite(ms) || ms < 0) return '—'
+  const m = Math.floor(ms / 60000)
+  if (m < 60) return `${m}m`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h ${m % 60}m`
+  return `${Math.floor(h / 24)}d ${h % 24}h`
 })
+
+// --- load / save -------------------------------------------------------------
 
 async function load() {
   loading.value = true
@@ -69,22 +142,25 @@ async function load() {
     effectiveHost.value = s.effective_host
     s3Entitled.value = s.s3_entitled
     volumeName.value = s.volume_name || 'mb-registry-data'
-    enabled.value = s.enabled
     hostSource.value = s.host_source
-    storage.value = {
+    storageSource.value = s.storage_source ?? 'default'
+    storageError.value = s.storage_error ?? ''
+    locks.value = s.locks
+    s3SecretSet.value = s.s3_secret_set
+    form.value = {
+      delete_enabled: s.delete_enabled,
+      per_workspace_quota_mb: s.per_workspace_quota_mb,
+      enabled: s.enabled,
+      // Show the stored host, not the derived one: editing a field pre-filled
+      // with a value you never set would silently pin the derived name.
+      host: s.host ?? '',
       storage_type: s.storage_type,
       s3_endpoint: s.s3_endpoint ?? '',
       s3_bucket: s.s3_bucket ?? '',
       s3_region: s.s3_region ?? '',
       s3_access_key: s.s3_access_key ?? '',
+      s3_secret_key: '',
       s3_force_path_style: s.s3_force_path_style,
-      s3_secret_set: s.s3_secret_set,
-      storage_source: s.storage_source ?? 'default',
-      storage_error: s.storage_error ?? '',
-    }
-    form.value = {
-      delete_enabled: s.delete_enabled,
-      per_workspace_quota_mb: s.per_workspace_quota_mb,
     }
   } catch (e) {
     notify.apiError(e)
@@ -93,15 +169,31 @@ async function load() {
   }
 }
 
-async function save() {
+// The server answers 409 with the sentence to show when a change strands data;
+// confirming re-sends the identical payload with confirm set.
+const pendingConfirm = ref('')
+
+async function save(confirm = false) {
   saving.value = true
   try {
-    const s = (await registryApi.updateSettings(form.value)).data.data
+    const payload: RegistrySettingsPayload = { ...form.value, confirm }
+    const s = (await registryApi.updateSettings(payload)).data.data
     effectiveHost.value = s.effective_host
     hostSource.value = s.host_source
+    storageSource.value = s.storage_source ?? 'default'
+    storageError.value = s.storage_error ?? ''
+    s3SecretSet.value = s.s3_secret_set
+    form.value.s3_secret_key = ''
+    pendingConfirm.value = ''
     notify.success('Registry settings saved')
+    void loadRuntime()
   } catch (e) {
-    notify.apiError(e)
+    const err = decodeApiError(e)
+    if (err.status === 409 && !confirm) {
+      pendingConfirm.value = err.message
+    } else {
+      notify.apiError(e)
+    }
   } finally {
     saving.value = false
   }
@@ -121,153 +213,263 @@ async function runGc() {
   }
 }
 
-onMounted(load)
+onMounted(async () => {
+  await load()
+  syncPolling()
+})
+onBeforeUnmount(() => { if (poll) clearInterval(poll) })
 </script>
 
 <template>
   <div>
     <div class="page-header">
-      <h1>Container Registry</h1>
+      <div>
+        <h1>Container Registry</h1>
+        <p class="text-muted text-sm subtitle">
+          A first-party, multi-tenant Docker registry. Members push &amp; pull with
+          <code>docker login {{ effectiveHost || 'registry.&lt;domain&gt;' }}</code>.
+        </p>
+      </div>
     </div>
 
     <div v-if="loading" class="card"><div class="card-body"><span class="spinner"></span></div></div>
 
-    <div v-else class="card" style="max-width: 720px">
-      <div class="card-header">
-        <div>
-          <h2>Built-in registry</h2>
-          <p class="text-muted text-sm" style="margin: 4px 0 0">
-            A first-party, multi-tenant Docker registry. Members push & pull with
-            <code>docker login {{ effectiveHost || 'registry.&lt;domain&gt;' }}</code>.
+    <template v-else>
+      <div v-if="storageError" class="alert-banner" role="alert">
+        <i class="mdi mdi-alert-circle-outline"></i>
+        <p><strong>The registry is not running.</strong> {{ storageError }}</p>
+      </div>
+
+      <div class="tabs">
+        <button
+          v-for="t in tabs" :key="t.id" type="button" class="tab"
+          :class="{ active: tab === t.id }" @click="selectTab(t.id)"
+        >
+          <i class="mdi" :class="t.icon"></i> {{ t.label }}
+        </button>
+      </div>
+
+      <!-- ── Overview ─────────────────────────────────────────────────────── -->
+      <div v-if="tab === 'overview'" class="card">
+        <div class="card-body">
+          <div class="status-row">
+            <span class="status-dot" :class="statusTone"></span>
+            <strong>{{ statusLabel }}</strong>
+            <!-- Health is a second axis: a container can be up and failing its probe. -->
+            <span v-if="runtime?.health" class="badge badge-muted">{{ runtime.health }}</span>
+            <span v-if="runtime?.restart_count" class="badge badge-warning">
+              {{ runtime.restart_count }} restart{{ runtime.restart_count === 1 ? '' : 's' }}
+            </span>
+          </div>
+          <p v-if="runtimeError" class="form-hint">Live status unavailable: {{ runtimeError }}</p>
+
+          <!-- Usage is the point of this tab: the registry belongs to no workspace,
+               so this is the only place its cost is visible. -->
+          <div v-if="runtime?.running" class="stat-grid">
+            <div class="stat">
+              <span class="stat-label">CPU</span>
+              <span class="stat-value">{{ fmtPercent(runtime.stats?.cpu_percent) }}</span>
+            </div>
+            <div class="stat">
+              <span class="stat-label">Memory</span>
+              <span class="stat-value">{{ fmtBytes(runtime.stats?.memory_usage_bytes) }}</span>
+              <span class="stat-sub">
+                {{ fmtPercent(runtime.stats?.memory_percent) }}
+                <template v-if="runtime.stats?.memory_limit_bytes"> of {{ fmtBytes(runtime.stats.memory_limit_bytes) }}</template>
+              </span>
+            </div>
+            <div class="stat">
+              <span class="stat-label">Network</span>
+              <span class="stat-value">↓ {{ fmtBytes(runtime.stats?.network_rx_bytes) }}</span>
+              <span class="stat-sub">↑ {{ fmtBytes(runtime.stats?.network_tx_bytes) }}</span>
+            </div>
+            <div class="stat">
+              <span class="stat-label">Uptime</span>
+              <span class="stat-value">{{ uptime }}</span>
+            </div>
+          </div>
+          <p v-if="runtime?.running && runtime.stats_error" class="form-hint">
+            Resource usage unavailable: {{ runtime.stats_error }}
           </p>
+          <p v-else-if="runtime && !runtime.running && form.enabled && !storageError" class="form-hint">
+            The registry is enabled but its container is not running. Save the settings to start it, or check the
+            control-plane logs.
+          </p>
+
+          <dl class="facts">
+            <div><dt>Host</dt><dd class="mono">{{ effectiveHost || '—' }}</dd></div>
+            <div><dt>Storage</dt><dd>{{ usesS3 ? `S3 / MinIO${form.s3_bucket ? ` (${form.s3_bucket})` : ''}` : `Local volume (${volumeName})` }}</dd></div>
+            <div v-if="runtime?.image"><dt>Image</dt><dd class="mono">{{ runtime.image }}</dd></div>
+            <div><dt>Tag deletion</dt><dd>{{ form.delete_enabled ? 'Enabled' : 'Disabled' }}</dd></div>
+            <div><dt>Per-workspace quota</dt><dd>{{ form.per_workspace_quota_mb ? `${form.per_workspace_quota_mb} MB` : 'Unlimited' }}</dd></div>
+          </dl>
         </div>
       </div>
-      <div class="card-body">
-        <h3 class="section-title">
-          Platform configuration
-          <span class="lock-pill"><i class="mdi mdi-lock-outline"></i> environment-only</span>
-        </h3>
-        <p class="section-note">
-          Set with <code>MIABI_REGISTRY_*</code> and applied at boot. Shown here so you can see what the registry
-          is actually running with; a change takes an environment edit and a restart.
-        </p>
 
-        <label class="toggle-row is-locked">
-          <input :checked="enabled" type="checkbox" disabled />
-          <span>Enable the registry (runs the container and seeds its gateway route)</span>
-        </label>
-        <small class="form-hint">
-          Set by <code>MIABI_REGISTRY_ENABLED={{ enabled ? 'true' : 'false' }}</code>. Fixed by the platform —
-          change it and restart Miabi.
-        </small>
+      <!-- ── Configuration ────────────────────────────────────────────────── -->
+      <div v-else-if="tab === 'configuration'" class="card" style="max-width: 720px">
+        <div class="card-body">
+          <p v-if="envManaged" class="section-note">
+            <i class="mdi mdi-lock-outline"></i>
+            Some fields are pinned by <code>MIABI_REGISTRY_*</code> in this install's environment. They are shown
+            here but can only be changed where they are declared.
+          </p>
 
-        <div class="form-group" style="margin-top: 16px">
-          <label class="form-label">Host</label>
-          <input :value="effectiveHost" class="form-input mono" placeholder="—" style="max-width: 420px" disabled />
-          <small class="form-hint">
-            Public hostname for docker login. {{ hostOrigin }} Fixed by the platform: every image reference
-            Miabi stores is anchored to this hostname, and matching against it is how a workspace's own
-            images are told apart from another's — so it cannot move while apps are running.
-          </small>
-        </div>
-
-        <div v-if="storage.storage_error" class="alert-banner" role="alert">
-          <i class="mdi mdi-alert-circle-outline"></i>
-          <p><strong>The registry is not running.</strong> {{ storage.storage_error }}</p>
-        </div>
-
-        <div class="form-group">
-          <label class="form-label">Storage driver</label>
-          <input
-            :value="usesS3 ? 'S3 / MinIO' : 'Local volume (filesystem)'"
-            class="form-input"
-            style="max-width: 280px"
-            disabled
-          />
-          <small class="form-hint">
-            {{ storageOrigin }} Fixed by the platform: every pushed blob lives in this backend, and drivers
-            <strong>do not migrate</strong> — switching one under a running registry would orphan every image
-            already stored. Change it in the environment and restart Miabi.
-            <template v-if="!s3Entitled"> S3/MinIO storage requires an Enterprise license; local storage is free.</template>
-          </small>
-        </div>
-
-        <div v-if="!usesS3" class="form-group">
-          <label class="form-label">Data volume</label>
-          <input :value="volumeName" class="form-input mono" style="max-width: 320px" disabled />
-          <small class="form-hint">The managed volume images are stored in. Fixed by the platform.</small>
-        </div>
-
-        <fieldset v-else class="s3-fields">
-          <div class="form-grid">
-            <div class="form-group">
-              <label class="form-label">Bucket</label>
-              <input :value="storage.s3_bucket || '—'" class="form-input mono" disabled />
-            </div>
-            <div class="form-group">
-              <label class="form-label">Region</label>
-              <input :value="storage.s3_region || '—'" class="form-input mono" disabled />
-            </div>
-          </div>
-          <div class="form-group">
-            <label class="form-label">Endpoint <span class="text-muted">(S3-compatible / MinIO)</span></label>
-            <input :value="storage.s3_endpoint || '— (AWS S3)'" class="form-input mono" disabled />
-          </div>
-          <div class="form-grid">
-            <div class="form-group">
-              <label class="form-label">Access key</label>
-              <input :value="storage.s3_access_key || '—'" class="form-input mono" disabled />
-            </div>
-            <div class="form-group">
-              <label class="form-label">Secret key</label>
-              <input :value="storage.s3_secret_set ? '••••• (set)' : '— (not set)'" class="form-input mono" disabled />
-            </div>
-          </div>
-          <label class="toggle-row is-locked">
-            <input :checked="storage.s3_force_path_style" type="checkbox" disabled />
-            <span>Force path-style URLs (MinIO and some S3-compatible stores)</span>
+          <label class="toggle-row" :class="{ 'is-locked': locks.enabled }">
+            <input v-model="form.enabled" type="checkbox" :disabled="locks.enabled" />
+            <span>Enable the registry (runs the container and seeds its gateway route)</span>
           </label>
           <small class="form-hint">
-            Read-only: set by <code>MIABI_REGISTRY_S3_BUCKET</code>, <code>_REGION</code>, <code>_ENDPOINT</code>,
-            <code>_ACCESS_KEY</code>, <code>_SECRET_KEY</code>, <code>_FORCE_PATH_STYLE</code>. Restart Miabi to apply
-            a change.
+            <template v-if="locks.enabled">Pinned by <code>MIABI_REGISTRY_ENABLED</code>.</template>
+            <template v-else>Turning this off tears the container down; images in storage are kept.</template>
           </small>
-        </fieldset>
 
-        <h3 class="section-title" style="margin-top: 28px">Settings</h3>
+          <div class="form-group" style="margin-top: 16px">
+            <label class="form-label">Host</label>
+            <input
+              v-model="form.host" class="form-input mono" :disabled="locks.host"
+              :placeholder="effectiveHost || 'registry.example.com'" style="max-width: 420px"
+            />
+            <small class="form-hint">
+              The public hostname for <code>docker login</code>. {{ hostOrigin }}
+              Every image reference Miabi records is anchored to it, so changing it after images exist asks for
+              confirmation and needs affected apps redeployed.
+            </small>
+          </div>
 
-        <div class="form-group">
-          <label class="form-label">Per-workspace quota (MB)</label>
-          <input v-model.number="form.per_workspace_quota_mb" type="number" min="0" class="form-input" style="max-width: 200px" />
-          <small class="form-hint">0 = unlimited.</small>
-        </div>
+          <div class="form-group">
+            <label class="form-label">Per-workspace quota (MB)</label>
+            <input v-model.number="form.per_workspace_quota_mb" type="number" min="0" class="form-input" style="max-width: 200px" />
+            <small class="form-hint">0 = unlimited.</small>
+          </div>
 
-        <label class="toggle-row">
-          <input v-model="form.delete_enabled" type="checkbox" />
-          <span>Enable tag deletion &amp; garbage collection</span>
-        </label>
+          <label class="toggle-row">
+            <input v-model="form.delete_enabled" type="checkbox" />
+            <span>Enable tag deletion &amp; garbage collection</span>
+          </label>
 
-        <div class="actions">
-          <button class="btn btn-primary" :disabled="saving" @click="save">
-            {{ saving ? 'Saving…' : 'Save settings' }}
-          </button>
-          <!-- Nothing to collect while the registry is down for a storage reason. -->
-          <button
-            v-if="enabled && form.delete_enabled && !storage.storage_error"
-            class="btn btn-secondary"
-            :disabled="runningGc"
-            @click="showGcConfirm = true"
-          >
-            {{ runningGc ? 'Collecting…' : 'Run garbage collection' }}
-          </button>
+          <div class="actions">
+            <button class="btn btn-primary" :disabled="saving" @click="save()">
+              {{ saving ? 'Saving…' : 'Save settings' }}
+            </button>
+          </div>
         </div>
       </div>
-    </div>
+
+      <!-- ── Storage ──────────────────────────────────────────────────────── -->
+      <div v-else-if="tab === 'storage'" class="card" style="max-width: 720px">
+        <div class="card-body">
+          <p class="section-note">
+            Blobs <strong>do not migrate</strong> between backends. Switching a registry that already holds images
+            leaves them in the old one — the change asks for confirmation and tells you how much is affected.
+          </p>
+
+          <div class="form-group">
+            <label class="form-label">Storage driver</label>
+            <select v-model="form.storage_type" class="form-select" style="max-width: 280px" :disabled="locks.storage">
+              <option value="filesystem">Local volume (filesystem)</option>
+              <option value="s3" :disabled="!s3Entitled">S3 / MinIO{{ s3Entitled ? '' : ' — Enterprise' }}</option>
+            </select>
+            <small class="form-hint">
+              <template v-if="locks.storage">Pinned by <code>MIABI_REGISTRY_STORAGE</code>.</template>
+              <template v-else-if="!s3Entitled">S3/MinIO storage requires an Enterprise license; local storage is free.</template>
+              <template v-else>Where every pushed blob lives.</template>
+            </small>
+          </div>
+
+          <div v-if="!usesS3" class="form-group">
+            <label class="form-label">Data volume</label>
+            <input :value="volumeName" class="form-input mono" style="max-width: 320px" disabled />
+            <small class="form-hint">A fixed platform name, so the data location stays predictable.</small>
+          </div>
+
+          <fieldset v-else class="s3-fields">
+            <div class="form-grid">
+              <div class="form-group">
+                <label class="form-label">Bucket</label>
+                <input v-model="form.s3_bucket" class="form-input mono" :disabled="locks.s3_bucket" placeholder="miabi-registry" />
+              </div>
+              <div class="form-group">
+                <label class="form-label">Region</label>
+                <input v-model="form.s3_region" class="form-input mono" :disabled="locks.s3_region" placeholder="us-east-1" />
+              </div>
+            </div>
+            <div class="form-group">
+              <label class="form-label">Endpoint <span class="text-muted">(S3-compatible / MinIO)</span></label>
+              <input v-model="form.s3_endpoint" class="form-input mono" :disabled="locks.s3_endpoint" placeholder="Leave blank for AWS S3" />
+            </div>
+            <div class="form-grid">
+              <div class="form-group">
+                <label class="form-label">Access key</label>
+                <input v-model="form.s3_access_key" class="form-input mono" :disabled="locks.s3_access_key" autocomplete="off" />
+              </div>
+              <div class="form-group">
+                <label class="form-label">Secret key</label>
+                <input
+                  v-model="form.s3_secret_key" type="password" class="form-input mono"
+                  :disabled="locks.s3_secret_key" autocomplete="new-password"
+                  :placeholder="s3SecretSet ? '••••• (set — leave blank to keep)' : 'Not set'"
+                />
+              </div>
+            </div>
+            <label class="toggle-row" :class="{ 'is-locked': locks.s3_force_path_style }">
+              <input v-model="form.s3_force_path_style" type="checkbox" :disabled="locks.s3_force_path_style" />
+              <span>Force path-style URLs (MinIO and some S3-compatible stores)</span>
+            </label>
+            <small class="form-hint">
+              Pinned fields come from <code>MIABI_REGISTRY_S3_*</code>.
+            </small>
+          </fieldset>
+
+          <div class="actions">
+            <button class="btn btn-primary" :disabled="saving" @click="save()">
+              {{ saving ? 'Saving…' : 'Save storage' }}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── Maintenance ──────────────────────────────────────────────────── -->
+      <div v-else class="card" style="max-width: 720px">
+        <div class="card-body">
+          <h3 class="section-title">Garbage collection</h3>
+          <p class="section-note">
+            Reclaims the space held by deleted and overwritten manifests. The registry switches to read-only while
+            it runs — pulls keep working, pushes pause.
+          </p>
+          <p v-if="!form.delete_enabled" class="form-hint">
+            Enable tag deletion under <a href="#" @click.prevent="selectTab('configuration')">Configuration</a> first —
+            there is nothing to collect until deletes are allowed.
+          </p>
+          <p v-else-if="!form.enabled" class="form-hint">The registry is disabled.</p>
+          <div class="actions">
+            <button
+              class="btn btn-secondary"
+              :disabled="runningGc || !form.enabled || !form.delete_enabled || !!storageError"
+              @click="showGcConfirm = true"
+            >
+              {{ runningGc ? 'Collecting…' : 'Run garbage collection' }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </template>
+
+    <ConfirmDialog
+      :open="!!pendingConfirm"
+      title="Confirm this change"
+      :message="pendingConfirm"
+      confirm-label="Change it anyway"
+      variant="danger"
+      :busy="saving"
+      @confirm="save(true)"
+      @cancel="pendingConfirm = ''"
+    />
 
     <ConfirmDialog
       :open="showGcConfirm"
       title="Run garbage collection"
-      :message="`Run garbage collection? The registry switches to read-only (pulls keep working, pushes pause) while it reclaims space.`"
+      message="Run garbage collection? The registry switches to read-only (pulls keep working, pushes pause) while it reclaims space."
       confirm-label="Run garbage collection"
       variant="primary"
       :busy="runningGc"
@@ -278,17 +480,19 @@ onMounted(load)
 </template>
 
 <style scoped>
+.subtitle { margin: 4px 0 0; }
+.tabs { margin-bottom: 16px; }
 .actions { display: flex; gap: 10px; margin-top: 20px; flex-wrap: wrap; }
 .toggle-row { display: flex; align-items: center; gap: 8px; cursor: pointer; color: var(--text-primary); }
 .toggle-row input { width: auto; margin: 0; }
+/* A locked toggle is not clickable, so it must not present as one. */
+.toggle-row.is-locked { cursor: default; color: var(--text-muted); }
 .s3-fields { border: 0; padding: 0; margin: 0 0 8px; min-width: 0; }
 .form-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px 16px; }
 .form-hint { display: block; font-size: 12px; color: var(--text-muted); margin-top: 4px; }
-/* A locked toggle is not clickable, so it must not present as one. */
-.toggle-row.is-locked { cursor: default; color: var(--text-muted); }
 .alert-banner {
   display: flex; align-items: flex-start; gap: 10px; flex-wrap: wrap;
-  padding: 12px 16px; margin-bottom: 20px;
+  padding: 12px 16px; margin-bottom: 16px;
   border: 1px solid var(--danger-500); border-radius: var(--radius-lg);
   background: var(--danger-50); font-size: 13px; color: var(--text-secondary);
 }
@@ -298,16 +502,30 @@ onMounted(load)
 .text-muted { color: var(--text-muted); }
 .text-sm { font-size: 13px; }
 .mono { font-family: monospace; }
-.section-title {
-  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
-  margin: 0 0 4px; font-size: 14px; font-weight: 600; color: var(--text-primary);
-}
+.section-title { margin: 0 0 4px; font-size: 14px; font-weight: 600; color: var(--text-primary); }
 .section-note { margin: 0 0 16px; font-size: 12px; color: var(--text-muted); }
-.lock-pill {
-  display: inline-flex; align-items: center; gap: 4px;
-  padding: 2px 8px; border-radius: 999px;
-  border: 1px solid var(--border-primary); background: var(--bg-tertiary);
-  font-size: 11px; font-weight: 500; color: var(--text-muted);
+
+.status-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 16px; }
+.status-dot { width: 9px; height: 9px; border-radius: 50%; flex-shrink: 0; background: var(--text-muted); }
+.status-dot.ok { background: var(--success-500, #22c55e); }
+.status-dot.warn { background: var(--warning-500, #f59e0b); }
+.status-dot.bad { background: var(--danger-500, #ef4444); }
+.status-dot.muted { background: var(--text-muted); }
+
+.stat-grid {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px; margin-bottom: 20px;
 }
-.lock-pill .mdi { font-size: 13px; }
+.stat {
+  display: flex; flex-direction: column; gap: 2px;
+  padding: 12px 14px; border: 1px solid var(--border-primary); border-radius: var(--radius-lg);
+}
+.stat-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-muted); }
+.stat-value { font-size: 18px; font-weight: 600; color: var(--text-primary); }
+.stat-sub { font-size: 12px; color: var(--text-muted); }
+
+.facts { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 8px 24px; margin: 0; }
+.facts > div { display: flex; justify-content: space-between; gap: 12px; padding: 6px 0; border-bottom: 1px solid var(--border-primary); }
+.facts dt { font-size: 13px; color: var(--text-muted); }
+.facts dd { margin: 0; font-size: 13px; color: var(--text-primary); text-align: right; overflow-wrap: anywhere; }
 </style>

--- a/web/src/views/secrets/Secrets.vue
+++ b/web/src/views/secrets/Secrets.vue
@@ -3,7 +3,7 @@ import { ref, computed, watch, onBeforeUnmount } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { useNotificationStore } from '@/stores/notification'
-import { secretApi, type SecretInput } from '@/api/secrets'
+import { secretApi, type SecretInput, type SecretOwnership } from '@/api/secrets'
 import type { Secret } from '@/api/types'
 import { usePagination } from '@/composables/usePagination'
 import { copyText } from '@/utils/clipboard'
@@ -17,13 +17,22 @@ const { currentWorkspaceId } = storeToRefs(ws)
 const secrets = ref<Secret[]>([])
 const loading = ref(false)
 const search = ref('')
+// Ownership is filtered by the API, not in this page: the list is paged, so
+// hiding rows here would leave the count and the page size disagreeing with
+// what's on screen.
+const ownership = ref<SecretOwnership>('all')
+const ownershipFilters: Array<{ value: SecretOwnership; label: string }> = [
+  { value: 'all', label: 'All' },
+  { value: 'unmanaged', label: 'Not managed' },
+  { value: 'managed', label: 'Managed' },
+]
 
 const { pageable, goToPage } = usePagination(async (page) => {
   const id = currentWorkspaceId.value
   if (!id) { secrets.value = []; return }
   loading.value = true
   try {
-    const res = await secretApi.list(id, search.value.trim(), page, pageable.value.size)
+    const res = await secretApi.list(id, search.value.trim(), page, pageable.value.size, ownership.value)
     secrets.value = res.data.data
     pageable.value = res.data.pageable
   } catch (e) { notify.apiError(e) }
@@ -34,6 +43,20 @@ const { pageable, goToPage } = usePagination(async (page) => {
 function reload() { goToPage(pageable.value.current_page) }
 // Switching workspaces resets to the first page.
 watch(currentWorkspaceId, () => goToPage(0))
+// Narrowing can leave the current page past the end of the result, so every
+// filter change re-queries from the first page.
+function setOwnership(v: SecretOwnership) {
+  ownership.value = v
+  goToPage(0)
+}
+
+// Whether the view is showing a subset — drives the empty state, which must not
+// read as "the vault is empty" when it is really "nothing matches".
+const narrowed = computed(() => !!search.value.trim() || ownership.value !== 'all')
+function clearFilters() {
+  search.value = ''
+  setOwnership('all')
+}
 
 let searchTimer: ReturnType<typeof setTimeout> | undefined
 function onSearchInput() {
@@ -162,6 +185,11 @@ const refForName = computed(() => `\${{ secrets.${form.value.name || 'name'} }}`
           <input v-model="search" class="form-input" type="search" placeholder="Search secrets by name or description…"
             aria-label="Search secrets" style="max-width: 320px" @input="onSearchInput" />
         </div>
+        <div class="filters" role="group" aria-label="Filter by ownership">
+          <button v-for="f in ownershipFilters" :key="f.value" type="button" class="chip"
+            :class="{ active: ownership === f.value }" :aria-pressed="ownership === f.value"
+            @click="setOwnership(f.value)">{{ f.label }}</button>
+        </div>
         <span class="text-muted">{{ pageable.total_elements }} secret{{ pageable.total_elements === 1 ? '' : 's'
           }}</span>
       </div>
@@ -169,11 +197,14 @@ const refForName = computed(() => `\${{ secrets.${form.value.name || 'name'} }}`
       <div v-if="loading && secrets.length === 0" class="card-body"><span class="spinner"></span></div>
       <div v-else-if="secrets.length === 0" class="empty-state">
         <span class="mdi mdi-key-variant" style="font-size: 44px; color: var(--text-muted)"></span>
-        <h3>No secrets {{ search.trim() ? 'found' : '' }}</h3>
-        <p v-if="search.trim()">No secrets match your search.</p>
+        <h3>No secrets {{ narrowed ? 'found' : '' }}</h3>
+        <!-- An empty result under a filter is not an empty vault: offering
+             "New secret" here would answer a question the user didn't ask. -->
+        <p v-if="narrowed">No secrets match the current search and filter.</p>
         <p v-else>Store a secret once and reference it from many apps. Rotating it updates every consumer on next
           deploy.</p>
-        <button v-if="ws.canEdit && !search.trim()" class="btn btn-primary mt-4" @click="openCreate">New secret</button>
+        <button v-if="narrowed" class="btn btn-secondary mt-4" @click="clearFilters">Clear filters</button>
+        <button v-else-if="ws.canEdit" class="btn btn-primary mt-4" @click="openCreate">New secret</button>
       </div>
       <template v-else>
         <div class="table-wrapper">
@@ -390,6 +421,27 @@ const refForName = computed(() => `\${{ secrets.${form.value.name || 'name'} }}`
 
 .search .form-input {
   padding-left: 32px;
+}
+
+.filters {
+  display: flex;
+  gap: 6px;
+}
+
+.chip {
+  padding: 4px 12px;
+  font-size: 12px;
+  border-radius: 999px;
+  cursor: pointer;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.chip.active {
+  border-color: var(--primary);
+  color: var(--primary);
 }
 
 code {

--- a/web/src/views/sources/GitRepositories.vue
+++ b/web/src/views/sources/GitRepositories.vue
@@ -6,6 +6,7 @@ import { useNotificationStore } from '@/stores/notification'
 import { gitRepositoryApi, type GitRepositoryInput } from '@/api/gitRepositories'
 import type { GitRepository, GitAuthType } from '@/api/types'
 import ConfirmDialog from '@/components/ConfirmDialog.vue'
+import CredentialSecretField from '@/components/CredentialSecretField.vue'
 
 const ws = useWorkspaceStore()
 const notify = useNotificationStore()
@@ -131,7 +132,12 @@ const authTypes: { value: GitAuthType; label: string }[] = [
                   <span class="avatar avatar-sm"><span class="mdi mdi-git" style="font-size: 14px"></span></span>
                   <span class="cell-text">
                     <span class="cell-title">{{ r.display_name || r.name }}</span>
-                    <span class="cell-sub">{{ r.has_secret ? 'secret set' : 'no secret' }}</span>
+                    <span class="cell-sub">
+                      <template v-if="r.secret_ref">
+                        <span class="mdi mdi-key-variant"></span> {{ r.secret_ref }}
+                      </template>
+                      <template v-else>{{ r.has_secret ? 'secret set' : 'no secret' }}</template>
+                    </span>
                   </span>
                 </div>
               </td>
@@ -178,14 +184,14 @@ const authTypes: { value: GitAuthType; label: string }[] = [
                   <label class="form-label">Username <span class="text-muted">(optional)</span></label>
                   <input v-model="form.username" class="form-input" :placeholder="form.auth_type === 'ssh' ? 'git' : 'x-access-token'" autocomplete="off" aria-label="Username" />
                 </div>
-                <div class="form-group" style="margin-bottom: 0">
-                  <label class="form-label">
-                    {{ form.auth_type === 'ssh' ? 'SSH private key' : 'Access token' }}
-                    <span v-if="editing" class="text-muted">(leave blank to keep current)</span>
-                  </label>
-                  <textarea v-if="form.auth_type === 'ssh'" v-model="form.secret" class="form-textarea" placeholder="-----BEGIN OPENSSH PRIVATE KEY-----" :required="!editing" aria-label="SSH private key"></textarea>
-                  <input v-else v-model="form.secret" type="password" class="form-input" placeholder="ghp_…" autocomplete="new-password" :required="!editing" aria-label="Access token" />
-                </div>
+                <CredentialSecretField
+                  v-model="form.secret"
+                  :label="form.auth_type === 'ssh' ? 'SSH private key' : 'Access token'"
+                  :editing="!!editing"
+                  :current-ref="editing?.secret_ref || ''"
+                  :multiline="form.auth_type === 'ssh'"
+                  :placeholder="form.auth_type === 'ssh' ? '-----BEGIN OPENSSH PRIVATE KEY-----' : 'ghp_…'"
+                />
               </template>
               <p v-else class="text-muted" style="font-size: 12px; margin: 0">No credentials needed — the repository is cloned anonymously.</p>
             </div>

--- a/web/src/views/sources/Registries.vue
+++ b/web/src/views/sources/Registries.vue
@@ -6,6 +6,7 @@ import { useNotificationStore } from '@/stores/notification'
 import { registryApi, type RegistryInput } from '@/api/registries'
 import type { Registry } from '@/api/types'
 import ConfirmDialog from '@/components/ConfirmDialog.vue'
+import CredentialSecretField from '@/components/CredentialSecretField.vue'
 
 const ws = useWorkspaceStore()
 const notify = useNotificationStore()
@@ -125,7 +126,12 @@ async function confirmDelete() {
                   <span class="avatar avatar-sm"><span class="mdi mdi-database-outline" style="font-size: 14px"></span></span>
                   <span class="cell-text">
                     <span class="cell-title">{{ r.display_name || r.name }}</span>
-                    <span class="cell-sub">{{ r.has_secret ? 'secret set' : 'no secret' }}</span>
+                    <span class="cell-sub">
+                      <template v-if="r.secret_ref">
+                        <span class="mdi mdi-key-variant"></span> {{ r.secret_ref }}
+                      </template>
+                      <template v-else>{{ r.has_secret ? 'secret set' : 'no secret' }}</template>
+                    </span>
                   </span>
                 </div>
               </td>
@@ -165,10 +171,12 @@ async function confirmDelete() {
                 <label class="form-label">Username</label>
                 <input v-model="form.username" class="form-input" placeholder="username" autocomplete="off" aria-label="Username" />
               </div>
-              <div class="form-group" style="margin-bottom: 0">
-                <label class="form-label">Password / token <span v-if="editing" class="text-muted">(leave blank to keep current)</span></label>
-                <input v-model="form.secret" type="password" class="form-input" placeholder="••••••••" autocomplete="new-password" :required="!editing" aria-label="Password / token" />
-              </div>
+              <CredentialSecretField
+                v-model="form.secret"
+                label="Password / token"
+                :editing="!!editing"
+                :current-ref="editing?.secret_ref || ''"
+              />
             </div>
             <div class="modal-footer">
               <button type="button" class="btn btn-secondary" @click="showModal = false">Cancel</button>


### PR DESCRIPTION
* fix: Workspace bundle export wrote blank credentials
* feat(secrets): filter by ownership and pick secrets from a searchable list
* feat(credentials): declare registries in manifests and back them with vault secrets


