### PR TITLE
feat(gateway): publish analytics from the manager's edge gateway, and…

### DIFF
--- a/cmd/miabi/server.go
+++ b/cmd/miabi/server.go
@@ -172,6 +172,18 @@ func runServer(cli *okapicli.CLI) {
 			// The manager's own gateway reuses the platform Redis for shared cache +
 			// distributed rate limiting (remote edge nodes get a per-node Redis).
 			nodeGateway.SetRedis(cfg.Redis.Addr, cfg.Redis.Password)
+			// Publish request events for Workspace Analytics — only meaningful while
+			// this process runs the consumer that reads them.
+			if cfg.AnalyticsEnabled {
+				nodeGateway.SetAnalytics(cfg.AnalyticsStream)
+			}
+			// The manager's gateway can only watch route files if it can be handed the
+			// volume Miabi writes them to. A stack install mounts one there and this
+			// finds it; a manual install, whose mounts Miabi did not create, yields
+			// nothing and the gateway polls the HTTP provider instead.
+			nodeGateway.SetProvidersVolume(
+				edgegateway.DetectProvidersVolume(context.Background(), dockerClient, cfg.GomaProviderDir),
+			)
 			// When set, gateways encrypt sensitive config (middleware rules + TLS) at rest.
 			nodeGateway.SetConfigEncryptionKey(cfg.GomaConfigEncryptionKey)
 			nodeManager.SetOnConnect(func(ctx context.Context, srv *models.Server, token string, dc docker.Client) {

--- a/internal/services/edgegateway/analytics_test.go
+++ b/internal/services/edgegateway/analytics_test.go
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package edgegateway
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/miabi-io/miabi/internal/models"
+)
+
+func analyticsService(t *testing.T, stream, platformRedis string) *Service {
+	t.Helper()
+	s := NewService(nil, "https://miabi.example.com", "goma:latest", "miabi", "ops@example.com")
+	s.SetRedis(platformRedis, "pw")
+	s.SetAnalytics(stream)
+	return s
+}
+
+// The manager's gateway publishes to the platform Redis — the one the analytics
+// consumer reads — so its rendered config turns analytics on.
+func TestManagerGatewayRendersAnalytics(t *testing.T) {
+	s := analyticsService(t, "goma:analytics", "miabi-redis:6379")
+	got := s.RenderConfig(&models.Server{Name: "manager", IsLocal: true})
+
+	for _, want := range []string{
+		"analytics:",
+		"stream: goma:analytics",
+		"sample: 1",
+		"maxLen: 1000000",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered config missing %q\n---\n%s", want, got)
+		}
+	}
+}
+
+// A remote edge node runs its own per-node Redis for cache and rate limiting.
+// Events written there are read by nobody, so enabling analytics would fill that
+// node's Redis to maxLen and never reach a dashboard.
+func TestRemoteEdgeNodeOmitsAnalytics(t *testing.T) {
+	s := analyticsService(t, "goma:analytics", "miabi-redis:6379")
+	got := s.RenderConfig(&models.Server{Name: "edge-1"})
+
+	if strings.Contains(got, "analytics:") {
+		t.Errorf("a remote edge node must not publish analytics nobody consumes\n---\n%s", got)
+	}
+	// It still gets its per-node Redis for the features that do work there.
+	if !strings.Contains(got, RedisContainer+":6379") {
+		t.Errorf("remote node lost its per-node Redis\n---\n%s", got)
+	}
+}
+
+// With the platform consumer switched off (MIABI_ANALYTICS_ENABLED=false) no
+// stream is wired, so nothing is published anywhere.
+func TestNoAnalyticsWithoutAConsumer(t *testing.T) {
+	s := analyticsService(t, "", "miabi-redis:6379")
+	if got := s.RenderConfig(&models.Server{Name: "manager", IsLocal: true}); strings.Contains(got, "analytics:") {
+		t.Errorf("analytics must stay off when no consumer reads the stream\n---\n%s", got)
+	}
+}
+
+// No platform Redis means nowhere to publish to at all.
+func TestNoAnalyticsWithoutPlatformRedis(t *testing.T) {
+	s := analyticsService(t, "goma:analytics", "")
+	if got := s.RenderConfig(&models.Server{Name: "manager", IsLocal: true}); strings.Contains(got, "analytics:") {
+		t.Errorf("analytics needs a Redis to publish to\n---\n%s", got)
+	}
+}

--- a/internal/services/edgegateway/edgegateway.go
+++ b/internal/services/edgegateway/edgegateway.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jkaninda/logger"
 	"github.com/miabi-io/miabi/internal/docker"
 	"github.com/miabi-io/miabi/internal/models"
+	"github.com/miabi-io/miabi/internal/selfcontainer"
 	"github.com/miabi-io/miabi/internal/services/platformimage"
 	"github.com/miabi-io/miabi/internal/storage/repositories"
 	"gopkg.in/yaml.v3"
@@ -56,9 +57,7 @@ const (
 	configPath        = "/etc/goma"
 	// DefaultConfigFile is Goma Gateway's default config path inside the container.
 	DefaultConfigFile = configPath + "/goma.yml"
-	// ProvidersVolume is the file-provider directory volume shared with Miabi
-	// (the control plane writes route files there). Mounted into the manager's
-	// gateway so it reads routes directly instead of polling the HTTP provider.
+	// ProvidersVolume is a legacy per-node providers volume.
 	ProvidersVolume = "mb-node-gateway-providers"
 	providersPath   = configPath + "/providers"
 	// gatewayRedisPasswordEnv is the env var the gateway's Redis password is
@@ -113,6 +112,14 @@ type Service struct {
 	redisAddr     string // the platform Redis address (reused by the manager's gateway)
 	redisPassword string // the platform Redis password
 	configEncKey  string // GOMA_CONFIG_ENCRYPTION_KEY injected into every gateway ("" = off)
+	// analyticsStream is the Redis stream request events are published to; empty
+	// disables analytics in the rendered config (see analyticsEnabledFor).
+	analyticsStream string
+	// providersVolume is the Docker volume backing Miabi's own route-file
+	// directory. Empty means Miabi cannot hand a gateway that directory, so the
+	// manager's gateway polls the HTTP provider like a remote node does. See
+	// SetProvidersVolume.
+	providersVolume string
 }
 
 func NewService(workspaces *repositories.WorkspaceRepository, controlURL, image, network, acmeEmail string) *Service {
@@ -142,6 +149,37 @@ func (s *Service) SetRedis(addr, password string) {
 	s.redisPassword = password
 }
 
+// Default analytics sampling and stream cap, matching the platform stack's
+// goma.yml so a gateway installed from the admin dashboard behaves the same as
+// one from the shipped stack.
+const (
+	defaultAnalyticsSample = 1.0
+	defaultAnalyticsMaxLen = 1_000_000
+)
+
+// SetAnalytics wires the Redis stream the gateway publishes request events to.
+// Pass "" when the platform's analytics consumer is not running
+// (MIABI_ANALYTICS_ENABLED=false): a gateway writing to a stream nobody reads
+// would fill Redis to maxLen and be discarded.
+func (s *Service) SetAnalytics(stream string) { s.analyticsStream = strings.TrimSpace(stream) }
+
+// analyticsEnabledFor reports whether the rendered config should turn analytics
+// on for this node's gateway.
+//
+// It requires the gateway to publish to the *platform* Redis, which is the one
+// Miabi's analytics consumer reads. A remote edge node runs its own per-node
+// Redis for cache and rate limiting; events written there are consumed by
+// nobody, so enabling analytics on one would silently fill that node's Redis and
+// never reach a dashboard. Until events are relayed from edge nodes, analytics
+// belongs to the manager's gateway only.
+//
+// Note this asks where the gateway runs, not which route provider it uses: a
+// manager gateway on the HTTP provider still writes to the platform Redis, so it
+// still gets analytics.
+func (s *Service) analyticsEnabledFor(srv *models.Server) bool {
+	return s.analyticsStream != "" && isManager(srv) && s.redisAddrFor(srv) != ""
+}
+
 // redisImg resolves the per-node gateway Redis image.
 func (s *Service) redisImg() string {
 	if s.images != nil {
@@ -158,11 +196,14 @@ func (s *Service) redisImg() string {
 func (s *Service) RedisEnabled(srv *models.Server) bool { return s.redisAddrFor(srv) != "" }
 
 // redisAddrFor returns the Redis address a node's gateway should use: the shared
-// platform Redis for the manager (file provider), or the per-node Redis for a
-// remote edge node. Empty when Redis is unavailable (manager with no platform
-// Redis configured).
+// platform Redis for the manager, or the per-node Redis for a remote edge node,
+// which is self-contained. Empty when Redis is unavailable (manager with no
+// platform Redis configured).
+//
+// Keyed on where the gateway runs, not on its route provider — a manager gateway
+// switched to the HTTP provider still shares the control plane's Redis.
 func (s *Service) redisAddrFor(srv *models.Server) string {
-	if usesFileProvider(srv) {
+	if isManager(srv) {
 		return s.redisAddr
 	}
 	return RedisContainer + ":6379"
@@ -242,9 +283,30 @@ type gateway struct {
 	TLS         *tlsBlock             `yaml:"tls,omitempty"`
 	Redis       *redisBlock           `yaml:"redis,omitempty"`
 	Networking  *networking           `yaml:"networking,omitempty"`
+	Analytics   *analyticsBlock       `yaml:"analytics,omitempty"`
 	EntryPoints map[string]entryPoint `yaml:"entryPoints,omitempty"`
 	Reload      *reloadBlock          `yaml:"reload,omitempty"`
 	Providers   providers             `yaml:"providers"`
+}
+
+// analyticsBlock makes the gateway publish one event per request to a Redis
+// stream, which Miabi's analytics consumer rolls up into the Traffic /
+// Performance / Web dashboards. Events carry no client IP — only a daily-salted
+// visitor hash and, where a GeoIP database is present, a country resolved at the
+// edge.
+//
+// It mirrors the platform stack's goma.yml so both install paths behave the
+// same. GOMA_ANALYTICS_* on the gateway container overrides whatever is here.
+type analyticsBlock struct {
+	Enabled bool   `yaml:"enabled"`
+	Stream  string `yaml:"stream"`
+	// Sample is the fraction of requests recorded (0..1). The dashboards scale
+	// sampled counts back up, so lowering it on a very high-traffic edge trades
+	// precision for load rather than losing whole panels.
+	Sample float64 `yaml:"sample"`
+	// MaxLen approximately caps the stream, so a stopped consumer cannot grow
+	// Redis without bound.
+	MaxLen int `yaml:"maxLen"`
 }
 
 // logBlock sets the edge gateway's log verbosity (Goma's gateway.log.level),
@@ -337,12 +399,102 @@ const defaultCertProvider = "acme"
 // config (Goma's gateway.log.level).
 const defaultLogLevel = "info"
 
-// usesFileProvider reports whether srv's gateway reads routes from the shared
-// providers volume (the manager) rather than polling the HTTP provider (remote
-// edge nodes). The manager runs alongside Miabi on the same host, so it can
-// share the volume Miabi writes route files to.
-func usesFileProvider(srv *models.Server) bool {
+// isManager reports whether srv is the node the control plane itself runs on.
+//
+// This is what decides *infrastructure*: the manager's gateway shares the
+// platform's Redis and the providers volume, while every remote edge node is
+// self-contained — its own Goma and its own Redis, reachable only over the
+// tunnel. Deliberately distinct from usesFileProvider: which Redis a gateway
+// uses is a property of where it runs, not of how it learns its routes.
+func isManager(srv *models.Server) bool {
 	return srv != nil && srv.IsLocal
+}
+
+// usesFileProvider reports which route source the *rendered default* config uses
+// for srv.
+//
+// The file provider needs one thing the HTTP provider does not: the gateway must
+// be given the very directory Miabi writes route files to. That is only possible
+// on the manager, and only when Miabi knows which Docker volume backs that
+// directory — true for a stack install, which owns its volumes, and not true for
+// a manual install, where the operator wired the mounts and Miabi cannot mount
+// what it cannot name. Everything else polls the HTTP provider, which needs
+// nothing shared.
+//
+// It is only the default. A gateway's config may be edited afterwards — see
+// effectiveFileProvider, which is what the runtime plumbing keys off.
+func (s *Service) usesFileProvider(srv *models.Server) bool {
+	return isManager(srv) && s.providersVolume != ""
+}
+
+// SetProvidersVolume names the Docker volume backing Miabi's own route-file
+// directory, so the manager's gateway can be given the same one. Leave it empty
+// (a manual install whose mounts Miabi did not create) and the manager's gateway
+// polls the HTTP provider instead — a route source that needs nothing shared.
+func (s *Service) SetProvidersVolume(name string) { s.providersVolume = strings.TrimSpace(name) }
+
+// DetectProvidersVolume returns the name of the Docker volume mounted at
+// providerDir inside Miabi's own container, or "" when there is none.
+//
+// This is what tells a stack install from a manual one without asking: a stack
+// install mounts a named volume there (Miabi created it), while a manual install
+// may use a bind mount, a differently-named volume, or nothing at all. Only a
+// named volume can be mounted into a second container, so only that answer lets
+// the manager's gateway watch the directory.
+func DetectProvidersVolume(ctx context.Context, dc docker.Client, providerDir string) string {
+	if dc == nil || strings.TrimSpace(providerDir) == "" {
+		return ""
+	}
+	self := selfcontainer.Detect()
+	if self == "" {
+		return "" // not running in a container: nothing to share
+	}
+	cfg, err := dc.InspectContainerConfig(ctx, self)
+	if err != nil {
+		logger.Warn("edgegateway: could not inspect own container for the providers volume", "error", err)
+		return ""
+	}
+	want := strings.TrimRight(providerDir, "/")
+	for _, m := range cfg.Mounts {
+		if strings.TrimRight(m.Destination, "/") != want {
+			continue
+		}
+		if m.Type != "volume" || m.Name == "" {
+			// A bind mount is a host path, not something Miabi can hand another
+			// container by name — the gateway polls instead.
+			logger.Info("edgegateway: route directory is not a named volume; the manager's gateway will poll the HTTP provider",
+				"destination", m.Destination, "type", m.Type)
+			return ""
+		}
+		return m.Name
+	}
+	return ""
+}
+
+// effectiveFileProvider reports whether srv's gateway *actually* reads routes
+// from the providers volume, honouring a customised config rather than assuming
+// the default. A manager gateway switched to the HTTP provider needs the same
+// plumbing a remote node gets — a reload token, and an on-demand reload when
+// routes change — or it would only pick up changes on its next poll.
+//
+// An unparseable config falls back to the default for the node; the config is
+// validated on save, so this only covers one hand-edited outside the API.
+func (s *Service) effectiveFileProvider(srv *models.Server) bool {
+	if srv == nil || strings.TrimSpace(srv.GatewayConfigYAML) == "" {
+		return s.usesFileProvider(srv)
+	}
+	var cfg gomaConfig
+	if err := yaml.Unmarshal([]byte(srv.GatewayConfigYAML), &cfg); err != nil {
+		return s.usesFileProvider(srv)
+	}
+	p := cfg.Gateway.Providers
+	if p.File != nil && p.File.Enabled {
+		return true
+	}
+	if p.HTTP != nil && p.HTTP.Enabled {
+		return false
+	}
+	return s.usesFileProvider(srv)
 }
 
 // RenderConfig builds the default goma.yml a node gateway runs with: ACME for
@@ -355,7 +507,7 @@ func usesFileProvider(srv *models.Server) bool {
 // This is the editable starting point shown in the UI.
 func (s *Service) RenderConfig(srv *models.Server) string {
 	var prov providers
-	if usesFileProvider(srv) {
+	if s.usesFileProvider(srv) {
 		prov.File = &fileProvider{Enabled: true, Directory: providersPath, Watch: true}
 	} else {
 		prov.HTTP = &httpProvider{
@@ -390,7 +542,7 @@ func (s *Service) RenderConfig(srv *models.Server) string {
 	// Remote edge nodes poll the HTTP provider; expose the on-demand reload
 	// endpoint so Miabi can make them pull immediately. The manager (local) uses a
 	// watched file provider that already reloads on write, so it doesn't need it.
-	if !usesFileProvider(srv) {
+	if !s.usesFileProvider(srv) {
 		cfg.Gateway.Reload = &reloadBlock{Enabled: true}
 	}
 	// Wire Redis for shared cache + distributed rate limiting when available: the
@@ -398,6 +550,12 @@ func (s *Service) RenderConfig(srv *models.Server) string {
 	// The password is injected as ${GATEWAY_REDIS_PASSWORD} at deploy time.
 	if addr := s.redisAddrFor(srv); addr != "" {
 		cfg.Gateway.Redis = &redisBlock{Addr: addr, Password: "${" + gatewayRedisPasswordEnv + "}"}
+	}
+	if s.analyticsEnabledFor(srv) {
+		cfg.Gateway.Analytics = &analyticsBlock{
+			Enabled: true, Stream: s.analyticsStream,
+			Sample: defaultAnalyticsSample, MaxLen: defaultAnalyticsMaxLen,
+		}
 	}
 	body, err := yaml.Marshal(cfg)
 	if err != nil {
@@ -515,7 +673,7 @@ func (s *Service) prepare(ctx context.Context, dc docker.Client, srv *models.Ser
 	// manager's default uses the file provider and does not.
 	cfg := strings.TrimSpace(srv.GatewayConfigYAML)
 	if cfg == "" {
-		if !usesFileProvider(srv) && s.controlURL == "" {
+		if !s.usesFileProvider(srv) && s.controlURL == "" {
 			return fmt.Errorf("control URL is not configured (set MIABI_CONTROL_URL)")
 		}
 		cfg = s.RenderConfig(srv)
@@ -528,7 +686,7 @@ func (s *Service) prepare(ctx context.Context, dc docker.Client, srv *models.Ser
 	}
 
 	// A remote edge node runs its own Redis (the manager reuses the platform one).
-	if !usesFileProvider(srv) {
+	if !isManager(srv) {
 		if err := s.ensureNodeRedis(ctx, dc, srv, redisPassword); err != nil {
 			return fmt.Errorf("ensure gateway redis: %w", err)
 		}
@@ -565,10 +723,12 @@ func (s *Service) runGateway(ctx context.Context, dc docker.Client, srv *models.
 		ConfigVolume: configPath,
 		CertsVolume:  "/etc/letsencrypt",
 	}
-	// The manager's gateway shares Miabi's providers volume (file provider),
-	// so route files Miabi writes are read directly.
-	if usesFileProvider(srv) {
-		mounts[ProvidersVolume] = providersPath
+	// Give the manager's gateway the very volume Miabi writes route files to —
+	// not a volume of the gateway's own, which would leave the file provider
+	// watching a directory nothing ever writes to. Only mounted when that volume
+	// is known; otherwise the config polls the HTTP provider and needs nothing.
+	if s.usesFileProvider(srv) {
+		mounts[s.providersVolume] = providersPath
 	}
 	spec := docker.RunSpec{
 		Name:     name,
@@ -608,14 +768,15 @@ func (s *Service) runGateway(ctx context.Context, dc docker.Client, srv *models.
 // ${GATEWAY_REDIS_PASSWORD}). Neither secret lives in the editable config.
 func (s *Service) gatewayEnv(srv *models.Server, token, redisPassword string) []string {
 	env := []string{apiKeyEnv + "=" + token}
-	// Protect the on-demand reload endpoint with the node's gateway token (remote
-	// edge nodes only; the manager reloads via its watched file provider).
-	if !usesFileProvider(srv) {
+	// Protect the on-demand reload endpoint with the node's gateway token. Needed
+	// by any gateway that polls the HTTP provider — every remote edge node, and a
+	// manager gateway configured to poll instead of watching the volume.
+	if !s.effectiveFileProvider(srv) {
 		env = append(env, reloadTokenEnv+"="+token)
 	}
 	if s.redisAddrFor(srv) != "" {
 		pw := redisPassword
-		if usesFileProvider(srv) {
+		if isManager(srv) {
 			pw = s.redisPassword
 		}
 		env = append(env, gatewayRedisPasswordEnv+"="+pw)

--- a/internal/services/edgegateway/edgegateway_test.go
+++ b/internal/services/edgegateway/edgegateway_test.go
@@ -50,7 +50,10 @@ func TestRenderConfig(t *testing.T) {
 }
 
 func TestRenderConfigManagerUsesFileProvider(t *testing.T) {
+	// A stack install: Miabi created the volume behind its route directory, so it
+	// can hand the manager's gateway the same one to watch.
 	s := NewService(nil, "https://miabi.example.com/", "img", "miabi", "ops@example.com")
+	s.SetProvidersVolume("mb-platform-gateway-providers")
 	got := s.RenderConfig(&models.Server{Name: "manager", IsLocal: true})
 
 	for _, want := range []string{

--- a/internal/services/edgegateway/provider_test.go
+++ b/internal/services/edgegateway/provider_test.go
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package edgegateway
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/miabi-io/miabi/internal/models"
+)
+
+// httpProviderConfig is a manager gateway switched to poll the control plane
+// instead of watching the providers volume.
+const httpProviderConfig = `
+version: 2
+gateway:
+  providers:
+    http:
+      enabled: true
+      endpoint: https://miabi.example.com/api/v1/provider/manager
+`
+
+// Where a gateway runs and how it learns its routes are separate questions. The
+// manager shares the control plane's Redis whichever provider it uses — the
+// Redis choice follows the node, not the config.
+func TestManagerSharesPlatformRedisOnEitherProvider(t *testing.T) {
+	s := analyticsService(t, "goma:analytics", "miabi-redis:6379")
+
+	for _, srv := range []*models.Server{
+		{Name: "manager", IsLocal: true},
+		{Name: "manager", IsLocal: true, GatewayConfigYAML: httpProviderConfig},
+	} {
+		if got := s.redisAddrFor(srv); got != "miabi-redis:6379" {
+			t.Errorf("manager redis = %q, want the platform Redis", got)
+		}
+		if !s.analyticsEnabledFor(srv) {
+			t.Error("a manager gateway publishes analytics whichever provider it uses")
+		}
+	}
+
+	// A remote edge node is self-contained: its own Redis, and no analytics,
+	// because nothing reads that Redis.
+	edge := &models.Server{Name: "edge-1"}
+	if got := s.redisAddrFor(edge); got != RedisContainer+":6379" {
+		t.Errorf("edge redis = %q, want the per-node Redis", got)
+	}
+	if s.analyticsEnabledFor(edge) {
+		t.Error("a remote edge node must not publish analytics nobody consumes")
+	}
+}
+
+// The manager can only watch route files if Miabi can hand it the volume it
+// writes them to. A stack install owns that volume; a manual install's mounts
+// were made by the operator, so Miabi cannot name one — and a gateway watching a
+// directory nothing writes to would serve no routes at all. It polls instead.
+func TestManagerFallsBackToHTTPWithoutAKnownVolume(t *testing.T) {
+	manager := &models.Server{Name: "manager", IsLocal: true}
+
+	// Manual install: no providers volume known.
+	manual := NewService(nil, "https://miabi.example.com", "goma:latest", "miabi", "ops@example.com")
+	got := manual.RenderConfig(manager)
+	if !strings.Contains(got, "http:") || !strings.Contains(got, "/api/v1/provider/manager") {
+		t.Errorf("a manual-install manager must poll the HTTP provider\n---\n%s", got)
+	}
+	if strings.Contains(got, "directory: /etc/goma/providers") {
+		t.Errorf("a manual-install manager must not watch a directory it was never given\n---\n%s", got)
+	}
+	// …and it needs the reload plumbing a poller depends on.
+	if !strings.Contains(got, "reload:") {
+		t.Errorf("a polling manager needs the reload endpoint\n---\n%s", got)
+	}
+	if manual.usesFileProvider(manager) {
+		t.Error("usesFileProvider must be false without a known volume")
+	}
+
+	// Stack install: the volume is known, so it watches it.
+	stack := NewService(nil, "https://miabi.example.com", "goma:latest", "miabi", "ops@example.com")
+	stack.SetProvidersVolume("mb-platform-gateway-providers")
+	if got = stack.RenderConfig(manager); !strings.Contains(got, "directory: /etc/goma/providers") {
+		t.Errorf("a stack-install manager must watch the route directory\n---\n%s", got)
+	}
+	if !stack.usesFileProvider(manager) {
+		t.Error("usesFileProvider must be true once the volume is known")
+	}
+}
+
+// The runtime plumbing that depends on the provider follows the gateway's actual
+// config, so a manager switched to HTTP polling is treated like any poller.
+func TestEffectiveFileProviderFollowsTheStoredConfig(t *testing.T) {
+	// A stack install: Miabi knows the volume backing its route directory, so the
+	// manager's default is the file provider.
+	s := NewService(nil, "https://miabi.example.com", "goma:latest", "miabi", "ops@example.com")
+	s.SetProvidersVolume("mb-platform-gateway-providers")
+
+	cases := []struct {
+		name string
+		srv  *models.Server
+		want bool
+	}{
+		{"manager default watches the volume", &models.Server{IsLocal: true}, true},
+		{"manager switched to http polls", &models.Server{IsLocal: true, GatewayConfigYAML: httpProviderConfig}, false},
+		{"edge node polls", &models.Server{}, false},
+		{
+			"edge node given a file provider watches",
+			&models.Server{GatewayConfigYAML: "version: 2\ngateway:\n  providers:\n    file:\n      enabled: true\n"},
+			true,
+		},
+		// The config is validated on save, so this only covers one edited by hand
+		// outside the API: fall back to the node's default rather than guessing.
+		{"unparseable config falls back", &models.Server{IsLocal: true, GatewayConfigYAML: "\tnot: [yaml"}, true},
+		{"config with no provider block falls back", &models.Server{GatewayConfigYAML: "version: 2\n"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := s.effectiveFileProvider(tc.srv); got != tc.want {
+				t.Errorf("effectiveFileProvider = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A polling gateway needs the reload token to accept the on-demand nudge —
+// including a manager that polls, which previously never got one.
+func TestReloadTokenFollowsTheProvider(t *testing.T) {
+	s := NewService(nil, "https://miabi.example.com", "goma:latest", "miabi", "ops@example.com")
+	s.SetProvidersVolume("mb-platform-gateway-providers") // stack install
+
+	has := func(srv *models.Server) bool {
+		for _, e := range s.gatewayEnv(srv, "tok", "") {
+			if strings.HasPrefix(e, reloadTokenEnv+"=") {
+				return true
+			}
+		}
+		return false
+	}
+	if has(&models.Server{IsLocal: true}) {
+		t.Error("a manager watching the volume needs no reload token")
+	}
+	if !has(&models.Server{IsLocal: true, GatewayConfigYAML: httpProviderConfig}) {
+		t.Error("a manager that polls needs a reload token")
+	}
+	if !has(&models.Server{Name: "edge-1"}) {
+		t.Error("a remote edge node needs a reload token")
+	}
+}
+
+// The manager's server record carries no address — it is "here" — so a reload
+// must reach its gateway over the shared proxy network by container name rather
+// than failing for want of an address.
+func TestReloadHostForTheManager(t *testing.T) {
+	s := NewService(nil, "https://miabi.example.com", "goma:latest", "miabi", "ops@example.com")
+
+	host, err := s.reloadHost(&models.Server{IsLocal: true})
+	if err != nil || host != ContainerName {
+		t.Errorf("manager reload host = (%q, %v), want the gateway container name", host, err)
+	}
+	if host, err = s.reloadHost(&models.Server{Name: "edge-1", Address: "10.0.0.5"}); err != nil || host != "10.0.0.5" {
+		t.Errorf("edge reload host = (%q, %v), want its address", host, err)
+	}
+	if _, err = s.reloadHost(&models.Server{Name: "edge-1"}); err == nil {
+		t.Error("an edge node with no address cannot be reloaded — that must be an error")
+	}
+}

--- a/internal/services/edgegateway/reload.go
+++ b/internal/services/edgegateway/reload.go
@@ -28,21 +28,44 @@ var reloadHTTPClient = &http.Client{Timeout: 10 * time.Second}
 
 // Reload tells the edge gateway fronting srv to pull and apply its configuration
 // immediately (POST /reload), instead of waiting for the HTTP-provider poll
-// interval. It is a no-op for the local manager, which uses a watched file
-// provider that already reloads on write. token is the node's gateway token (the
-// same value injected as GOMA_RELOAD_TOKEN on the gateway).
+// interval. token is the node's gateway token (the same value injected as
+// GOMA_RELOAD_TOKEN on the gateway).
+//
+// A no-op for a gateway watching the providers volume, which already reloads on
+// write. That is the manager's default — but a manager gateway switched to the
+// HTTP provider polls like any edge node and does need the nudge, so the
+// decision follows the gateway's actual config rather than the node.
 func (s *Service) Reload(ctx context.Context, srv *models.Server, token string) error {
-	if usesFileProvider(srv) {
+	if s.effectiveFileProvider(srv) {
 		return nil
 	}
-	if srv == nil || srv.Address == "" {
-		return fmt.Errorf("edgegateway: server has no address to reach its gateway")
+	host, err := s.reloadHost(srv)
+	if err != nil {
+		return err
 	}
-	baseURL := "http://" + net.JoinHostPort(srv.Address, strconv.Itoa(gatewayWebPort))
+	baseURL := "http://" + net.JoinHostPort(host, strconv.Itoa(gatewayWebPort))
 	if err := postReload(ctx, reloadHTTPClient, baseURL, token); err != nil {
 		return fmt.Errorf("edgegateway: reload %q: %w", srv.Name, err)
 	}
 	return nil
+}
+
+// reloadHost is the address Miabi reaches a node's gateway at.
+//
+// A remote edge node is reached over the network at its own address. The manager
+// is not: its server record carries no address (it is "here"), and the control
+// plane runs in a container, so its own loopback is not the host's. Both
+// containers share MIABI_PROXY_NETWORK, though — the same network the gateway is
+// attached to and reaches app containers by alias on — so the gateway is
+// addressable there by container name.
+func (s *Service) reloadHost(srv *models.Server) (string, error) {
+	if isManager(srv) {
+		return ContainerName, nil
+	}
+	if srv == nil || srv.Address == "" {
+		return "", fmt.Errorf("edgegateway: server has no address to reach its gateway")
+	}
+	return srv.Address, nil
 }
 
 // postReload issues the authenticated POST <baseURL>/reload request.

--- a/internal/services/edgegateway/reload_test.go
+++ b/internal/services/edgegateway/reload_test.go
@@ -51,6 +51,7 @@ func TestPostReloadErrorsOnNon2xx(t *testing.T) {
 
 func TestReloadNoOpForLocalManager(t *testing.T) {
 	s := NewService(nil, "https://miabi.example.com", "img", "miabi", "ops@example.com")
+	s.SetProvidersVolume("mb-platform-gateway-providers") // stack install
 	// Local manager uses the watched file provider; reload must be a no-op even
 	// with no address configured.
 	if err := s.Reload(context.Background(), &models.Server{IsLocal: true}, "tok"); err != nil {
@@ -72,7 +73,8 @@ func TestRenderConfigEnablesReloadForEdge(t *testing.T) {
 		t.Fatalf("edge config missing reload block:\n%s", got)
 	}
 
-	// The local manager relies on file-provider watch; no reload block.
+	// A stack-install manager relies on file-provider watch; no reload block.
+	s.SetProvidersVolume("mb-platform-gateway-providers")
 	mgr := s.RenderConfig(&models.Server{Name: "manager", IsLocal: true})
 	if strings.Contains(mgr, "reload:") {
 		t.Fatalf("manager config should not have a reload block:\n%s", mgr)

--- a/web/src/views/admin/Nodes.vue
+++ b/web/src/views/admin/Nodes.vue
@@ -435,6 +435,7 @@ async function submit() {
     license.load(true) // refresh node usage so the cap chip stays accurate
     if (mode === 'agent') {
       createdToken.value = res.data.data.token
+      await loadAgentCommand(res.data.data.node.id, res.data.data.token)
       notify.success('Node added — copy the join token now')
     } else {
       showCreate.value = false
@@ -460,15 +461,38 @@ async function submit() {
 const ACCESS_LABELS: Record<string, string> = { socket: 'Local socket', agent: 'Agent', api: 'Docker API' }
 function accessLabel(m?: string): string { return ACCESS_LABELS[m || 'agent'] || m || '—' }
 
-const controlUrl = computed(() => window.location.origin)
-const agentCommand = computed(
-  () =>
+// The join command is built by the server, so it carries the configured
+// MIABI_CONTROL_URL — the address the node must dial back on, which is not
+// necessarily the address this browser reached the panel at. Building it here
+// from window.location.origin enrolled agents against whatever host the admin
+// happened to open (an internal IP, a port-forward, a proxy that is not the
+// control plane), and the node then silently failed to connect.
+const agentCommand = ref('')
+
+// localAgentCommand is the fallback used only when the server's command cannot
+// be fetched. The token is shown exactly once, so an empty dialog would lose it
+// — a command with a best-guess URL is recoverable, a missing one is not.
+function localAgentCommand(token: string): string {
+  return (
     `docker run -d --name miabi-agent --restart unless-stopped \\\n` +
-    `  -e MIABI_CONTROL_URL=${controlUrl.value} \\\n` +
-    `  -e MIABI_NODE_TOKEN=${createdToken.value ?? '<token>'} \\\n` +
+    `  -e MIABI_CONTROL_URL=${window.location.origin} \\\n` +
+    `  -e MIABI_NODE_TOKEN=${token} \\\n` +
     `  -v /var/run/docker.sock:/var/run/docker.sock \\\n` +
-    `  ${agentImage.value}`,
-)
+    `  ${agentImage.value}`
+  )
+}
+
+// The server returns the command with a <JOIN_TOKEN> placeholder (the token is
+// never in a GET response); the real one is spliced in here so it stays
+// copy-paste ready.
+async function loadAgentCommand(nodeId: number, token: string) {
+  try {
+    const jc = (await nodesApi.joinCommand(nodeId)).data.data
+    agentCommand.value = jc.command.replace('<JOIN_TOKEN>', token)
+  } catch {
+    agentCommand.value = localAgentCommand(token)
+  }
+}
 
 async function copy(text: string) {
   if (await copyText(text)) notify.success('Copied')


### PR DESCRIPTION
… fix its route source

fix(nodes): build the agent join command from the configured control URL