### PR TITLE
feat(declarative): route security and maintenance in the manifest

### DIFF
--- a/examples/apply/domain.yaml
+++ b/examples/apply/domain.yaml
@@ -78,6 +78,26 @@ spec:
   port: 8080
   tls: custom
 ---
+# Gateway-level switches. exploitProtection blocks common injection/traversal
+# signatures before the backend sees them. maintenance parks the route: the
+# gateway answers every request itself, so the app can be migrated behind a
+# deliberate 503. Remove the block (or set enabled: false) to resume traffic —
+# a manifest is the desired state, so an apply un-parks a hand-parked route.
+apiVersion: miabi.io/v1
+kind: Route
+metadata: { name: shop-admin }
+spec:
+  hosts: [admin.shop.example.com]
+  app: shop-web
+  port: 8080
+  tls: acme
+  security:
+    exploitProtection: true
+  maintenance:
+    enabled: true
+    statusCode: 503
+    message: Scheduled upgrade — back at 14:00 UTC
+---
 # Internal/plain-HTTP route (no TLS) — e.g. behind an upstream load balancer.
 apiVersion: miabi.io/v1
 kind: Route

--- a/internal/declarative/plan.go
+++ b/internal/declarative/plan.go
@@ -439,6 +439,20 @@ func specFields(r Resource) map[string]string {
 		f["path"] = r.Route.Path
 		f["tls"] = r.Route.TLS
 		f["port"] = fmt.Sprintf("%d", r.Route.Port)
+		sec := r.Route.Security
+		if sec == nil {
+			sec = &RouteSecuritySpec{}
+		}
+		f["security.exploitProtection"] = fmt.Sprintf("%t", sec.ExploitProtection)
+		// Flattened to canonical strings so an omitted block and an explicitly
+		// disabled one compare equal, instead of drifting on every plan.
+		mt := r.Route.Maintenance
+		if mt == nil {
+			mt = &RouteMaintenanceSpec{}
+		}
+		f["maintenance.enabled"] = fmt.Sprintf("%t", mt.Enabled)
+		f["maintenance.statusCode"] = fmt.Sprintf("%d", mt.StatusCode)
+		f["maintenance.message"] = mt.Message
 	case r.Stack != nil:
 		f["description"] = r.Stack.Description
 	case r.Domain != nil:

--- a/internal/declarative/route_gateway_test.go
+++ b/internal/declarative/route_gateway_test.go
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package declarative
+
+import "testing"
+
+func routeRes(name string, mutate func(*RouteSpec)) Resource {
+	spec := &RouteSpec{Hosts: []string{"app.example.com"}, App: "web", Path: "/", TLS: "acme"}
+	if mutate != nil {
+		mutate(spec)
+	}
+	return Resource{APIVersion: APIVersion, Kind: KindRoute, Metadata: Meta{Name: name}, Route: spec}
+}
+
+func fieldNames(diffs []FieldDiff) []string {
+	out := make([]string, 0, len(diffs))
+	for _, d := range diffs {
+		out = append(out, d.Field)
+	}
+	return out
+}
+
+// An omitted maintenance block and an explicitly disabled one describe the same
+// route. If they compared unequal, every plan would report drift on a converged
+// route and GitOps would rewrite it forever.
+func TestOmittedMaintenanceIsNotDrift(t *testing.T) {
+	live := routeRes("web", nil)
+	desired := routeRes("web", func(s *RouteSpec) {
+		s.Maintenance = &RouteMaintenanceSpec{Enabled: false}
+	})
+	if d := diffFields(live, desired); len(d) != 0 {
+		t.Errorf("phantom drift: %v", fieldNames(d))
+	}
+}
+
+func TestParkedRouteIsDriftAgainstAServingManifest(t *testing.T) {
+	live := routeRes("web", func(s *RouteSpec) {
+		s.Maintenance = &RouteMaintenanceSpec{Enabled: true, StatusCode: 503, Message: "brb"}
+	})
+	desired := routeRes("web", nil)
+	got := fieldNames(diffFields(live, desired))
+	if len(got) == 0 {
+		t.Fatal("a manifest with no maintenance block did not plan to resume traffic")
+	}
+	want := map[string]bool{"maintenance.enabled": true, "maintenance.message": true, "maintenance.statusCode": true}
+	for _, f := range got {
+		if !want[f] {
+			t.Errorf("unexpected drift field %q", f)
+		}
+	}
+}
+
+func TestMaintenanceMessageChangeIsDrift(t *testing.T) {
+	live := routeRes("web", func(s *RouteSpec) {
+		s.Maintenance = &RouteMaintenanceSpec{Enabled: true, Message: "back at 14:00"}
+	})
+	desired := routeRes("web", func(s *RouteSpec) {
+		s.Maintenance = &RouteMaintenanceSpec{Enabled: true, Message: "back at 16:00"}
+	})
+	got := fieldNames(diffFields(live, desired))
+	if len(got) != 1 || got[0] != "maintenance.message" {
+		t.Errorf("fields = %v, want just maintenance.message", got)
+	}
+}
+
+func TestEmptySecurityBlockIsNotDrift(t *testing.T) {
+	live := routeRes("web", nil)
+	desired := routeRes("web", func(s *RouteSpec) { s.Security = &RouteSecuritySpec{} })
+	if d := diffFields(live, desired); len(d) != 0 {
+		t.Errorf("phantom drift: %v", fieldNames(d))
+	}
+}
+
+func TestExploitProtectionIsDiffed(t *testing.T) {
+	live := routeRes("web", nil)
+	desired := routeRes("web", func(s *RouteSpec) {
+		s.Security = &RouteSecuritySpec{ExploitProtection: true}
+	})
+	got := fieldNames(diffFields(live, desired))
+	if len(got) != 1 || got[0] != "security.exploitProtection" {
+		t.Errorf("fields = %v, want just security.exploitProtection", got)
+	}
+	if d := diffFields(desired, desired); len(d) != 0 {
+		t.Errorf("a converged protected route shows drift: %v", fieldNames(d))
+	}
+}
+
+// Strict parsing: a typo must fail at apply time rather than being dropped.
+func TestRouteRejectsUnknownGatewayKey(t *testing.T) {
+	_, err := Parse([]byte(`apiVersion: miabi.io/v1
+kind: Route
+metadata:
+  name: web
+spec:
+  hosts: [app.example.com]
+  app: web
+  security:
+    exploitProtectionn: true
+`))
+	if err == nil {
+		t.Fatal("a misspelled key was accepted")
+	}
+}
+
+func TestRouteParsesGatewayFields(t *testing.T) {
+	rs, err := Parse([]byte(`apiVersion: miabi.io/v1
+kind: Application
+metadata:
+  name: web
+spec:
+  image: nginx
+---
+apiVersion: miabi.io/v1
+kind: Route
+metadata:
+  name: web
+spec:
+  hosts: [app.example.com]
+  app: web
+  security:
+    exploitProtection: true
+  maintenance:
+    enabled: true
+    statusCode: 503
+    message: Back at 14:00 UTC
+`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var r Resource
+	for _, res := range rs.All() {
+		if res.Kind == KindRoute {
+			r = res
+		}
+	}
+	if r.Route == nil {
+		t.Fatal("no Route parsed")
+	}
+	if r.Route.Security == nil || !r.Route.Security.ExploitProtection {
+		t.Errorf("security = %+v", r.Route.Security)
+	}
+	if r.Route.Maintenance == nil || !r.Route.Maintenance.Enabled ||
+		r.Route.Maintenance.StatusCode != 503 || r.Route.Maintenance.Message != "Back at 14:00 UTC" {
+		t.Errorf("maintenance = %+v", r.Route.Maintenance)
+	}
+}

--- a/internal/declarative/schema.go
+++ b/internal/declarative/schema.go
@@ -191,6 +191,29 @@ type RouteSpec struct {
 	Port  int      `yaml:"port,omitempty" json:"port,omitempty"`
 	Path  string   `yaml:"path,omitempty" json:"path,omitempty"`
 	TLS   string   `yaml:"tls,omitempty" json:"tls,omitempty"` // acme|custom|off (default acme)
+	// Security carries the gateway's per-route switches.
+	Security *RouteSecuritySpec `yaml:"security,omitempty" json:"security,omitempty"`
+	// Maintenance parks the route at the gateway. Omitting it means "serving",
+	// so removing the block from a manifest resumes traffic.
+	Maintenance *RouteMaintenanceSpec `yaml:"maintenance,omitempty" json:"maintenance,omitempty"`
+}
+
+// RouteSecuritySpec holds a route's gateway security switches, mirroring Goma's
+// own security block so the manifest reads like the gateway config it produces.
+type RouteSecuritySpec struct {
+	// ExploitProtection has the gateway reject requests carrying common injection
+	// and traversal signatures before the backend sees them.
+	ExploitProtection bool `yaml:"exploitProtection,omitempty" json:"exploitProtection,omitempty"`
+}
+
+// RouteMaintenanceSpec is the response a parked route answers with. An unset
+// statusCode or message leaves the gateway's defaults (503 and a short notice).
+type RouteMaintenanceSpec struct {
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// StatusCode must be 4xx or 5xx: a parked route answering 2xx reads as
+	// healthy to uptime monitors and search engines.
+	StatusCode int    `yaml:"statusCode,omitempty" json:"statusCode,omitempty"`
+	Message    string `yaml:"message,omitempty" json:"message,omitempty"`
 }
 
 // DomainSpec declares an owned hostname/zone; the hostname is the resource's metadata.name (a real

--- a/internal/services/apply/apply.go
+++ b/internal/services/apply/apply.go
@@ -809,10 +809,7 @@ func (s *Service) snapshot(ctx context.Context, workspaceID uint) (*declarative.
 		set.Add(declarative.Resource{
 			APIVersion: declarative.APIVersion, Kind: declarative.KindRoute,
 			Metadata: meta(r.UID, r.Name, r.Metadata),
-			Route: &declarative.RouteSpec{
-				Hosts: append([]string(nil), r.Hosts...), App: appSlugByID[r.ApplicationID], Port: r.TargetPort,
-				Path: path, TLS: tlsToSpec(r.TLSMode),
-			},
+			Route:    routeSpecOf(r, appSlugByID[r.ApplicationID], path),
 		})
 	}
 
@@ -1234,10 +1231,40 @@ func (s *Service) routeInput(name string, appID uint, spec *declarative.RouteSpe
 	if path == "" {
 		path = "/"
 	}
+	exploit := spec.Security != nil && spec.Security.ExploitProtection
+	mt := models.RouteMaintenance{}
+	if spec.Maintenance != nil {
+		mt = models.RouteMaintenance{
+			Enabled: spec.Maintenance.Enabled, StatusCode: spec.Maintenance.StatusCode, Message: spec.Maintenance.Message,
+		}
+	}
 	return route.Input{
 		Name: name, ApplicationID: appID, Hosts: spec.Hosts,
 		Path: path, TargetPort: spec.Port, TLSMode: tlsFromSpec(spec.TLS),
+		ExploitProtection: &exploit,
+		// Always non-nil: the manifest is the desired state, so dropping the
+		// maintenance block has to resume traffic rather than leave it parked.
+		Maintenance: &mt,
 	}
+}
+
+// routeSpecOf projects a live route onto its manifest shape. Maintenance is
+// emitted only while parked, so an exported bundle stays clean and matches a
+// manifest that simply omits the block.
+func routeSpecOf(r models.Route, app, path string) *declarative.RouteSpec {
+	spec := &declarative.RouteSpec{
+		Hosts: append([]string(nil), r.Hosts...), App: app, Port: r.TargetPort,
+		Path: path, TLS: tlsToSpec(r.TLSMode),
+	}
+	if r.ExploitProtection {
+		spec.Security = &declarative.RouteSecuritySpec{ExploitProtection: true}
+	}
+	if r.Maintenance.Enabled {
+		spec.Maintenance = &declarative.RouteMaintenanceSpec{
+			Enabled: true, StatusCode: r.Maintenance.StatusCode, Message: r.Maintenance.Message,
+		}
+	}
+	return spec
 }
 
 func (s *Service) applyVolume(ctx context.Context, workspaceID uint, ch declarative.Change, desired declarative.Resource) error {

--- a/schema/miabi.io-v1.schema.json
+++ b/schema/miabi.io-v1.schema.json
@@ -309,6 +309,37 @@
       },
       "type": "object"
     },
+    "RouteMaintenanceSpec": {
+      "additionalProperties": false,
+      "description": "RouteMaintenanceSpec is the response a parked route answers with. An unset statusCode or message leaves the gateway's defaults (503 and a short notice).",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "message": {
+          "type": "string"
+        },
+        "statusCode": {
+          "description": "StatusCode must be 4xx or 5xx: a parked route answering 2xx reads as healthy to uptime monitors and search engines.",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "type": "object"
+    },
+    "RouteSecuritySpec": {
+      "additionalProperties": false,
+      "description": "RouteSecuritySpec holds a route's gateway security switches, mirroring Goma's own security block so the manifest reads like the gateway config it produces.",
+      "properties": {
+        "exploitProtection": {
+          "description": "ExploitProtection has the gateway reject requests carrying common injection and traversal signatures before the backend sees them.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
     "RouteSpec": {
       "additionalProperties": false,
       "description": "RouteSpec binds one or more hostnames (and an optional path) to an application's port with a TLS mode — an HTTP routing rule. List every hostname the route should answer on, e.g. both example.com and www.example.com.",
@@ -323,11 +354,19 @@
           },
           "type": "array"
         },
+        "maintenance": {
+          "$ref": "#/$defs/RouteMaintenanceSpec",
+          "description": "Maintenance parks the route at the gateway. Omitting it means \"serving\", so removing the block from a manifest resumes traffic."
+        },
         "path": {
           "type": "string"
         },
         "port": {
           "type": "integer"
+        },
+        "security": {
+          "$ref": "#/$defs/RouteSecuritySpec",
+          "description": "Security carries the gateway's per-route switches."
         },
         "tls": {
           "description": "acme|custom|off (default acme)",


### PR DESCRIPTION
A route's gateway switches were console-only, so a GitOps-managed route could not be hardened or parked from the repository that owns it.