### PR TITLE
feat(analytics): roll edge-gateway traffic into Workspace Analytics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,9 @@ MIABI_LDFLAGS := $(LDFLAGS) -X $(PKG)/internal/enterprise.embeddedPublicKey=$(LI
 WEB_DIR := web
 EMBED_WEB_DIR := internal/web/dist
 
-.PHONY: run worker agent build build-agent build-ui build-all dev-ui test lint tidy migrate license-tool docker docker-rootless docker-agent compose-up compose-down
+SCHEMA_FILE ?= miabi.io-v1.schema.json
+
+.PHONY: run worker agent build build-agent build-ui build-all dev-ui test lint tidy migrate license-tool schema docker docker-rootless docker-agent compose-up compose-down
 
 run: ## Run the API server
 	go run -tags enterprise -ldflags "$(MIABI_LDFLAGS)" ./cmd/miabi server
@@ -52,6 +54,12 @@ test: ## Run tests (enterprise build tag — matches the shipped binary)
 lint: ## Static analysis
 	go vet ./...
 	@command -v golangci-lint >/dev/null 2>&1 && golangci-lint run || echo "golangci-lint not installed, skipping"
+
+schema: ## Generate the miabi.io/v1 JSON Schema and publish it to the docs site + VS Code extension
+	go run ./cmd/schemagen -o schema/$(SCHEMA_FILE)
+	@for d in ../docs/static/schema ../vscode-miabi/schemas; do \
+		if [ -d "$$(dirname $$d)" ]; then mkdir -p "$$d" && cp schema/$(SCHEMA_FILE) "$$d/" && echo "  -> $$d/$(SCHEMA_FILE)"; fi; \
+	done
 
 tidy: ## Sync go.mod / go.sum
 	go mod tidy

--- a/cmd/schemagen/main.go
+++ b/cmd/schemagen/main.go
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Command schemagen renders the miabi.io/v1 JSON Schema from the types the
+// manifest parser binds to. Editors consume it for completion and validation, so
+// it is generated rather than written: a field the parser accepts and the schema
+// does not is a false error, and the reverse is a file that fails at apply.
+//
+//	go run ./cmd/schemagen -o schema/miabi.io-v1.schema.json
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/miabi-io/miabi/internal/declarative"
+)
+
+func main() {
+	out := flag.String("o", "", "write to this file instead of stdout")
+	flag.Parse()
+
+	b, err := declarative.JSONSchema()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "schemagen:", err)
+		os.Exit(1)
+	}
+	b = append(b, '\n')
+
+	if *out == "" {
+		_, _ = os.Stdout.Write(b)
+		return
+	}
+	if err := os.WriteFile(*out, b, 0o644); err != nil {
+		fmt.Fprintln(os.Stderr, "schemagen:", err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stderr, "schemagen: wrote %s (%d bytes)\n", *out, len(b))
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/miabi-io/miabi
 go 1.26.3
 
 require (
+	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.106.2
 	github.com/axiomhq/hyperloglog v0.2.6
 	github.com/crewjam/saml v0.5.1
@@ -48,6 +49,7 @@ require (
 	github.com/go-asn1-ber/asn1-ber v1.5.8 // indirect
 	github.com/jkaninda/njia v0.0.3 // indirect
 	github.com/kamstrup/intmap v0.5.2 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 )
 
 require (
@@ -130,7 +132,7 @@ require (
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/russellhaering/goxmldsig v1.4.0 // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/ProtonMail/gopenpgp/v2 v2.8.2 h1:fe/XagfxkHRCr+cLFMcoF7XwaASRGSmK/fmc
 github.com/ProtonMail/gopenpgp/v2 v2.8.2/go.mod h1:pPWZyRQWpQ7g8NWsdZmUynNZ1R09k4MdbSHvm+KooqM=
 github.com/alexbrainman/sspi v0.0.0-20250919150558-7d374ff0d59e h1:4dAU9FXIyQktpoUAgOJK3OTFc/xug0PCXYCqU0FgDKI=
 github.com/alexbrainman/sspi v0.0.0-20250919150558-7d374ff0d59e/go.mod h1:cEWa1LVoE5KvSD9ONXsZrj0z6KqySlCCNKHlLzbqAt4=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -339,6 +341,8 @@ github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
 github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/internal/declarative/jsonschema.go
+++ b/internal/declarative/jsonschema.go
@@ -1,0 +1,299 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package declarative
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// schemaSource is this file's neighbour, embedded so the generator can read the
+// doc comments reflection cannot see. Editors show them as hovers, which is what
+// makes a generated schema worth more than a hand-written one.
+//
+//go:embed schema.go
+var schemaSource string
+
+// SchemaID is where the generated schema is published. Editors resolve $ref
+// against it, so it must be the URL the file is actually served from.
+const SchemaID = "https://docs.miabi.io/schema/miabi.io-v1.schema.json"
+
+func JSONSchema() ([]byte, error) {
+	g := &schemaGen{defs: map[string]any{}, docs: fieldDocs()}
+
+	kinds := make([]string, 0, len(knownKinds))
+	for k := range knownKinds {
+		kinds = append(kinds, string(k))
+	}
+	sort.Strings(kinds)
+
+	specFor := map[Kind]any{
+		KindApplication: ApplicationSpec{},
+		KindStack:       StackSpec{},
+		KindDatabase:    DatabaseSpec{},
+		KindVolume:      VolumeSpec{},
+		KindRoute:       RouteSpec{},
+		KindSecret:      SecretSpec{},
+		KindDomain:      DomainSpec{},
+		KindRegistry:    RegistrySpec{},
+		KindProject:     ProjectSpec{},
+		KindConfig:      ConfigSpec{},
+	}
+	branches := make([]any, 0, len(kinds))
+	for _, k := range kinds {
+		ref := g.define(reflect.TypeOf(specFor[Kind(k)]))
+		branches = append(branches, map[string]any{
+			"if":   map[string]any{"properties": map[string]any{"kind": map[string]any{"const": k}}, "required": []string{"kind"}},
+			"then": map[string]any{"properties": map[string]any{"spec": ref}},
+		})
+	}
+
+	metaRef := g.define(reflect.TypeOf(Meta{}))
+	schema := map[string]any{
+		"$schema":              "http://json-schema.org/draft-07/schema#",
+		"$id":                  SchemaID,
+		"title":                "Miabi manifest (" + APIVersion + ")",
+		"description":          "A declarative Miabi resource. Manifests are strictly parsed: an unknown key is an error, not a silently ignored typo.",
+		"type":                 "object",
+		"required":             []string{"apiVersion", "kind", "metadata"},
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"apiVersion": map[string]any{"const": APIVersion, "description": "The only accepted API version."},
+			"kind":       map[string]any{"enum": kinds, "description": "The resource kind. Decides which fields `spec` accepts."},
+			"metadata":   metaRef,
+			"spec":       map[string]any{"type": "object", "description": "Kind-specific configuration."},
+		},
+		"allOf": branches,
+		"$defs": g.defs,
+	}
+	return json.MarshalIndent(schema, "", "  ")
+}
+
+type schemaGen struct {
+	defs     map[string]any
+	docs     map[string]string
+	building map[string]bool
+}
+
+// define registers t in $defs (once) and returns a $ref to it.
+func (g *schemaGen) define(t reflect.Type) map[string]any {
+	name := t.Name()
+	ref := map[string]any{"$ref": "#/$defs/" + name}
+	if _, done := g.defs[name]; done {
+		return ref
+	}
+	if g.building == nil {
+		g.building = map[string]bool{}
+	}
+	if g.building[name] {
+		return ref
+	}
+	g.building[name] = true
+	g.defs[name] = g.object(t)
+	delete(g.building, name)
+	return ref
+}
+
+func (g *schemaGen) object(t reflect.Type) map[string]any {
+	props := map[string]any{}
+	var required []string
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		name, opts, ok := yamlName(f)
+		if !ok {
+			continue
+		}
+		prop := g.field(t, f)
+		props[name] = prop
+		// A field the author is expected to set carries no omitempty — the same
+		// signal the parser and the docs already agree on.
+		if !opts.omitempty {
+			required = append(required, name)
+		}
+	}
+	// A Project's children are written under spec.resources, but the field carries
+	// `yaml:"-"` because the parser flattens them itself before binding. The
+	// schema has to describe what authors type, not what the struct binds.
+	if t.Name() == "ProjectSpec" {
+		props["resources"] = map[string]any{
+			"type":        "array",
+			"description": "Resources authored in this bundle. Each item is a full manifest document; the parser flattens them into the set.",
+			"items":       map[string]any{"$ref": "#"},
+		}
+	}
+	sort.Strings(required)
+	out := map[string]any{
+		"type":                 "object",
+		"properties":           props,
+		"additionalProperties": false,
+	}
+	if doc := g.docs[t.Name()]; doc != "" {
+		out["description"] = doc
+	}
+	if len(required) > 0 {
+		out["required"] = required
+	}
+	return out
+}
+
+// field renders one struct field, attaching its doc comment and any enum the
+// validator enforces for it.
+func (g *schemaGen) field(owner reflect.Type, f reflect.StructField) map[string]any {
+	out := g.typeOf(f.Type)
+	if doc := g.docs[owner.Name()+"."+f.Name]; doc != "" {
+		out["description"] = doc
+	}
+	if vals := enumFor(owner.Name(), f.Name); len(vals) > 0 {
+		out["enum"] = vals
+	}
+	return out
+}
+
+func (g *schemaGen) typeOf(t reflect.Type) map[string]any {
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	switch t.Kind() {
+	case reflect.String:
+		return map[string]any{"type": "string"}
+	case reflect.Bool:
+		return map[string]any{"type": "boolean"}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return map[string]any{"type": "integer"}
+	case reflect.Float32, reflect.Float64:
+		return map[string]any{"type": "number"}
+	case reflect.Slice, reflect.Array:
+		return map[string]any{"type": "array", "items": g.typeOf(t.Elem())}
+	case reflect.Map:
+		return map[string]any{"type": "object", "additionalProperties": g.typeOf(t.Elem())}
+	case reflect.Struct:
+		return g.define(t)
+	default:
+		// An unmapped kind must not silently become "anything": that is how a
+		// schema starts accepting what the parser rejects.
+		return map[string]any{}
+	}
+}
+
+type yamlOpts struct{ omitempty bool }
+
+// yamlName reads the field's YAML name; ok is false for unexported fields and
+// for `yaml:"-"` (the typed spec pointers, which the parser fills itself).
+func yamlName(f reflect.StructField) (string, yamlOpts, bool) {
+	if f.PkgPath != "" {
+		return "", yamlOpts{}, false
+	}
+	tag := f.Tag.Get("yaml")
+	if tag == "-" {
+		return "", yamlOpts{}, false
+	}
+	parts := strings.Split(tag, ",")
+	name := parts[0]
+	if name == "" {
+		name = strings.ToLower(f.Name)
+	}
+	var o yamlOpts
+	for _, p := range parts[1:] {
+		if p == "omitempty" {
+			o.omitempty = true
+		}
+	}
+	return name, o, true
+}
+
+// enumFor returns the values the validator accepts for a field. The sets are
+// this package's own, so renaming one breaks the build instead of leaving the
+// schema quietly permissive.
+func enumFor(typeName, field string) []string {
+	switch typeName + "." + field {
+	case "RouteSpec.TLS":
+		return sortedKeys(validTLS)
+	case "DomainSpec.TLS":
+		return sortedKeys(validDomainTLS)
+	case "DatabaseSpec.Placement":
+		return sortedKeys(placements)
+	case "ApplicationSpec.ReloadPolicy":
+		return []string{ReloadRestart, ReloadNone}
+	case "PortSpec.Protocol":
+		return []string{"tcp", "udp"}
+	case "PortSpec.Scheme":
+		return []string{"http", "https"}
+	}
+	return nil
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// fieldDocs maps "Type" and "Type.Field" to the doc comments in schema.go, so
+// the schema's descriptions and the code's comments are the same words.
+func fieldDocs() map[string]string {
+	out := map[string]string{}
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "schema.go", schemaSource, parser.ParseComments)
+	if err != nil {
+		return out
+	}
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok {
+				continue
+			}
+			if doc := commentText(gen.Doc); doc != "" {
+				out[ts.Name.Name] = doc
+			}
+			for _, f := range st.Fields.List {
+				doc := commentText(f.Doc)
+				if doc == "" {
+					doc = commentText(f.Comment)
+				}
+				if doc == "" {
+					continue
+				}
+				for _, n := range f.Names {
+					out[ts.Name.Name+"."+n.Name] = doc
+				}
+			}
+		}
+	}
+	return out
+}
+
+// commentText flattens a comment group into one line: an editor hover renders
+// the wrapping as-is, and a Go source wrap width is not a tooltip's.
+func commentText(g *ast.CommentGroup) string {
+	if g == nil {
+		return ""
+	}
+	return strings.Join(strings.Fields(g.Text()), " ")
+}
+
+// SchemaFileName is the published file name, kept here so the generator, the
+// docs site and the editor extension cannot disagree about it.
+const SchemaFileName = "miabi.io-v1.schema.json"
+
+var _ = fmt.Sprintf // keep fmt for future error wrapping without churn

--- a/internal/declarative/jsonschema_test.go
+++ b/internal/declarative/jsonschema_test.go
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package declarative_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	d "github.com/miabi-io/miabi/internal/declarative"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"gopkg.in/yaml.v3"
+)
+
+// committedSchema is the generated file checked into the repo and published to
+// editors. A stale copy means completion for a field the parser already accepts.
+const committedSchema = "../../schema/miabi.io-v1.schema.json"
+
+func TestCommittedSchemaIsCurrent(t *testing.T) {
+	want, err := d.JSONSchema()
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	got, err := os.ReadFile(committedSchema)
+	if err != nil {
+		t.Fatalf("read %s: %v — run `make schema`", committedSchema, err)
+	}
+	if !bytes.Equal(bytes.TrimSpace(got), bytes.TrimSpace(want)) {
+		t.Fatalf("%s is stale — run `make schema` and commit the result", committedSchema)
+	}
+}
+
+func compiled(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+	raw, err := d.JSONSchema()
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := jsonschema.NewCompiler()
+	if err := c.AddResource(d.SchemaID, doc); err != nil {
+		t.Fatal(err)
+	}
+	s, err := c.Compile(d.SchemaID)
+	if err != nil {
+		t.Fatalf("the generated schema does not compile: %v", err)
+	}
+	return s
+}
+
+// docsOf splits a multi-document manifest into JSON-shaped values the validator
+// can read, the same way the parser splits it.
+func docsOf(t *testing.T, path string) []any {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var out []any
+	dec := yaml.NewDecoder(f)
+	for {
+		var node any
+		err := dec.Decode(&node)
+		if err != nil {
+			break
+		}
+		if node == nil {
+			continue
+		}
+		// Round-trip through JSON so map keys are strings, as JSON Schema expects.
+		b, merr := json.Marshal(node)
+		if merr != nil {
+			t.Fatalf("%s: %v", path, merr)
+		}
+		v, uerr := jsonschema.UnmarshalJSON(bytes.NewReader(b))
+		if uerr != nil {
+			t.Fatalf("%s: %v", path, uerr)
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+// Every example the parser accepts must validate. A schema stricter than the
+// parser flags correct files; the examples are the shared reference for both.
+func TestExamplesValidateAgainstSchema(t *testing.T) {
+	files, err := filepath.Glob("../../examples/apply/*.yaml")
+	if err != nil || len(files) == 0 {
+		t.Skip("no example manifests")
+	}
+	schema := compiled(t)
+	for _, path := range files {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			// Projects inline their children, so a document count of one is normal.
+			for i, doc := range docsOf(t, path) {
+				if err := schema.Validate(doc); err != nil {
+					t.Errorf("document %d does not validate:\n%v", i, err)
+				}
+			}
+		})
+	}
+}
+
+// The gitops examples are the same schema seen through a directory source.
+func TestGitOpsExamplesValidate(t *testing.T) {
+	files, _ := filepath.Glob("../../examples/gitops/*/*/stack.yaml")
+	more, _ := filepath.Glob("../../examples/gitops/*/stack.yaml")
+	files = append(files, more...)
+	if len(files) == 0 {
+		t.Skip("no gitops examples")
+	}
+	schema := compiled(t)
+	for _, path := range files {
+		t.Run(strings.TrimPrefix(path, "../../examples/"), func(t *testing.T) {
+			for i, doc := range docsOf(t, path) {
+				if err := schema.Validate(doc); err != nil {
+					t.Errorf("document %d does not validate:\n%v", i, err)
+				}
+			}
+		})
+	}
+}
+
+// The strictness the parser has, the schema must have: a typo is the failure
+// this whole file exists to move from apply-time to type-time.
+func TestSchemaRejectsWhatTheParserRejects(t *testing.T) {
+	schema := compiled(t)
+	cases := []struct {
+		name, yaml string
+	}{
+		{"unknown top-level key", "apiVersion: miabi.io/v1\nkind: Volume\nmetadata: {name: v}\nspce: {}\n"},
+		{"unknown spec field", "apiVersion: miabi.io/v1\nkind: Application\nmetadata: {name: a}\nspec: {image: nginx, imagee: x}\n"},
+		{"wrong apiVersion", "apiVersion: miabi.io/v2\nkind: Volume\nmetadata: {name: v}\n"},
+		{"unknown kind", "apiVersion: miabi.io/v1\nkind: Sercet\nmetadata: {name: s}\n"},
+		{"missing metadata", "apiVersion: miabi.io/v1\nkind: Volume\n"},
+		{"application without image", "apiVersion: miabi.io/v1\nkind: Application\nmetadata: {name: a}\nspec: {tag: '1'}\n"},
+		{"route tls out of range", "apiVersion: miabi.io/v1\nkind: Route\nmetadata: {name: r}\nspec: {hosts: [a.example.com], app: web, tls: maybe}\n"},
+		{"port is not a number", "apiVersion: miabi.io/v1\nkind: Application\nmetadata: {name: a}\nspec: {image: nginx, ports: [{container: eighty}]}\n"},
+		{"field from another kind", "apiVersion: miabi.io/v1\nkind: Volume\nmetadata: {name: v}\nspec: {image: nginx}\n"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			var node any
+			if err := yaml.Unmarshal([]byte(tt.yaml), &node); err != nil {
+				t.Fatal(err)
+			}
+			b, _ := json.Marshal(node)
+			v, _ := jsonschema.UnmarshalJSON(bytes.NewReader(b))
+			if err := schema.Validate(v); err == nil {
+				t.Error("accepted by the schema; the parser would reject it")
+			}
+		})
+	}
+}
+
+// Descriptions are the reason to generate rather than hand-write: an editor
+// hover should be the same prose as the code's comment.
+func TestSchemaCarriesDescriptions(t *testing.T) {
+	raw, err := d.JSONSchema()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		Defs map[string]struct {
+			Description string                    `json:"description"`
+			Properties  map[string]map[string]any `json:"properties"`
+		} `json:"$defs"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatal(err)
+	}
+	described, total := 0, 0
+	for _, def := range doc.Defs {
+		for _, p := range def.Properties {
+			total++
+			if s, _ := p["description"].(string); s != "" {
+				described++
+			}
+		}
+	}
+	if described == 0 {
+		t.Fatal("no field carries a description — the doc-comment pass is broken")
+	}
+	t.Logf("%d/%d fields documented", described, total)
+	if doc.Defs["ConfigSpec"].Properties["delimiters"]["description"] == "" {
+		t.Error("ConfigSpec.delimiters lost its comment")
+	}
+}

--- a/internal/handlers/provider_handler.go
+++ b/internal/handlers/provider_handler.go
@@ -4,10 +4,14 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 
+	"github.com/jkaninda/logger"
 	"github.com/jkaninda/okapi"
+	"github.com/miabi-io/miabi/internal/models"
 	"github.com/miabi-io/miabi/internal/proxy"
+	"github.com/miabi-io/miabi/internal/services/analytics"
 	"github.com/miabi-io/miabi/internal/services/node"
 	"github.com/miabi-io/miabi/internal/services/route"
 )
@@ -16,12 +20,28 @@ import (
 // Gateway polls these endpoints with its join token. The bundle contains every middleware (routes
 // reference them by name) but only the routes for apps placed on that node.
 type ProviderHandler struct {
-	nodes  *node.Service
-	routes *route.Service
+	nodes     *node.Service
+	routes    *route.Service
+	ingest    *analytics.Ingester
+	metrics   AnalyticsIngestMetrics
+	forwarder func(*models.Server) AnalyticsForwarderConfig
+}
+
+// AnalyticsIngestMetrics records ingest outcomes; nil-safe via noopIngestMetrics.
+type AnalyticsIngestMetrics interface {
+	IngestAccepted(node string, n int)
+	IngestRejected(node string, n int)
 }
 
 func NewProviderHandler(n *node.Service, routes *route.Service) *ProviderHandler {
 	return &ProviderHandler{nodes: n, routes: routes}
+}
+
+// SetAnalyticsIngest enables POST /provider/{slug}/analytics. Without it the
+// endpoint reports 503 rather than silently dropping a node's events.
+func (h *ProviderHandler) SetAnalyticsIngest(i *analytics.Ingester, m AnalyticsIngestMetrics,
+	forwarder func(*models.Server) AnalyticsForwarderConfig) {
+	h.ingest, h.metrics, h.forwarder = i, m, forwarder
 }
 
 // Full serves routes + middlewares.
@@ -60,3 +80,68 @@ func (h *ProviderHandler) serve(c *okapi.Context, withRoutes, withMiddlewares bo
 	_, _ = w.Write(body)
 	return nil
 }
+
+// AnalyticsForwarderConfig tells an agent how to drain its node's local analytics
+// stream. Resolved from the agent's own token, so a node cannot ask about another.
+type AnalyticsForwarderConfig struct {
+	Enabled       bool   `json:"enabled"`
+	Node          string `json:"node"`
+	Stream        string `json:"stream,omitempty"`
+	RedisAddr     string `json:"redis_addr,omitempty"`
+	RedisPassword string `json:"redis_password,omitempty"`
+}
+
+// AnalyticsConfig hands the agent its forwarder settings: which local stream its
+// gateway writes to and how to reach the node Redis holding it.
+func (h *ProviderHandler) AnalyticsConfig(c *okapi.Context) error {
+	srv, err := h.nodes.Authenticate(bearer(c.Header("Authorization")))
+	if err != nil {
+		return c.AbortUnauthorized("invalid node token")
+	}
+	if h.ingest == nil || h.forwarder == nil {
+		return ok(c, AnalyticsForwarderConfig{Node: srv.Name})
+	}
+	cfg := h.forwarder(srv)
+	cfg.Node = srv.Name
+	return ok(c, cfg)
+}
+
+// AnalyticsIngestRequest is a batch of gateway events forwarded by an edge node.
+type AnalyticsIngestRequest struct {
+	Body analytics.Batch `json:"body"`
+}
+
+// IngestAnalytics accepts one batch of request events from a node's gateway and
+// appends them to the platform stream, so edge traffic lands in the same rollups
+// as the manager's. Authenticated as the node; the node is resolved from the
+// token, never from the body.
+func (h *ProviderHandler) IngestAnalytics(c *okapi.Context, req *AnalyticsIngestRequest) error {
+	if h.ingest == nil {
+		return c.AbortWithError(http.StatusServiceUnavailable, errAnalyticsDisabled)
+	}
+	srv, err := h.nodes.AuthenticateProvider(c.Param("slug"), bearer(c.Header("Authorization")))
+	if err != nil {
+		return c.AbortUnauthorized("invalid node token")
+	}
+	res, err := h.ingest.Ingest(c.Request().Context(), srv.ID, req.Body)
+	switch {
+	case errors.Is(err, analytics.ErrBatchTooLarge), errors.Is(err, analytics.ErrNoEvents), errors.Is(err, analytics.ErrNoBatchID):
+		// Permanent: the forwarder must drop this batch, not retry it forever.
+		return c.AbortBadRequest(err.Error())
+	case err != nil:
+		return c.AbortInternalServerError("failed to ingest analytics", err)
+	}
+	if h.metrics != nil {
+		h.metrics.IngestAccepted(srv.Name, res.Accepted)
+		if res.Rejected > 0 {
+			h.metrics.IngestRejected(srv.Name, res.Rejected)
+		}
+	}
+	if res.Rejected > 0 {
+		logger.Warn("analytics ingest dropped events for routes the node does not serve",
+			"node", srv.Name, "rejected", res.Rejected, "accepted", res.Accepted)
+	}
+	return ok(c, res)
+}
+
+var errAnalyticsDisabled = errors.New("analytics ingest is not enabled on this instance")

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -54,7 +54,8 @@ var (
 )
 
 func init() {
-	prometheus.MustRegister(buildInfo, subnetPoolUsed, subnetPoolTotal, gpuDevicesTotal, gpuDevicesEnabled, gpuAllocated)
+	prometheus.MustRegister(buildInfo, subnetPoolUsed, subnetPoolTotal, gpuDevicesTotal, gpuDevicesEnabled, gpuAllocated,
+		analyticsIngested, analyticsRejected)
 }
 
 // SetBuildInfo records the running build's version and commit.
@@ -75,6 +76,33 @@ func SetGPUStats(total, enabled, allocated int) {
 	gpuDevicesTotal.Set(float64(total))
 	gpuDevicesEnabled.Set(float64(enabled))
 	gpuAllocated.Set(float64(allocated))
+}
+
+// Analytics ingest from edge nodes. A node reporting routes it does not serve is
+// a compromise signal, so rejects are counted per node rather than only logged.
+var (
+	analyticsIngested = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "miabi_analytics_ingested_events_total",
+		Help: "Gateway request events accepted from edge nodes.",
+	}, []string{"node"})
+	analyticsRejected = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "miabi_analytics_rejected_events_total",
+		Help: "Events dropped because the node does not serve the route they claim.",
+	}, []string{"node"})
+)
+
+// IngestAccepted records events accepted from a node.
+func IngestAccepted(node string, n int) {
+	if n > 0 {
+		analyticsIngested.WithLabelValues(node).Add(float64(n))
+	}
+}
+
+// IngestRejected records events dropped for an unowned route.
+func IngestRejected(node string, n int) {
+	if n > 0 {
+		analyticsRejected.WithLabelValues(node).Add(float64(n))
+	}
 }
 
 // Handler returns the Prometheus scrape handler.

--- a/internal/routes/node_routes.go
+++ b/internal/routes/node_routes.go
@@ -7,7 +7,9 @@ import (
 	"net/http"
 
 	"github.com/jkaninda/okapi"
+	"github.com/miabi-io/miabi/internal/dto"
 	"github.com/miabi-io/miabi/internal/handlers"
+	"github.com/miabi-io/miabi/internal/services/analytics"
 )
 
 func (r *Router) nodeRoutes() []okapi.RouteDefinition {
@@ -473,6 +475,23 @@ func (r *Router) providerRoutes() []okapi.RouteDefinition {
 			Handler: r.h.provider.Middlewares,
 			Tags:    []string{"Nodes"},
 			Summary: "Node Goma middlewares",
+		},
+		{
+			Method:   http.MethodGet,
+			Path:     "/api/v1/agent/analytics-config",
+			Handler:  r.h.provider.AnalyticsConfig,
+			Tags:     []string{"Nodes"},
+			Summary:  "Analytics forwarder settings for the calling agent",
+			Response: &dto.Response[handlers.AnalyticsForwarderConfig]{},
+		},
+		{
+			Method:   http.MethodPost,
+			Path:     "/api/v1/provider/{slug}/analytics",
+			Handler:  okapi.H(r.h.provider.IngestAnalytics),
+			Tags:     []string{"Nodes"},
+			Summary:  "Ingest a node gateway's request events",
+			Request:  &handlers.AnalyticsIngestRequest{},
+			Response: &dto.Response[analytics.IngestResult]{},
 		},
 	}
 }

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -1060,6 +1060,30 @@ func InitRoutes(app *okapi.Okapi, db *gorm.DB, redisClient *redis.Client, cfg *c
 		},
 	}
 
+	// Edge gateways buffer their events on the node's own Redis; the agent forwards
+	// them here, so they land in the same stream the consumer already reads.
+	if cfg.AnalyticsEnabled && redisClient != nil {
+		r.h.provider.SetAnalyticsIngest(
+			analytics.NewIngester(redisClient, routeService, cfg.AnalyticsStream),
+			ingestMetrics{},
+			func(srv *models.Server) handlers.AnalyticsForwarderConfig {
+				// Only an edge gateway buffers locally; every other node's traffic is
+				// already served by the manager's gateway.
+				if srv == nil || srv.IsLocal || srv.Connectivity != models.ConnectivityEdgeGateway {
+					return handlers.AnalyticsForwarderConfig{}
+				}
+				pw, err := nodeService.GatewayRedisPassword(srv.ID)
+				if err != nil {
+					return handlers.AnalyticsForwarderConfig{}
+				}
+				return handlers.AnalyticsForwarderConfig{
+					Enabled: true, Stream: cfg.AnalyticsStream,
+					RedisAddr: edgegateway.RedisContainer + ":6379", RedisPassword: pw,
+				}
+			},
+		)
+	}
+
 	// Platform notification emails (password reset, workspace invitation, welcome).
 	r.h.auth.SetMailer(platformMailer)
 	r.h.workspace.SetMailer(platformMailer)
@@ -1406,3 +1430,9 @@ func urlHost(raw string) string {
 	}
 	return u.Hostname()
 }
+
+// ingestMetrics adapts the metrics package to the handler's interface.
+type ingestMetrics struct{}
+
+func (ingestMetrics) IngestAccepted(node string, n int) { metrics.IngestAccepted(node, n) }
+func (ingestMetrics) IngestRejected(node string, n int) { metrics.IngestRejected(node, n) }

--- a/internal/services/analytics/ingest.go
+++ b/internal/services/analytics/ingest.go
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package analytics
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Ingest limits. MaxBatch bounds one POST; MaxSkew bounds how far a node's clock
+// may be from the manager's before its timestamps are distrusted.
+const (
+	MaxBatch    = 500
+	MaxSkew     = 15 * time.Minute
+	batchTTL    = 10 * time.Minute
+	maxStreamID = 1_000_000
+)
+
+// StreamEventField is the stream entry field Goma writes each event under, and
+// the only one the consumer reads. Anything appended under another name is
+// dropped without a trace, so writers and the reader share this constant.
+const StreamEventField = "e"
+
+var (
+	ErrBatchTooLarge = errors.New("batch exceeds the maximum size")
+	ErrNoEvents      = errors.New("batch declares no events")
+	ErrNoBatchID     = errors.New("batch id is required")
+)
+
+// Batch is one node's forwarded run of gateway events.
+type Batch struct {
+	BatchID string  `json:"batch_id"`
+	Events  []Event `json:"events"`
+}
+
+// IngestResult reports what the manager did with a batch. Rejected events are
+// counted rather than failing the batch: one bad event must not strand the rest.
+type IngestResult struct {
+	Accepted  int  `json:"accepted"`
+	Duplicate bool `json:"duplicate"`
+	// Rejected counts events dropped for a route the node does not serve.
+	Rejected int `json:"rejected"`
+	// Reclocked counts events whose timestamp was too far off to trust.
+	Reclocked int `json:"reclocked"`
+}
+
+// RouteOwnership answers which Goma route names a node is allowed to report on.
+type RouteOwnership interface {
+	RouteNamesForNode(serverID uint) (map[string]bool, error)
+}
+
+// Ingester appends events forwarded by an edge node to the platform stream the
+// AnalyticsConsumer reads, so edge traffic converges with the manager's.
+type Ingester struct {
+	rdb    *redis.Client
+	owner  RouteOwnership
+	stream string
+	maxLen int64
+	now    func() time.Time
+}
+
+func NewIngester(rdb *redis.Client, owner RouteOwnership, stream string) *Ingester {
+	return &Ingester{rdb: rdb, owner: owner, stream: stream, maxLen: maxStreamID, now: time.Now}
+}
+
+// acceptBatch claims a batch id and appends its events in one step. Recording the
+// id after the append would double-count a retry that crashed in between, and the
+// aggregator sums counters, so a replay is invisible in the dashboards.
+var acceptBatch = redis.NewScript(`
+local claimed = redis.call('SET', KEYS[1], '1', 'NX', 'EX', ARGV[1])
+if not claimed then return 0 end
+for i = 4, #ARGV do
+  redis.call('XADD', KEYS[2], 'MAXLEN', '~', ARGV[2], '*', ARGV[3], ARGV[i])
+end
+return 1
+`)
+
+// Ingest validates a node's batch and appends the events it is allowed to report.
+// Duplicate batches return the already-accepted result so the forwarder can ACK.
+func (i *Ingester) Ingest(ctx context.Context, serverID uint, b Batch) (IngestResult, error) {
+	switch {
+	case b.BatchID == "":
+		return IngestResult{}, ErrNoBatchID
+	case len(b.Events) == 0:
+		return IngestResult{}, ErrNoEvents
+	case len(b.Events) > MaxBatch:
+		return IngestResult{}, fmt.Errorf("%w: %d > %d", ErrBatchTooLarge, len(b.Events), MaxBatch)
+	}
+
+	owned, err := i.owner.RouteNamesForNode(serverID)
+	if err != nil {
+		return IngestResult{}, fmt.Errorf("resolve node routes: %w", err)
+	}
+
+	res := IngestResult{}
+	payloads := make([]any, 0, len(b.Events)+2)
+	payloads = append(payloads, int(batchTTL.Seconds()), i.maxLen, StreamEventField)
+	now := i.now().UTC()
+	for _, e := range b.Events {
+		if !owned[e.Route] {
+			res.Rejected++
+			continue
+		}
+		if skewed(e.Ts, now) {
+			e.Ts = now.UnixMilli()
+			res.Reclocked++
+		}
+		raw, merr := json.Marshal(e)
+		if merr != nil {
+			res.Rejected++
+			continue
+		}
+		payloads = append(payloads, string(raw))
+		res.Accepted++
+	}
+	if res.Accepted == 0 {
+		return res, nil
+	}
+
+	claimed, err := acceptBatch.Run(ctx, i.rdb, []string{batchKey(serverID, b.BatchID), i.stream}, payloads...).Int()
+	if err != nil {
+		return IngestResult{}, fmt.Errorf("append events: %w", err)
+	}
+	if claimed == 0 {
+		return IngestResult{Duplicate: true}, nil
+	}
+	return res, nil
+}
+
+// skewed reports whether an event's timestamp is too far from the manager's clock
+// to file into a minute bucket. Missing timestamps are handled by the aggregator.
+func skewed(ts int64, now time.Time) bool {
+	if ts == 0 {
+		return false
+	}
+	d := now.Sub(time.UnixMilli(ts))
+	return d > MaxSkew || d < -MaxSkew
+}
+
+func batchKey(serverID uint, id string) string {
+	return fmt.Sprintf("miabi:analytics:batch:%d:%s", serverID, id)
+}

--- a/internal/services/analytics/ingest_roundtrip_test.go
+++ b/internal/services/analytics/ingest_roundtrip_test.go
@@ -1,0 +1,49 @@
+package analytics
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+// The whole point of the feature: an event a node's gateway buffered locally must
+// come out of the platform stream shaped exactly as the consumer expects.
+func TestIngestedEventSurvivesRoundTrip(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	ing := NewIngester(rdb, ownedRoutes{"mb-ws3-shop": true}, "goma:analytics")
+
+	sent := Event{
+		Ts: time.Now().UnixMilli(), Gateway: "edge-1", Route: "mb-ws3-shop",
+		Host: "shop.example.com", Method: "GET", Status: 200, Path: "/cart",
+		DurationMs: 42, UpstreamMs: 30, VID: "v1", Country: "BE", UA: "Mozilla/5.0",
+	}
+	if _, err := ing.Ingest(context.Background(), 9, Batch{BatchID: "b", Events: []Event{sent}}); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+
+	msgs, _ := rdb.XRange(context.Background(), "goma:analytics", "-", "+").Result()
+	if len(msgs) != 1 {
+		t.Fatalf("stream holds %d entries", len(msgs))
+	}
+	var got Event
+	if err := json.Unmarshal([]byte(msgs[0].Values[StreamEventField].(string)), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got != sent {
+		t.Fatalf("round trip changed the event:\n got %+v\nwant %+v", got, sent)
+	}
+	// And the consumer can still resolve its workspace + count it.
+	if ws := WorkspaceIDFromRoute(got.Route); ws != 3 {
+		t.Errorf("workspace = %d, want 3", ws)
+	}
+	agg := NewAggregator()
+	agg.Ingest(&got, 3, 0)
+	if n := len(agg.Flush(time.Now().Add(5 * time.Minute))); n != 1 {
+		t.Errorf("aggregator produced %d buckets, want 1", n)
+	}
+}

--- a/internal/services/analytics/ingest_test.go
+++ b/internal/services/analytics/ingest_test.go
@@ -1,0 +1,257 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package analytics
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+type ownedRoutes map[string]bool
+
+func (o ownedRoutes) RouteNamesForNode(uint) (map[string]bool, error) { return o, nil }
+
+type failingOwner struct{}
+
+func (failingOwner) RouteNamesForNode(uint) (map[string]bool, error) {
+	return nil, errors.New("boom")
+}
+
+const stream = "goma:analytics"
+
+func newIngester(t *testing.T, owner RouteOwnership) (*Ingester, *miniredis.Miniredis, *redis.Client) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+	return NewIngester(rdb, owner, stream), mr, rdb
+}
+
+func event(route string, ts int64) Event {
+	return Event{Ts: ts, Route: route, Host: "example.com", Method: "GET", Status: 200, DurationMs: 12}
+}
+
+func streamed(t *testing.T, rdb *redis.Client) []Event {
+	t.Helper()
+	msgs, err := rdb.XRange(context.Background(), stream, "-", "+").Result()
+	if err != nil {
+		t.Fatalf("XRange: %v", err)
+	}
+	out := make([]Event, 0, len(msgs))
+	for _, m := range msgs {
+		raw, _ := m.Values[StreamEventField].(string)
+		var e Event
+		if err := json.Unmarshal([]byte(raw), &e); err != nil {
+			t.Fatalf("stored event is not an Event: %v", err)
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+func TestIngestAppendsOwnedRoutes(t *testing.T) {
+	ing, _, rdb := newIngester(t, ownedRoutes{"mb-ws1-web": true})
+	now := time.Now().UnixMilli()
+
+	res, err := ing.Ingest(context.Background(), 7, Batch{
+		BatchID: "b1",
+		Events:  []Event{event("mb-ws1-web", now), event("mb-ws1-web", now)},
+	})
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if res.Accepted != 2 || res.Rejected != 0 || res.Duplicate {
+		t.Fatalf("result = %+v, want 2 accepted", res)
+	}
+	if got := streamed(t, rdb); len(got) != 2 {
+		t.Fatalf("stream holds %d events, want 2", len(got))
+	}
+}
+
+// The workspace is parsed straight out of the route name, so a node reporting a
+// route it does not serve is claiming another tenant's traffic.
+func TestIngestRejectsForeignRoutes(t *testing.T) {
+	ing, _, rdb := newIngester(t, ownedRoutes{"mb-ws1-web": true})
+	now := time.Now().UnixMilli()
+
+	res, err := ing.Ingest(context.Background(), 7, Batch{
+		BatchID: "b1",
+		Events:  []Event{event("mb-ws1-web", now), event("mb-ws42-victim", now), event("mb-ws42-anything", now)},
+	})
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if res.Accepted != 1 || res.Rejected != 2 {
+		t.Fatalf("result = %+v, want 1 accepted / 2 rejected", res)
+	}
+	for _, e := range streamed(t, rdb) {
+		if e.Route != "mb-ws1-web" {
+			t.Errorf("foreign route %q reached the stream", e.Route)
+		}
+	}
+}
+
+// A replayed batch must not double-count: the aggregator sums counters, so a
+// duplicate would inflate the dashboards invisibly.
+func TestIngestDeduplicatesBatch(t *testing.T) {
+	ing, _, rdb := newIngester(t, ownedRoutes{"mb-ws1-web": true})
+	b := Batch{BatchID: "same", Events: []Event{event("mb-ws1-web", time.Now().UnixMilli())}}
+
+	if _, err := ing.Ingest(context.Background(), 7, b); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	res, err := ing.Ingest(context.Background(), 7, b)
+	if err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	if !res.Duplicate {
+		t.Errorf("replay reported %+v, want Duplicate", res)
+	}
+	if got := streamed(t, rdb); len(got) != 1 {
+		t.Fatalf("stream holds %d events after a replay, want 1", len(got))
+	}
+}
+
+// Batch ids are per node, so two nodes using the same id do not shadow each other.
+func TestIngestBatchIDIsScopedToNode(t *testing.T) {
+	ing, _, rdb := newIngester(t, ownedRoutes{"mb-ws1-web": true})
+	b := Batch{BatchID: "same", Events: []Event{event("mb-ws1-web", time.Now().UnixMilli())}}
+
+	if _, err := ing.Ingest(context.Background(), 1, b); err != nil {
+		t.Fatalf("node 1: %v", err)
+	}
+	res, err := ing.Ingest(context.Background(), 2, b)
+	if err != nil {
+		t.Fatalf("node 2: %v", err)
+	}
+	if res.Duplicate {
+		t.Error("a second node's batch was treated as a replay")
+	}
+	if got := streamed(t, rdb); len(got) != 2 {
+		t.Fatalf("stream holds %d events, want 2", len(got))
+	}
+}
+
+// A node with a broken clock would file traffic in the wrong minute bucket, but
+// dropping it loses real traffic — stamp arrival time and count it instead.
+func TestIngestReclocksSkewedEvents(t *testing.T) {
+	ing, _, rdb := newIngester(t, ownedRoutes{"mb-ws1-web": true})
+	now := time.Now()
+	ing.now = func() time.Time { return now }
+
+	skewed := now.Add(-2 * time.Hour).UnixMilli()
+	res, err := ing.Ingest(context.Background(), 7, Batch{
+		BatchID: "b1",
+		Events:  []Event{event("mb-ws1-web", skewed), event("mb-ws1-web", now.UnixMilli())},
+	})
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if res.Accepted != 2 || res.Reclocked != 1 {
+		t.Fatalf("result = %+v, want 2 accepted / 1 reclocked", res)
+	}
+	for _, e := range streamed(t, rdb) {
+		if e.Ts == skewed {
+			t.Error("a skewed timestamp reached the stream unchanged")
+		}
+	}
+}
+
+// A missing timestamp is the aggregator's job (it buckets to now), not a skew.
+func TestIngestKeepsZeroTimestamp(t *testing.T) {
+	ing, _, _ := newIngester(t, ownedRoutes{"mb-ws1-web": true})
+	res, err := ing.Ingest(context.Background(), 7, Batch{
+		BatchID: "b1", Events: []Event{event("mb-ws1-web", 0)},
+	})
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if res.Reclocked != 0 || res.Accepted != 1 {
+		t.Fatalf("result = %+v, want 1 accepted / 0 reclocked", res)
+	}
+}
+
+// These are permanent: the forwarder has to drop the batch, so they must be
+// distinguishable from a transient failure.
+func TestIngestRejectsMalformedBatches(t *testing.T) {
+	ing, _, _ := newIngester(t, ownedRoutes{"mb-ws1-web": true})
+	big := make([]Event, MaxBatch+1)
+	for i := range big {
+		big[i] = event("mb-ws1-web", time.Now().UnixMilli())
+	}
+	tests := []struct {
+		name string
+		in   Batch
+		want error
+	}{
+		{"no batch id", Batch{Events: []Event{event("mb-ws1-web", 0)}}, ErrNoBatchID},
+		{"no events", Batch{BatchID: "b"}, ErrNoEvents},
+		{"too large", Batch{BatchID: "b", Events: big}, ErrBatchTooLarge},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := ing.Ingest(context.Background(), 7, tt.in); !errors.Is(err, tt.want) {
+				t.Fatalf("err = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+// A batch of only foreign routes must not claim its id: nothing was stored, so a
+// corrected retry has to be able to land.
+func TestIngestAllRejectedDoesNotClaimBatch(t *testing.T) {
+	ing, _, rdb := newIngester(t, ownedRoutes{"mb-ws1-web": true})
+	res, err := ing.Ingest(context.Background(), 7, Batch{
+		BatchID: "b1", Events: []Event{event("mb-ws9-other", time.Now().UnixMilli())},
+	})
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if res.Accepted != 0 || res.Rejected != 1 {
+		t.Fatalf("result = %+v, want 0 accepted / 1 rejected", res)
+	}
+	if n, _ := rdb.Exists(context.Background(), batchKey(7, "b1")).Result(); n != 0 {
+		t.Error("an empty batch claimed its id, blocking a corrected retry")
+	}
+}
+
+func TestIngestOwnerFailureIsTransient(t *testing.T) {
+	ing, _, _ := newIngester(t, failingOwner{})
+	_, err := ing.Ingest(context.Background(), 7, Batch{
+		BatchID: "b1", Events: []Event{event("mb-ws1-web", 0)},
+	})
+	if err == nil {
+		t.Fatal("expected an error when route ownership cannot be resolved")
+	}
+	for _, permanent := range []error{ErrNoBatchID, ErrNoEvents, ErrBatchTooLarge} {
+		if errors.Is(err, permanent) {
+			t.Errorf("a lookup failure reported as permanent (%v)", permanent)
+		}
+	}
+}
+
+// The consumer reads exactly one field name. Appending under any other drops
+// every forwarded event with no error anywhere — the failure this feature exists
+// to remove, reintroduced one layer down.
+func TestIngestWritesTheFieldTheConsumerReads(t *testing.T) {
+	ing, _, rdb := newIngester(t, ownedRoutes{"mb-ws1-web": true})
+	if _, err := ing.Ingest(context.Background(), 7, Batch{
+		BatchID: "b", Events: []Event{event("mb-ws1-web", time.Now().UnixMilli())},
+	}); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	msgs, err := rdb.XRange(context.Background(), stream, "-", "+").Result()
+	if err != nil || len(msgs) != 1 {
+		t.Fatalf("XRange: %v (%d entries)", err, len(msgs))
+	}
+	if _, ok := msgs[0].Values[StreamEventField]; !ok {
+		t.Fatalf("entry has fields %v, want one named %q", msgs[0].Values, StreamEventField)
+	}
+}

--- a/internal/services/edgegateway/analytics_test.go
+++ b/internal/services/edgegateway/analytics_test.go
@@ -36,19 +36,43 @@ func TestManagerGatewayRendersAnalytics(t *testing.T) {
 	}
 }
 
-// A remote edge node runs its own per-node Redis for cache and rate limiting.
-// Events written there are read by nobody, so enabling analytics would fill that
-// node's Redis to maxLen and never reach a dashboard.
-func TestRemoteEdgeNodeOmitsAnalytics(t *testing.T) {
+// A remote edge node publishes to its own Redis, which the agent drains and
+// forwards to the manager — so it publishes too, into that local buffer.
+func TestRemoteEdgeNodeRendersAnalytics(t *testing.T) {
 	s := analyticsService(t, "goma:analytics", "miabi-redis:6379")
 	got := s.RenderConfig(&models.Server{Name: "edge-1"})
 
-	if strings.Contains(got, "analytics:") {
-		t.Errorf("a remote edge node must not publish analytics nobody consumes\n---\n%s", got)
+	for _, want := range []string{"analytics:", "stream: goma:analytics", RedisContainer + ":6379"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered config missing %q\n---\n%s", want, got)
+		}
 	}
-	// It still gets its per-node Redis for the features that do work there.
-	if !strings.Contains(got, RedisContainer+":6379") {
-		t.Errorf("remote node lost its per-node Redis\n---\n%s", got)
+}
+
+// Every event names the gateway that served it, or edge traffic is
+// indistinguishable from the manager's once both land in one stream.
+func TestEdgeGatewayEnvCarriesGatewayID(t *testing.T) {
+	s := analyticsService(t, "goma:analytics", "miabi-redis:6379")
+	env := s.gatewayEnv(&models.Server{Name: "edge-1"}, "tok", "redispw")
+
+	var found bool
+	for _, e := range env {
+		if e == gatewayIDEnv+"=edge-1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("gateway env missing %s=edge-1: %v", gatewayIDEnv, env)
+	}
+}
+
+// With no stream wired there is nothing to name a gateway for.
+func TestNoGatewayIDWithoutAnalytics(t *testing.T) {
+	s := analyticsService(t, "", "miabi-redis:6379")
+	for _, e := range s.gatewayEnv(&models.Server{Name: "edge-1"}, "tok", "redispw") {
+		if strings.HasPrefix(e, gatewayIDEnv+"=") {
+			t.Errorf("gateway id set with analytics off: %v", e)
+		}
 	}
 }
 
@@ -61,7 +85,7 @@ func TestNoAnalyticsWithoutAConsumer(t *testing.T) {
 	}
 }
 
-// No platform Redis means nowhere to publish to at all.
+// No platform Redis means the manager's gateway has nowhere to publish to.
 func TestNoAnalyticsWithoutPlatformRedis(t *testing.T) {
 	s := analyticsService(t, "goma:analytics", "")
 	if got := s.RenderConfig(&models.Server{Name: "manager", IsLocal: true}); strings.Contains(got, "analytics:") {

--- a/internal/services/edgegateway/edgegateway.go
+++ b/internal/services/edgegateway/edgegateway.go
@@ -153,11 +153,8 @@ const (
 // Redis to maxLen and be discarded.
 func (s *Service) SetAnalytics(stream string) { s.analyticsStream = strings.TrimSpace(stream) }
 
-// analyticsEnabledFor reports whether the rendered config should turn analytics on for this node's gateway. It
-// requires publishing to the *platform* Redis, the one Miabi's consumer reads: a remote edge node runs its own
-// Redis, so events there reach no dashboard. It asks where the gateway runs, not which route provider it uses.
 func (s *Service) analyticsEnabledFor(srv *models.Server) bool {
-	return s.analyticsStream != "" && isManager(srv) && s.redisAddrFor(srv) != ""
+	return s.analyticsStream != "" && s.redisAddrFor(srv) != ""
 }
 
 func (s *Service) redisImg() string {
@@ -347,6 +344,11 @@ type fileProvider struct {
 // references it (Goma expands ${...} at runtime) so the stored/editable config
 // holds no secret.
 const apiKeyEnv = "INSTANCE_API_KEY"
+
+// gatewayIDEnv stamps every analytics event with the node it was served by
+// (Goma's `gw` field). Without it every event reports an empty gateway and edge
+// traffic is indistinguishable from the manager's.
+const gatewayIDEnv = "GOMA_GATEWAY_ID"
 
 // reloadTokenEnv is the env var Goma reads the reload-endpoint token from
 // (GOMA_RELOAD_TOKEN). Set to the node's gateway token at deploy so Miabi, which
@@ -693,6 +695,11 @@ func (s *Service) runGateway(ctx context.Context, dc docker.Client, srv *models.
 // ${GATEWAY_REDIS_PASSWORD}). Neither secret lives in the editable config.
 func (s *Service) gatewayEnv(srv *models.Server, token, redisPassword string) []string {
 	env := []string{apiKeyEnv + "=" + token}
+	// Name the gateway on every event it publishes, so the manager can tell which
+	// node served a request once edge events reach the same stream.
+	if s.analyticsEnabledFor(srv) && srv != nil && srv.Name != "" {
+		env = append(env, gatewayIDEnv+"="+srv.Name)
+	}
 	// Protect the on-demand reload endpoint with the node's gateway token. Needed
 	// by any gateway that polls the HTTP provider — every remote edge node, and a
 	// manager gateway configured to poll instead of watching the volume.

--- a/internal/services/edgegateway/provider_test.go
+++ b/internal/services/edgegateway/provider_test.go
@@ -39,14 +39,14 @@ func TestManagerSharesPlatformRedisOnEitherProvider(t *testing.T) {
 		}
 	}
 
-	// A remote edge node is self-contained: its own Redis, and no analytics,
-	// because nothing reads that Redis.
+	// A remote edge node uses its own Redis, and publishes analytics into it: the
+	// agent drains that stream and forwards it to the manager.
 	edge := &models.Server{Name: "edge-1"}
 	if got := s.redisAddrFor(edge); got != RedisContainer+":6379" {
 		t.Errorf("edge redis = %q, want the per-node Redis", got)
 	}
-	if s.analyticsEnabledFor(edge) {
-		t.Error("a remote edge node must not publish analytics nobody consumes")
+	if !s.analyticsEnabledFor(edge) {
+		t.Error("an edge node buffers analytics on its own Redis for the agent to forward")
 	}
 }
 

--- a/internal/services/route/route.go
+++ b/internal/services/route/route.go
@@ -1258,6 +1258,22 @@ func (s *Service) allocateHostPort(serverID uint) int {
 	return 0
 }
 
+// RouteNamesForNode returns the Goma route names a node serves, as they appear in
+// its gateway's analytics events. Analytics ingest gates on this: the workspace is
+// read out of the route name, so reporting a foreign one would claim another
+// tenant's traffic.
+func (s *Service) RouteNamesForNode(serverID uint) (map[string]bool, error) {
+	rendered, _, err := s.NodeBundle(serverID)
+	if err != nil {
+		return nil, err
+	}
+	names := make(map[string]bool, len(rendered))
+	for i := range rendered {
+		names[proxy.GomaName(rendered[i].WorkspaceID, rendered[i].Name)] = true
+	}
+	return names, nil
+}
+
 // NodeBundle renders the Goma config a remote node's Gateway pulls over the HTTP
 // provider: every middleware (routes reference them by name) plus only the
 // routes for apps placed on that node, with node-local upstreams.

--- a/internal/worker/analytics.go
+++ b/internal/worker/analytics.go
@@ -26,9 +26,7 @@ const (
 	// late-arriving events still land in their bucket before it is flushed.
 	analyticsBucketGrace = 90 * time.Second
 	// analyticsRouteTTL bounds how stale the route→app reverse map may get.
-	analyticsRouteTTL = time.Minute
-	// analyticsStopTimeout bounds how long shutdown waits for the final flush
-	// before giving up on it — a hung database must not hold the process open.
+	analyticsRouteTTL    = time.Minute
 	analyticsStopTimeout = 10 * time.Second
 )
 
@@ -40,21 +38,15 @@ type AnalyticsConsumer struct {
 	routes *repositories.RouteRepository
 	store  *repositories.AnalyticsRepository
 	agg    *analytics.Aggregator
-	// live counts visitors active in the last few minutes, straight off the
-	// stream — the rollups can't answer it, since a bucket isn't written until
-	// its minute closes and the grace period passes.
+
 	live     *analytics.LiveTracker
 	stream   string
 	consumer string
 
-	flushEvery time.Duration
-	// retentionDays returns the effective number of days of rollups to keep,
-	// resolved at prune time so a license install/expiry takes effect live
-	// (Community clamps to enterprise.CommunityAnalyticsRetentionDays).
+	flushEvery    time.Duration
 	retentionDays func() int
 
-	// route→app cache
-	routeMap    map[string]uint // gomaName → applicationID
+	routeMap    map[string]uint
 	routeLoaded time.Time
 }
 
@@ -178,7 +170,7 @@ func (c *AnalyticsConsumer) ensureGroup(ctx context.Context) error {
 // ingestMessage rolls one event into its bucket and reports the visitor sighting the caller should
 // record, if the event counts towards live visitors.
 func (c *AnalyticsConsumer) ingestMessage(msg redis.XMessage) (analytics.LiveVisit, bool) {
-	raw, ok := msg.Values["e"].(string)
+	raw, ok := msg.Values[analytics.StreamEventField].(string)
 	if !ok || raw == "" {
 		return analytics.LiveVisit{}, false
 	}
@@ -244,8 +236,6 @@ func (c *AnalyticsConsumer) flushLoop(ctx context.Context) {
 			return
 		case <-flush.C:
 			c.flush(ctx)
-			// Live counts are already window-correct on read; this just keeps the
-			// visitor sets from holding everyone who ever visited.
 			c.live.Sweep(ctx)
 		case <-prune.C:
 			c.prune(ctx)

--- a/schema/miabi.io-v1.schema.json
+++ b/schema/miabi.io-v1.schema.json
@@ -1,0 +1,617 @@
+{
+  "$defs": {
+    "ApplicationSpec": {
+      "additionalProperties": false,
+      "description": "ApplicationSpec is a long-running container workload. CI writes the immutable Digest; GitOps converges runtime to it.",
+      "properties": {
+        "command": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "containerLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "ContainerLabels are user-defined Docker labels stamped on the app's container(s), for label-driven tools like Traefik. Reserved keys (io.miabi.*, com.docker.*) are stripped on apply — a manifest is machine-authored, so import is fail-soft rather than erroring.",
+          "type": "object"
+        },
+        "digest": {
+          "description": "sha256:… (immutable pin)",
+          "type": "string"
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "externalLabel": {
+          "description": "ExternalLabel pins the subdomain used for external access (`\u003clabel\u003e.\u003cbase-domain\u003e`). When unset Miabi generates a stable label. The label is platform-wide unique: if already claimed it is ignored and a generated one is used, so a copy-pasted manifest never fails on a clash.",
+          "type": "string"
+        },
+        "image": {
+          "type": "string"
+        },
+        "mounts": {
+          "items": {
+            "$ref": "#/$defs/MountSpec"
+          },
+          "type": "array"
+        },
+        "ports": {
+          "items": {
+            "$ref": "#/$defs/PortSpec"
+          },
+          "type": "array"
+        },
+        "registry": {
+          "description": "Registry names the Registry credential used to pull this image; empty means an anonymous public pull. It need not be declared in the same bundle: a name not in the manifest resolves against the workspace's existing credentials, so a token created once in the UI can be reused.",
+          "type": "string"
+        },
+        "reloadPolicy": {
+          "description": "ReloadPolicy decides what a mounted config's content change does: \"restart\" (default) redeploys the app, \"none\" leaves it running for apps that watch their own config file.",
+          "enum": [
+            "restart",
+            "none"
+          ],
+          "type": "string"
+        },
+        "resources": {
+          "$ref": "#/$defs/ResourceSpec"
+        },
+        "secretEnv": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "stack": {
+          "description": "Stack optionally names the owning Stack resource.",
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "image"
+      ],
+      "type": "object"
+    },
+    "ConfigSpec": {
+      "additionalProperties": false,
+      "description": "ConfigSpec is a set of named files projected into containers at mount time. Values are interpolated exactly like application env, so a config can carry a rendered database password without a bootstrap script.",
+      "properties": {
+        "data": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Data maps a file key (a relative filename, \"/\" permitted for subdirectories) to its content.",
+          "type": "object"
+        },
+        "delimiters": {
+          "description": "Delimiters overrides the interpolation delimiters for every value, so a file whose own syntax uses {{ }} is not mangled. Exactly two distinct entries.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "mode": {
+          "description": "Mode is the default octal file mode applied to every key (\"0644\" when empty).",
+          "type": "string"
+        },
+        "sensitive": {
+          "description": "Sensitive redacts content in API responses and diffs it by digest only.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "type": "object"
+    },
+    "DatabaseSpec": {
+      "additionalProperties": false,
+      "description": "DatabaseSpec requests a logical database on a DatabaseInstance.",
+      "properties": {
+        "engine": {
+          "description": "postgres|mysql|mariadb|redis",
+          "type": "string"
+        },
+        "placement": {
+          "enum": [
+            "auto",
+            "dedicated",
+            "shared"
+          ],
+          "type": "string"
+        },
+        "version": {
+          "description": "e.g. \"16-alpine\"",
+          "type": "string"
+        }
+      },
+      "required": [
+        "engine"
+      ],
+      "type": "object"
+    },
+    "DomainSpec": {
+      "additionalProperties": false,
+      "description": "DomainSpec declares an owned hostname/zone; the hostname is the resource's metadata.name (a real FQDN). tls is the default certificate policy routes under it inherit, and wildcard covers *.name too. Ownership verification is a runtime action.",
+      "properties": {
+        "tls": {
+          "description": "acme|custom (default acme)",
+          "enum": [
+            "acme",
+            "custom"
+          ],
+          "type": "string"
+        },
+        "wildcard": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "Meta": {
+      "additionalProperties": false,
+      "description": "Meta is the identity block shared by every kind. Labels are short and identifying (for selection and grouping); Annotations hold descriptive data the engine stores but never queries. Custom metadata belongs in one of these maps, never as ad-hoc top-level keys.",
+      "properties": {
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        },
+        "uid": {
+          "description": "UID is the resource's portable identifier (its Miabi uid). Written on export so a restore into another install — or a rename in a manifest — keeps identity. Optional in hand-authored manifests; matched ahead of name when set.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "MountSpec": {
+      "additionalProperties": false,
+      "description": "MountSpec attaches a managed Volume into the container filesystem.",
+      "properties": {
+        "config": {
+          "type": "string"
+        },
+        "key": {
+          "description": "Key selects one file from the config, making Path that file's exact location. Empty projects every key under Path as a directory prefix.",
+          "type": "string"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "volume": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "type": "object"
+    },
+    "PortSpec": {
+      "additionalProperties": false,
+      "description": "PortSpec is a container port and how it is reached. The two exposure knobs are orthogonal: externalAccess gives it a public HTTPS URL through the reverse proxy, while publish/hostPort binds it to a raw port on the node, like `docker -p`.",
+      "properties": {
+        "container": {
+          "type": "integer"
+        },
+        "externalAccess": {
+          "description": "ExternalAccess publishes this port on `\u003cexternalLabel\u003e.\u003cbase-domain\u003e` over HTTPS via the reverse proxy (the base domain must be configured platform-wide).",
+          "type": "boolean"
+        },
+        "hostPort": {
+          "type": "integer"
+        },
+        "protocol": {
+          "description": "tcp|udp (default tcp)",
+          "enum": [
+            "tcp",
+            "udp"
+          ],
+          "type": "string"
+        },
+        "publish": {
+          "description": "Publish binds this container port to a host port on the node (raw TCP/UDP). HostPort requests a specific host port; 0 auto-allocates from the pool.",
+          "type": "boolean"
+        },
+        "scheme": {
+          "description": "http|https (default http)",
+          "enum": [
+            "http",
+            "https"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "container"
+      ],
+      "type": "object"
+    },
+    "ProjectSpec": {
+      "additionalProperties": false,
+      "description": "ProjectSpec bundles a set of resources authored in one place. Child resources may be inlined; the parser flattens them into the document set.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "resources": {
+          "description": "Resources authored in this bundle. Each item is a full manifest document; the parser flattens them into the set.",
+          "items": {
+            "$ref": "#"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "RegistrySpec": {
+      "additionalProperties": false,
+      "description": "RegistrySpec is a container-registry credential; an Application selects one via spec.registry. Password is write-only and never appears in a plan — prefer a vault reference over an inline literal. A rotation still converges via an unreadable fingerprint (see PasswordFP).",
+      "properties": {
+        "password": {
+          "type": "string"
+        },
+        "server": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ResourceSpec": {
+      "additionalProperties": false,
+      "description": "ResourceSpec caps memory/CPU and requests GPUs. Empty/zero means unlimited/none.",
+      "properties": {
+        "cpu": {
+          "description": "e.g. \"0.5\"",
+          "type": "string"
+        },
+        "gpu": {
+          "description": "GPU is the number of whole GPU units the app requests (0 = none). GPUKind narrows the request to a vendor/model (\"nvidia\", \"NVIDIA A100-…\").",
+          "type": "integer"
+        },
+        "gpuKind": {
+          "type": "string"
+        },
+        "memory": {
+          "description": "e.g. \"512Mi\"",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "RouteSpec": {
+      "additionalProperties": false,
+      "description": "RouteSpec binds one or more hostnames (and an optional path) to an application's port with a TLS mode — an HTTP routing rule. List every hostname the route should answer on, e.g. both example.com and www.example.com.",
+      "properties": {
+        "app": {
+          "description": "target application name",
+          "type": "string"
+        },
+        "hosts": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "path": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "tls": {
+          "description": "acme|custom|off (default acme)",
+          "enum": [
+            "acme",
+            "custom",
+            "off"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "app",
+        "hosts"
+      ],
+      "type": "object"
+    },
+    "SecretSpec": {
+      "additionalProperties": false,
+      "description": "SecretSpec is a write-only secret value. Value is never read back; the diff engine treats secrets as opaque (presence/absence only).",
+      "properties": {
+        "generate": {
+          "type": "boolean"
+        },
+        "length": {
+          "type": "integer"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "StackSpec": {
+      "additionalProperties": false,
+      "description": "StackSpec groups applications into one logical unit / network.",
+      "properties": {
+        "description": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "VolumeSpec": {
+      "additionalProperties": false,
+      "description": "VolumeSpec declares persistent storage.",
+      "properties": {
+        "size": {
+          "description": "e.g. \"5Gi\" (0/empty = unbounded)",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "$id": "https://docs.miabi.io/schema/miabi.io-v1.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "Application"
+          }
+        },
+        "required": [
+          "kind"
+        ]
+      },
+      "then": {
+        "properties": {
+          "spec": {
+            "$ref": "#/$defs/ApplicationSpec"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "Config"
+          }
+        },
+        "required": [
+          "kind"
+        ]
+      },
+      "then": {
+        "properties": {
+          "spec": {
+            "$ref": "#/$defs/ConfigSpec"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "Database"
+          }
+        },
+        "required": [
+          "kind"
+        ]
+      },
+      "then": {
+        "properties": {
+          "spec": {
+            "$ref": "#/$defs/DatabaseSpec"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "Domain"
+          }
+        },
+        "required": [
+          "kind"
+        ]
+      },
+      "then": {
+        "properties": {
+          "spec": {
+            "$ref": "#/$defs/DomainSpec"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "Project"
+          }
+        },
+        "required": [
+          "kind"
+        ]
+      },
+      "then": {
+        "properties": {
+          "spec": {
+            "$ref": "#/$defs/ProjectSpec"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "Registry"
+          }
+        },
+        "required": [
+          "kind"
+        ]
+      },
+      "then": {
+        "properties": {
+          "spec": {
+            "$ref": "#/$defs/RegistrySpec"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "Route"
+          }
+        },
+        "required": [
+          "kind"
+        ]
+      },
+      "then": {
+        "properties": {
+          "spec": {
+            "$ref": "#/$defs/RouteSpec"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "Secret"
+          }
+        },
+        "required": [
+          "kind"
+        ]
+      },
+      "then": {
+        "properties": {
+          "spec": {
+            "$ref": "#/$defs/SecretSpec"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "Stack"
+          }
+        },
+        "required": [
+          "kind"
+        ]
+      },
+      "then": {
+        "properties": {
+          "spec": {
+            "$ref": "#/$defs/StackSpec"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "Volume"
+          }
+        },
+        "required": [
+          "kind"
+        ]
+      },
+      "then": {
+        "properties": {
+          "spec": {
+            "$ref": "#/$defs/VolumeSpec"
+          }
+        }
+      }
+    }
+  ],
+  "description": "A declarative Miabi resource. Manifests are strictly parsed: an unknown key is an error, not a silently ignored typo.",
+  "properties": {
+    "apiVersion": {
+      "const": "miabi.io/v1",
+      "description": "The only accepted API version."
+    },
+    "kind": {
+      "description": "The resource kind. Decides which fields `spec` accepts.",
+      "enum": [
+        "Application",
+        "Config",
+        "Database",
+        "Domain",
+        "Project",
+        "Registry",
+        "Route",
+        "Secret",
+        "Stack",
+        "Volume"
+      ]
+    },
+    "metadata": {
+      "$ref": "#/$defs/Meta"
+    },
+    "spec": {
+      "description": "Kind-specific configuration.",
+      "type": "object"
+    }
+  },
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata"
+  ],
+  "title": "Miabi manifest (miabi.io/v1)",
+  "type": "object"
+}


### PR DESCRIPTION
An app on an edge-gateway node never appeared in the dashboards. Edge gateways now publish into that local Redis as a store-and-forward buffer and the agent drains it to POST /api/v1/provider/{slug}/analytics, which appends to the platform stream. The consumer, aggregator and rollups are untouched: they still read one stream on one Redis.