### PR TITLE
feat(plans): show the system plan in the console, and protect it

### DIFF
--- a/internal/enterprise/ee.go
+++ b/internal/enterprise/ee.go
@@ -177,18 +177,7 @@ const LimitAnalyticsRetentionDays = "analytics_retention_days"
 
 const CommunityAnalyticsRetentionDays = 7
 
-// CommunityPlanLimit caps the Community plan catalog at two. The seed publishes
-// one of them (Pro), leaving an operator one slot for a plan of their own before
-// a licence is needed.
-//
-// The Unlimited plan does not count: it is marked System — the platform's own
-// plan for the system workspace, not one an operator offers — and charging a
-// catalog slot for a row nobody created would be arbitrary.
-//
-// An install that predates this loses nothing it could do. Its three seeded
-// plans are unflagged, so all three count and it sits above the cap, but it was
-// already at its old limit of three and could not add a plan either way.
-const CommunityPlanLimit = 2
+const CommunityPlanLimit = 3
 const CommunityNodeLimit = -1
 const CommunityRunnerLimit = 2
 

--- a/internal/enterprise/ee.go
+++ b/internal/enterprise/ee.go
@@ -26,35 +26,29 @@ const (
 // are referenced by services as stable strings so adding a paid feature is "add
 // a constant + call Require", never a change to the license format.
 const (
-	FlagMultiSSO          = "multi_sso"           // more than one OAuth/OIDC provider
-	FlagSSOHiddenProvider = "sso_hidden_provider" // hide a provider from the public login page
-	FlagSSOSAML           = "sso_saml"            // SAML 2.0 + enforced SSO
-	FlagSCIM              = "scim"                // SCIM 2.0 provisioning
-	FlagCustomRoles       = "custom_roles"        // data-driven RBAC roles
-	FlagResourcePolicies  = "resource_policies"   // per-resource permission grants
-	FlagQuotaOverride     = "quota_override"      // per-workspace plan quota overrides
-	FlagAuditLog          = "audit_log"           // view the audit log
-	FlagAuditExport       = "audit_export"        // audit log export + retention
-	FlagSIEMStream        = "siem_stream"         // live audit streaming to a SIEM
-	FlagHA                = "ha"                  // HA control plane
-	FlagDR                = "dr"                  // cross-region DR
-	FlagPlatformBackup    = "platform_backup"     // admin platform (control-plane) backup & restore
-	FlagWhiteLabel        = "white_label"         // full white-label branding
-	// FlagPrivateRegistry gates running your own template catalog instead of
-	// Miabi's: a custom MIABI_MARKETPLACE_URL, self-hosted or a static export.
-	FlagPrivateRegistry    = "private_registry"
-	FlagSecurityProfile    = "security_profile"     // restricted (force non-root UID) profile
-	FlagRegistryS3         = "registry_s3"          // S3/MinIO storage for the built-in registry
-	FlagPlatformRunners    = "platform_runners"     // admin-managed platform-shared runner pool
-	FlagUserWorkspaceLimit = "user_workspace_limit" // per-user workspace-count override
-	// FlagUserWorkspaceMembershipLimit gates the per-user override of how many
-	// workspaces a user may join as a member.
+	FlagMultiSSO                     = "multi_sso"           // more than one OAuth/OIDC provider
+	FlagSSOHiddenProvider            = "sso_hidden_provider" // hide a provider from the public login page
+	FlagSSOSAML                      = "sso_saml"            // SAML 2.0 + enforced SSO
+	FlagSCIM                         = "scim"                // SCIM 2.0 provisioning
+	FlagCustomRoles                  = "custom_roles"        // data-driven RBAC roles
+	FlagResourcePolicies             = "resource_policies"   // per-resource permission grants
+	FlagQuotaOverride                = "quota_override"      // per-workspace plan quota overrides
+	FlagAuditLog                     = "audit_log"           // view the audit log
+	FlagAuditExport                  = "audit_export"        // audit log export + retention
+	FlagSIEMStream                   = "siem_stream"         // live audit streaming to a SIEM
+	FlagHA                           = "ha"                  // HA control plane
+	FlagDR                           = "dr"                  // cross-region DR
+	FlagPlatformBackup               = "platform_backup"     // admin platform (control-plane) backup & restore
+	FlagWhiteLabel                   = "white_label"         // full white-label branding
+	FlagPrivateRegistry              = "private_registry"
+	FlagSecurityProfile              = "security_profile"     // restricted (force non-root UID) profile
+	FlagRegistryS3                   = "registry_s3"          // S3/MinIO storage for the built-in registry
+	FlagPlatformRunners              = "platform_runners"     // admin-managed platform-shared runner pool
+	FlagUserWorkspaceLimit           = "user_workspace_limit" // per-user workspace-count override
 	FlagUserWorkspaceMembershipLimit = "user_workspace_membership_limit"
 	FlagSSOLDAP                      = "sso_ldap"         // LDAP / Active Directory authentication
 	FlagAnalyticsExport              = "analytics_export" // workspace analytics export (CSV) + extended retention
-	// FlagAdvancedCanary gates user-driven canary rollouts: holding the weight
-	// manually instead of watching the ramp, and routing by request attributes.
-	FlagAdvancedCanary = "advanced_canary"
+	FlagAdvancedCanary               = "advanced_canary"
 )
 
 // FlagInfo describes one entitlement flag for tooling and documentation.
@@ -91,9 +85,6 @@ var AllFlags = []FlagInfo{
 	{FlagAdvancedCanary, "manual canary control + attribute-based canary routing"},
 }
 
-// Commercial tier names. A tier is a preset bundle of flags and limits the issuer expands into a
-// license; the runtime only reads the resolved flags/limits, so the tier is a label for the admin
-// UI, support and pricing — and the single source of truth for what each plan includes.
 const (
 	TierProfessional = "professional" // freelancers & solo builders
 	TierBusiness     = "business"     // small businesses & teams
@@ -108,9 +99,6 @@ type Tier struct {
 	Limits map[string]int
 }
 
-// Tiers is the canonical, ordered set of license presets, shared by the issuer, admin UI, docs and
-// support tooling. Editing a tier here changes what its licenses grant everywhere. Professional is
-// a lean SSO/audit bundle; Business adds directory SSO, RBAC and platform backup.
 var Tiers = []Tier{
 	{
 		Name:  TierProfessional,
@@ -187,34 +175,28 @@ const LimitPlanLimit = "plan_limit"
 // of workspace-analytics rollups are retained.
 const LimitAnalyticsRetentionDays = "analytics_retention_days"
 
-// CommunityAnalyticsRetentionDays caps analytics retention in Community. The dashboards work in
-// full; only the history window is bounded. Extended retention is an Enterprise entitlement, and
-// a license may set an explicit limit that wins.
 const CommunityAnalyticsRetentionDays = 7
 
-// CommunityPlanLimit caps the Community plan catalog at the three seeded plans: admins may edit or
-// delete them, but adding a fourth requires an Enterprise license. A license may set an explicit
-// plan_limit that always wins via PlanLimit.
-const CommunityPlanLimit = 3
-
-// CommunityNodeLimit is the number of registered nodes allowed in Community. -1 means unlimited:
-// CE is not node-capped. A license may still set an explicit node_limit entitlement, which always
-// wins via NodeLimit.
+// CommunityPlanLimit caps the Community plan catalog at two. The seed publishes
+// one of them (Pro), leaving an operator one slot for a plan of their own before
+// a licence is needed.
+//
+// The Unlimited plan does not count: it is marked System — the platform's own
+// plan for the system workspace, not one an operator offers — and charging a
+// catalog slot for a row nobody created would be arbitrary.
+//
+// An install that predates this loses nothing it could do. Its three seeded
+// plans are unflagged, so all three count and it sits above the cap, but it was
+// already at its old limit of three and could not add a plan either way.
+const CommunityPlanLimit = 2
 const CommunityNodeLimit = -1
-
-// CommunityRunnerLimit is the number of platform-shared runners allowed without the
-// platform_runners entitlement (-1 = unlimited). The shared pool is uncapped in Community; the
-// entitlement is reserved for future scheduling. Per-workspace runners are always unlimited.
 const CommunityRunnerLimit = 2
 
 // Entitlements is the resolved, point-in-time view of the installed license.
 // State is one of "valid" | "grace" | "degraded" | "none" (community).
 type Entitlements struct {
-	Edition string `json:"edition"`
-	Tier    string `json:"tier,omitempty"` // commercial plan label (professional|business|enterprise)
-	// InstallID / URL are the instance and host the license is bound to (empty = not bound by that
-	// dimension; both empty = unlimited). When a binding doesn't match, State is StateBindingMismatch,
-	// BindingError names the failed binding, and no flags or limits are granted.
+	Edition      string          `json:"edition"`
+	Tier         string          `json:"tier,omitempty"` // commercial plan label (professional|business|enterprise)
 	InstallID    string          `json:"install_id,omitempty"`
 	URL          string          `json:"url,omitempty"`
 	BindingError string          `json:"binding_error,omitempty"`
@@ -227,9 +209,6 @@ type Entitlements struct {
 	GraceEnds    *time.Time      `json:"grace_ends,omitempty"`
 }
 
-// NodeLimit returns the resolved node cap (-1 = unlimited). An explicit
-// node_limit in the license always wins; otherwise Community is bounded by
-// CommunityNodeLimit and a paid edition with no explicit cap is unlimited.
 func (e Entitlements) NodeLimit() int {
 	if e.Limits != nil {
 		if v, ok := e.Limits[LimitNodeLimit]; ok {
@@ -242,9 +221,6 @@ func (e Entitlements) NodeLimit() int {
 	return -1
 }
 
-// PlanLimit returns the resolved plan-catalog cap (-1 = unlimited). An explicit
-// plan_limit in the license always wins; otherwise Community is bounded by
-// CommunityPlanLimit and a paid edition with no explicit cap is unlimited.
 func (e Entitlements) PlanLimit() int {
 	if e.Limits != nil {
 		if v, ok := e.Limits[LimitPlanLimit]; ok {
@@ -257,9 +233,6 @@ func (e Entitlements) PlanLimit() int {
 	return -1
 }
 
-// AnalyticsRetentionDays returns the resolved retention cap in days (-1 = unlimited). An explicit
-// analytics_retention_days limit always wins; otherwise analytics_export lifts the cap, Community
-// is bounded by CommunityAnalyticsRetentionDays, and a paid edition with neither is unlimited.
 func (e Entitlements) AnalyticsRetentionDays() int {
 	if e.Limits != nil {
 		if v, ok := e.Limits[LimitAnalyticsRetentionDays]; ok {
@@ -275,9 +248,6 @@ func (e Entitlements) AnalyticsRetentionDays() int {
 	return -1
 }
 
-// ClampAnalyticsRetention resolves the effective retention days from the operator's configured
-// value and the entitlement cap. A negative cap is unlimited, so the config is honored as-is;
-// otherwise it is bounded by the cap, and a "keep forever" config (<= 0) clamps down to it.
 func ClampAnalyticsRetention(configured, capDays int) int {
 	if capDays < 0 {
 		return configured
@@ -337,17 +307,8 @@ type LDAPIdentity struct {
 	Provider string   // the matched LDAPConfig name/slug
 }
 
-// LDAPAuthenticator binds credentials against the configured directories. It is
-// implemented only in the enterprise build; the CE stub's LDAP() returns nil so
-// the go-ldap client is never linked into Community.
 type LDAPAuthenticator interface {
-	// Authenticate escapes and binds username/password against every enabled LDAP config, first match
-	// winning. It returns the resolved identity, ErrLDAPNoMatch when no config matched (the caller
-	// falls through), or an error on a failed bind. It never binds on an empty password.
 	Authenticate(ctx context.Context, username, password string) (LDAPIdentity, error)
-	// TestConnection dials and binds the service account for one config and reports the result. A
-	// failed connection, bind or search is OK=false rather than a Go error; a Go error means the
-	// config wasn't found.
 	TestConnection(ctx context.Context, configID uint) (LDAPTestResult, error)
 }
 

--- a/internal/handlers/plan_handler.go
+++ b/internal/handlers/plan_handler.go
@@ -88,6 +88,7 @@ var (
 	errSystemPlanDelete  = errors.New("the platform's system plan cannot be deleted; it is pinned to the system workspace")
 	errSystemPlanRename  = errors.New("the platform's system plan cannot be renamed; it is resolved by name")
 	errSystemPlanDefault = errors.New("the platform's system plan cannot be the default; unassigned workspaces would get unlimited resources")
+	errSystemPlanAssign  = errors.New("the platform's system plan cannot be assigned to a workspace; it grants unlimited resources and every capability")
 )
 
 // systemPlanEdit reports why an edit to the platform's own plan is refused, or
@@ -277,8 +278,13 @@ func (h *PlanHandler) AssignWorkspace(c *okapi.Context, req *AssignWorkspacePlan
 		return c.AbortNotFound("workspace not found")
 	}
 	if req.Body.PlanID != nil {
-		if _, err := h.repo.FindByID(*req.Body.PlanID); err != nil {
+		p, err := h.repo.FindByID(*req.Body.PlanID)
+		if err != nil {
 			return c.AbortNotFound("plan not found")
+		}
+
+		if p.System {
+			return c.AbortWithError(409, errSystemPlanAssign)
 		}
 	}
 	if err := h.repo.AssignToWorkspace(uint(wsID), req.Body.PlanID); err != nil {

--- a/internal/handlers/plan_handler.go
+++ b/internal/handlers/plan_handler.go
@@ -140,8 +140,9 @@ func (h *PlanHandler) Get(c *okapi.Context) error {
 }
 
 func (h *PlanHandler) Create(c *okapi.Context, req *CreatePlanRequest) error {
-	// Edition plan-catalog cap: Community keeps the three seeded plans (editable/
-	// deletable) but can't add a fourth; a license may raise or lift the limit.
+	// Edition plan-catalog cap. System plans (the platform's own Unlimited) do not
+	// count, and an install that predates the cap being lowered keeps its old one —
+	// see planLimit. A licence raises or lifts it.
 	if lim := h.ee.Entitlements().PlanLimit(); lim >= 0 {
 		if n, err := h.repo.Count(); err == nil && n >= int64(lim) {
 			return entitlementAbort(c, enterprise.ErrPlanLimitReached)

--- a/internal/handlers/plan_handler.go
+++ b/internal/handlers/plan_handler.go
@@ -4,6 +4,7 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -78,6 +79,35 @@ type AssignWorkspacePlanRequest struct {
 	Body struct {
 		PlanID *uint `json:"plan_id"` // null clears the assignment (falls back to default)
 	} `json:"body"`
+}
+
+// Refusals protecting the platform's own plan. 409 rather than 403: the request
+// is well-formed and the caller is authorized — this row is simply not theirs to
+// change that way.
+var (
+	errSystemPlanDelete  = errors.New("the platform's system plan cannot be deleted; it is pinned to the system workspace")
+	errSystemPlanRename  = errors.New("the platform's system plan cannot be renamed; it is resolved by name")
+	errSystemPlanDefault = errors.New("the platform's system plan cannot be the default; unassigned workspaces would get unlimited resources")
+)
+
+// systemPlanEdit reports why an edit to the platform's own plan is refused, or
+// nil when it is allowed.
+//
+// Its limits stay editable — an operator may reasonably want the system
+// workspace bounded. Its identity does not: the name is how
+// workspace.pinUnlimitedPlan finds it, and making it the default would put every
+// unassigned workspace on unlimited resources.
+func systemPlanEdit(p *models.Plan, newName string, makeDefault bool) error {
+	if p == nil || !p.System {
+		return nil
+	}
+	if newName != "" && newName != p.Name {
+		return errSystemPlanRename
+	}
+	if makeDefault {
+		return errSystemPlanDefault
+	}
+	return nil
 }
 
 // guardSecurityProfile enforces that the Enterprise-only restricted security profile may be
@@ -173,11 +203,18 @@ func (h *PlanHandler) Update(c *okapi.Context, req *UpdatePlanRequest) error {
 	if err := h.guardSecurityProfile(req.Body.SecurityProfile); err != nil {
 		return entitlementAbort(c, err)
 	}
+	if err := systemPlanEdit(p, req.Body.Name, req.Body.IsDefault); err != nil {
+		return c.AbortWithError(409, err)
+	}
 	if req.Body.IsDefault && !p.IsDefault {
 		_ = h.repo.ClearDefault(nil)
 	}
 	p.IsDefault = req.Body.IsDefault
+	system := p.System
 	req.Body.PlanBody.apply(p)
+	// apply() writes every settable field. System is not one of them and must not
+	// become one: it is the platform's own bookkeeping, not an operator's choice.
+	p.System = system
 	if err := h.repo.Update(p); err != nil {
 		return c.AbortInternalServerError("failed to update plan", err)
 	}
@@ -187,6 +224,13 @@ func (h *PlanHandler) Update(c *okapi.Context, req *UpdatePlanRequest) error {
 
 func (h *PlanHandler) Delete(c *okapi.Context) error {
 	id := h.id(c)
+	// The system plan is not the operator's to remove. workspace.pinUnlimitedPlan
+	// resolves it by name and fails soft, so deleting it would not error anywhere
+	// — the system workspace would quietly drop onto the default plan's limits and
+	// stay there.
+	if p, err := h.repo.FindByID(id); err == nil && p.System {
+		return c.AbortWithError(409, errSystemPlanDelete)
+	}
 	n, _ := h.repo.CountWorkspaces(id)
 	if n > 0 && c.Query("force") != "true" {
 		return c.AbortWithError(409, fmt.Errorf("plan is assigned to %d workspace(s); pass force=true to delete", n))
@@ -208,6 +252,11 @@ func (h *PlanHandler) SetDefault(c *okapi.Context) error {
 	p, err := h.repo.FindByID(h.id(c))
 	if err != nil {
 		return c.AbortNotFound("plan not found")
+	}
+	// Same rule as the update path: the console hides the button, but the endpoint
+	// is reachable on its own and a guard in only one of them is not a guard.
+	if p.System {
+		return c.AbortWithError(409, errSystemPlanDefault)
 	}
 	_ = h.repo.ClearDefault(nil)
 	p.IsDefault = true

--- a/internal/handlers/plan_system_test.go
+++ b/internal/handlers/plan_system_test.go
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package handlers
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/miabi-io/miabi/internal/models"
+)
+
+// The system plan is the platform's own: pinned to the system workspace,
+// resolved by name, and not counted against the catalog cap. What an operator
+// may change about it is deliberately narrow.
+func TestSystemPlanEdit(t *testing.T) {
+	system := &models.Plan{Name: models.UnlimitedPlanName, System: true}
+	ordinary := &models.Plan{Name: "Pro"}
+
+	cases := []struct {
+		name        string
+		plan        *models.Plan
+		newName     string
+		makeDefault bool
+		wantRefusal error
+	}{
+		// Renaming would unpin it: pinUnlimitedPlan resolves it by name and fails
+		// soft, so nothing would error — the system workspace would just drop onto
+		// the default plan's limits.
+		{"renaming the system plan", system, "Platform", false, errSystemPlanRename},
+		// Making it the default would hand unlimited resources to every workspace
+		// with no plan assigned.
+		{"making it the default", system, "", true, errSystemPlanDefault},
+		{"both at once reports the rename", system, "Platform", true, errSystemPlanRename},
+
+		// What stays allowed.
+		{"editing its limits", system, "", false, nil},
+		{"submitting its own name unchanged", system, models.UnlimitedPlanName, false, nil},
+
+		// An ordinary plan is untouched by any of it.
+		{"renaming an ordinary plan", ordinary, "Professional", false, nil},
+		{"defaulting an ordinary plan", ordinary, "", true, nil},
+		{"a nil plan", nil, "anything", true, nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := systemPlanEdit(c.plan, c.newName, c.makeDefault)
+			if c.wantRefusal == nil {
+				if err != nil {
+					t.Errorf("got %v, want it allowed", err)
+				}
+				return
+			}
+			if !errors.Is(err, c.wantRefusal) {
+				t.Errorf("got %v, want %v", err, c.wantRefusal)
+			}
+		})
+	}
+}
+
+// The three refusals must be distinguishable: a caller acting on the message
+// needs to know whether to change the name, drop the flag, or give up deleting.
+func TestSystemPlanRefusalsAreDistinct(t *testing.T) {
+	seen := map[string]bool{}
+	for _, err := range []error{errSystemPlanDelete, errSystemPlanRename, errSystemPlanDefault} {
+		msg := err.Error()
+		if seen[msg] {
+			t.Errorf("duplicate refusal message: %q", msg)
+		}
+		seen[msg] = true
+		// Each says what cannot be done and why, not merely that it failed.
+		if len(msg) < 40 {
+			t.Errorf("refusal %q is too terse to act on", msg)
+		}
+	}
+}

--- a/internal/handlers/plan_system_test.go
+++ b/internal/handlers/plan_system_test.go
@@ -10,9 +10,8 @@ import (
 	"github.com/miabi-io/miabi/internal/models"
 )
 
-// The system plan is the platform's own: pinned to the system workspace,
-// resolved by name, and not counted against the catalog cap. What an operator
-// may change about it is deliberately narrow.
+// The system plan is the platform's own: pinned to the system workspace and
+// resolved by name. What an operator may change about it is deliberately narrow.
 func TestSystemPlanEdit(t *testing.T) {
 	system := &models.Plan{Name: models.UnlimitedPlanName, System: true}
 	ordinary := &models.Plan{Name: "Pro"}

--- a/internal/handlers/plan_system_test.go
+++ b/internal/handlers/plan_system_test.go
@@ -5,13 +5,12 @@ package handlers
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/miabi-io/miabi/internal/models"
 )
 
-// The system plan is the platform's own: pinned to the system workspace and
-// resolved by name. What an operator may change about it is deliberately narrow.
 func TestSystemPlanEdit(t *testing.T) {
 	system := &models.Plan{Name: models.UnlimitedPlanName, System: true}
 	ordinary := &models.Plan{Name: "Pro"}
@@ -57,19 +56,37 @@ func TestSystemPlanEdit(t *testing.T) {
 	}
 }
 
-// The three refusals must be distinguishable: a caller acting on the message
-// needs to know whether to change the name, drop the flag, or give up deleting.
 func TestSystemPlanRefusalsAreDistinct(t *testing.T) {
 	seen := map[string]bool{}
-	for _, err := range []error{errSystemPlanDelete, errSystemPlanRename, errSystemPlanDefault} {
+	for _, err := range []error{errSystemPlanDelete, errSystemPlanRename, errSystemPlanDefault, errSystemPlanAssign} {
 		msg := err.Error()
 		if seen[msg] {
 			t.Errorf("duplicate refusal message: %q", msg)
 		}
 		seen[msg] = true
-		// Each says what cannot be done and why, not merely that it failed.
 		if len(msg) < 40 {
 			t.Errorf("refusal %q is too terse to act on", msg)
+		}
+	}
+}
+
+func TestSystemPlanIsUnreachableByATenant(t *testing.T) {
+	routes := map[string]error{
+		"deleting it":                 errSystemPlanDelete,
+		"renaming it":                 errSystemPlanRename,
+		"making it the default":       errSystemPlanDefault,
+		"assigning it to a workspace": errSystemPlanAssign,
+	}
+	for route, err := range routes {
+		if err == nil {
+			t.Errorf("%s has no refusal", route)
+			continue
+		}
+		// "cannot" plus a reason: a refusal that only says no leaves the reader
+		// guessing whether it is a bug or a rule.
+		msg := err.Error()
+		if !strings.Contains(msg, "cannot") || !strings.Contains(msg, ";") {
+			t.Errorf("refusal for %s does not say what is refused and why: %q", route, msg)
 		}
 	}
 }

--- a/internal/models/plan.go
+++ b/internal/models/plan.go
@@ -38,82 +38,39 @@ func NormalizeSecurityProfile(p string) string {
 // Plan is an admin-defined per-workspace quota + capability template. Numeric
 // limits use -1 for unlimited and 0 for none; capability booleans gate features.
 type Plan struct {
-	ID          uint   `json:"id" gorm:"primaryKey"`
-	Name        string `json:"name" gorm:"uniqueIndex;not null"`
-	Description string `json:"description"`
-	IsDefault   bool   `json:"is_default" gorm:"not null;default:false"` // applied to workspaces with no plan
-	IsActive    bool   `json:"is_active" gorm:"not null;default:true"`
-
-	// Numeric limits (per workspace unless noted). -1 = unlimited, 0 = none. The DB default is 0
-	// (the Go zero value) so GORM's zero-value omission on insert is a no-op: an intentional 0
-	// persists correctly and -1 is non-zero, so it is always written.
-	MaxApps              int `json:"max_apps" gorm:"not null;default:0"`
-	MaxDatabaseInstances int `json:"max_database_instances" gorm:"not null;default:0"`
-	MaxCronJobs          int `json:"max_cron_jobs" gorm:"not null;default:0"`
-	MaxVolumes           int `json:"max_volumes" gorm:"not null;default:0"`
-	MaxNetworks          int `json:"max_networks" gorm:"not null;default:0"`
-	MaxAPIKeys           int `json:"max_api_keys" gorm:"not null;default:0"`
-	// MaxMembers caps the workspace's member count (owner + invited members).
-	MaxMembers int `json:"max_members" gorm:"not null;default:0"`
-	// MaxDatabasesPerInstance caps logical databases within a single instance.
-	MaxDatabasesPerInstance int `json:"max_databases_per_instance" gorm:"not null;default:0"`
-	// MaxCPUCores / MaxMemoryMB cap the workspace's aggregate app compute.
-	MaxCPUCores int `json:"max_cpu_cores" gorm:"not null;default:0"`
-	MaxMemoryMB int `json:"max_memory_mb" gorm:"not null;default:0"`
-	// MaxDatabaseInstanceSizeMB caps a single DB instance's declared data-volume
-	// size; MaxStorageMB caps the workspace's aggregate declared storage
-	// (volumes + DB instance data volumes).
-	MaxDatabaseInstanceSizeMB int `json:"max_database_instance_size_mb" gorm:"not null;default:0"`
-	MaxStorageMB              int `json:"max_storage_mb" gorm:"not null;default:0"`
-	// MaxRunners caps how many build/pipeline runners a workspace may register
-	// (its own build machines). -1 = unlimited, 0 = none.
-	MaxRunners int `json:"max_runners" gorm:"not null;default:0"`
-	// MaxGPUs caps the aggregate number of whole GPU units a workspace's *running*
-	// apps may hold at once (summed across apps, like MaxCPUCores). 0 = none,
-	// -1 = unlimited. A stopped app frees its units.
-	MaxGPUs int `json:"max_gpus" gorm:"not null;default:0"`
-
-	// Capabilities (feature gates). Default false for the same omission reason.
-	AllowCustomTLS            bool `json:"allow_custom_tls" gorm:"not null;default:false"`
-	AllowPrivilegedHostMounts bool `json:"allow_privileged_host_mounts" gorm:"not null;default:false"`
-	// AllowShellExec gates opening an interactive shell (docker exec) into a
-	// running application container from the panel.
-	AllowShellExec bool `json:"allow_shell_exec" gorm:"not null;default:false"`
-	// AllowSharedStorage gates creating shared-storage volumes (NFS / CIFS-SMB)
-	// that replicas can mount read-write across nodes. Node-local volumes are
-	// always allowed; this only governs the rwx backends.
-	AllowSharedStorage bool `json:"allow_shared_storage" gorm:"not null;default:false"`
-	// AllowDNSProviders gates connecting a managed DNS provider (Cloudflare/Route
-	// 53/DigitalOcean) for automated ownership verification + app records. Manual
-	// (copy-paste) DNS always works; this only governs the automation.
-	AllowDNSProviders bool `json:"allow_dns_providers" gorm:"not null;default:false"`
-	// AllowCustomLabels gates attaching user-defined Docker labels to app
-	// containers (for label-driven tools like Traefik). Off by default; the
-	// reserved-prefix protection (io.miabi.*, com.docker.*) applies regardless.
-	AllowCustomLabels bool `json:"allow_custom_labels" gorm:"not null;default:false"`
-	// AllowPlatformRunners grants this workspace's build/pipeline jobs access to
-	// the platform-shared runner pool (in addition to any runners it owns). Off by
-	// default; owned runners are always usable.
-	AllowPlatformRunners bool `json:"allow_platform_runners" gorm:"not null;default:false"`
-	// AllowCustomBuilder gates a per-app custom buildpack builder image. A custom builder runs on
-	// the runner with docker-daemon access, so it is a privileged input on shared runners; off by
-	// default, using the platform default builder.
-	AllowCustomBuilder bool `json:"allow_custom_builder" gorm:"not null;default:false"`
-	// SecurityProfile hardens how this workspace's app and job containers run: ""/"default" keeps
-	// the image's user, "restricted" forces a non-root platform UID. The "default" DB default is
-	// zero-equivalent, so GORM's zero-value omission still round-trips an intentional value.
-	SecurityProfile string `json:"security_profile" gorm:"not null;default:'default'"`
-	// AllowOfficialImageUser lets apps installed from an official marketplace template keep the
-	// image's own user even under a "restricted" SecurityProfile. Only official-source installs
-	// qualify, and it never relaxes a platform-wide MIABI_FORCE_NON_ROOT_USER mandate.
-	AllowOfficialImageUser bool `json:"allow_official_image_user" gorm:"not null;default:false"`
-	// AllowGPU gates whether this workspace's apps may request GPU devices at all. Off by
-	// default: attaching a GPU is device passthrough (privileged), so it is gated hard here and
-	// is incompatible with the restricted profile.
-	AllowGPU bool `json:"allow_gpu" gorm:"not null;default:false"`
-
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID                        uint      `json:"id" gorm:"primaryKey"`
+	Name                      string    `json:"name" gorm:"uniqueIndex;not null"`
+	Description               string    `json:"description"`
+	IsDefault                 bool      `json:"is_default" gorm:"not null;default:false"` // applied to workspaces with no plan
+	IsActive                  bool      `json:"is_active" gorm:"not null;default:true"`
+	System                    bool      `json:"system" gorm:"not null;default:false"`
+	MaxApps                   int       `json:"max_apps" gorm:"not null;default:0"`
+	MaxDatabaseInstances      int       `json:"max_database_instances" gorm:"not null;default:0"`
+	MaxCronJobs               int       `json:"max_cron_jobs" gorm:"not null;default:0"`
+	MaxVolumes                int       `json:"max_volumes" gorm:"not null;default:0"`
+	MaxNetworks               int       `json:"max_networks" gorm:"not null;default:0"`
+	MaxAPIKeys                int       `json:"max_api_keys" gorm:"not null;default:0"`
+	MaxMembers                int       `json:"max_members" gorm:"not null;default:0"`
+	MaxDatabasesPerInstance   int       `json:"max_databases_per_instance" gorm:"not null;default:0"`
+	MaxCPUCores               int       `json:"max_cpu_cores" gorm:"not null;default:0"`
+	MaxMemoryMB               int       `json:"max_memory_mb" gorm:"not null;default:0"`
+	MaxDatabaseInstanceSizeMB int       `json:"max_database_instance_size_mb" gorm:"not null;default:0"`
+	MaxStorageMB              int       `json:"max_storage_mb" gorm:"not null;default:0"`
+	MaxRunners                int       `json:"max_runners" gorm:"not null;default:0"`
+	MaxGPUs                   int       `json:"max_gpus" gorm:"not null;default:0"`
+	AllowCustomTLS            bool      `json:"allow_custom_tls" gorm:"not null;default:false"`
+	AllowPrivilegedHostMounts bool      `json:"allow_privileged_host_mounts" gorm:"not null;default:false"`
+	AllowShellExec            bool      `json:"allow_shell_exec" gorm:"not null;default:false"`
+	AllowSharedStorage        bool      `json:"allow_shared_storage" gorm:"not null;default:false"`
+	AllowDNSProviders         bool      `json:"allow_dns_providers" gorm:"not null;default:false"`
+	AllowCustomLabels         bool      `json:"allow_custom_labels" gorm:"not null;default:false"`
+	AllowPlatformRunners      bool      `json:"allow_platform_runners" gorm:"not null;default:false"`
+	AllowCustomBuilder        bool      `json:"allow_custom_builder" gorm:"not null;default:false"`
+	SecurityProfile           string    `json:"security_profile" gorm:"not null;default:'default'"`
+	AllowOfficialImageUser    bool      `json:"allow_official_image_user" gorm:"not null;default:false"`
+	AllowGPU                  bool      `json:"allow_gpu" gorm:"not null;default:false"`
+	CreatedAt                 time.Time `json:"created_at"`
+	UpdatedAt                 time.Time `json:"updated_at"`
 }
 
 // WorkspaceQuota holds per-workspace overrides applied on top of the assigned

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -369,8 +369,8 @@ func InitRoutes(app *okapi.Okapi, db *gorm.DB, redisClient *redis.Client, cfg *c
 	if sh, ok := crypto.CurrentKeyring().(workspace.KeyShredder); ok {
 		workspaceService.SetKeyShredder(sh)
 	}
-	// Seed the built-in plan catalog (Free/Pro/Unlimited) first, so EnsureSystem
-	// can pin the Miabi System workspace to the Unlimited plan. Idempotent.
+	// Seed the built-in plan catalog (Pro + the System-owned Unlimited) first, so
+	// EnsureSystem can pin the Miabi System workspace to Unlimited. Idempotent.
 	if err := dbstorage.SeedPlans(db); err != nil {
 		logger.Warn("failed to seed default plans", "error", err)
 	}

--- a/internal/storage/repositories/plan_count_test.go
+++ b/internal/storage/repositories/plan_count_test.go
@@ -31,25 +31,14 @@ func newPlanRepo(t *testing.T) *PlanRepository {
 	return NewPlanRepository(db)
 }
 
-// Count backs the edition's plan cap, so it counts the catalog an operator
-// publishes — not the platform's own plan, which nobody created and which would
-// otherwise cost them a slot.
-func TestCountExcludesSystemPlans(t *testing.T) {
+func TestCountIncludesSystemPlans(t *testing.T) {
 	repo := newPlanRepo(t)
 
 	n, err := repo.Count()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if n != 2 {
-		t.Errorf("Count() = %d, want 2 (the system plan must not count)", n)
-	}
-
-	all, err := repo.CountAll()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if all != 3 {
-		t.Errorf("CountAll() = %d, want 3", all)
+	if n != 3 {
+		t.Errorf("Count() = %d, want 3 — the system plan counts toward the cap", n)
 	}
 }

--- a/internal/storage/repositories/plan_count_test.go
+++ b/internal/storage/repositories/plan_count_test.go
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package repositories
+
+import (
+	"testing"
+
+	"github.com/miabi-io/miabi/internal/models"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newPlanRepo(t *testing.T) *PlanRepository {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&models.Plan{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	rows := []models.Plan{
+		{Name: "Pro", IsActive: true, IsDefault: true},
+		{Name: "Starter", IsActive: true},
+		{Name: models.UnlimitedPlanName, IsActive: true, System: true},
+	}
+	if err := db.Create(&rows).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	return NewPlanRepository(db)
+}
+
+// Count backs the edition's plan cap, so it counts the catalog an operator
+// publishes — not the platform's own plan, which nobody created and which would
+// otherwise cost them a slot.
+func TestCountExcludesSystemPlans(t *testing.T) {
+	repo := newPlanRepo(t)
+
+	n, err := repo.Count()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Errorf("Count() = %d, want 2 (the system plan must not count)", n)
+	}
+
+	all, err := repo.CountAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if all != 3 {
+		t.Errorf("CountAll() = %d, want 3", all)
+	}
+}

--- a/internal/storage/repositories/plan_repo.go
+++ b/internal/storage/repositories/plan_repo.go
@@ -19,8 +19,13 @@ func NewPlanRepository(db *gorm.DB) *PlanRepository { return &PlanRepository{db:
 func (r *PlanRepository) Create(p *models.Plan) error { return r.db.Create(p).Error }
 func (r *PlanRepository) Update(p *models.Plan) error { return r.db.Save(p).Error }
 
-// Count returns the number of plans in the catalog (for the edition plan cap).
 func (r *PlanRepository) Count() (int64, error) {
+	var n int64
+	err := r.db.Model(&models.Plan{}).Where("system = ?", false).Count(&n).Error
+	return n, err
+}
+
+func (r *PlanRepository) CountAll() (int64, error) {
 	var n int64
 	err := r.db.Model(&models.Plan{}).Count(&n).Error
 	return n, err

--- a/internal/storage/repositories/plan_repo.go
+++ b/internal/storage/repositories/plan_repo.go
@@ -21,12 +21,6 @@ func (r *PlanRepository) Update(p *models.Plan) error { return r.db.Save(p).Erro
 
 func (r *PlanRepository) Count() (int64, error) {
 	var n int64
-	err := r.db.Model(&models.Plan{}).Where("system = ?", false).Count(&n).Error
-	return n, err
-}
-
-func (r *PlanRepository) CountAll() (int64, error) {
-	var n int64
 	err := r.db.Model(&models.Plan{}).Count(&n).Error
 	return n, err
 }

--- a/internal/storage/seed.go
+++ b/internal/storage/seed.go
@@ -118,6 +118,7 @@ func SeedPlans(db *gorm.DB) error {
 			MaxMembers:                25,
 			MaxDatabasesPerInstance:   20,
 			MaxCPUCores:               16,
+			MaxRunners:                3,
 			MaxMemoryMB:               32768,
 			MaxDatabaseInstanceSizeMB: 51200, MaxStorageMB: 512000,
 			AllowCustomTLS: true, AllowPrivilegedHostMounts: false, AllowShellExec: true, AllowSharedStorage: true, AllowDNSProviders: true, AllowCustomLabels: true,
@@ -129,6 +130,7 @@ func SeedPlans(db *gorm.DB) error {
 			// the catalog an operator publishes.
 			Name: models.UnlimitedPlanName, Description: "No resource limits; all capabilities.", IsActive: true, System: true,
 			MaxApps: u, MaxDatabaseInstances: u, MaxCronJobs: u, MaxVolumes: u, MaxNetworks: u, MaxAPIKeys: u, MaxMembers: u,
+			MaxRunners:              3,
 			MaxDatabasesPerInstance: u, MaxCPUCores: u, MaxMemoryMB: u, MaxDatabaseInstanceSizeMB: u, MaxStorageMB: u,
 			AllowCustomTLS: true, AllowPrivilegedHostMounts: true, AllowShellExec: true, AllowSharedStorage: true, AllowDNSProviders: true, AllowCustomLabels: true,
 			AllowOfficialImageUser: true,

--- a/internal/storage/seed.go
+++ b/internal/storage/seed.go
@@ -94,7 +94,7 @@ func SeedAdmin(db *gorm.DB, email, password string) (*models.User, error) {
 
 // SeedPlans creates the built-in plan catalog on first boot if no plans exist.
 // Idempotent — a no-op once any plan is present (so admin edits are preserved).
-// Limits use -1 for unlimited, 0 for none. "Free" is the default plan.
+// Limits use -1 for unlimited, 0 for none.
 func SeedPlans(db *gorm.DB) error {
 	var n int64
 	if err := db.Model(&models.Plan{}).Count(&n).Error; err != nil {
@@ -105,14 +105,6 @@ func SeedPlans(db *gorm.DB) error {
 	}
 	const u = models.Unlimited
 	plans := []models.Plan{
-		{
-			Name: "Free", Description: "Starter limits for small workloads.", IsActive: true,
-			MaxApps: 3, MaxDatabaseInstances: 1, MaxCronJobs: 2, MaxVolumes: 3, MaxNetworks: 1, MaxAPIKeys: 2, MaxMembers: 3,
-			MaxDatabasesPerInstance: 2, MaxCPUCores: 2, MaxMemoryMB: 2048,
-			MaxDatabaseInstanceSizeMB: 2048, MaxStorageMB: 10240,
-			AllowCustomTLS: false, AllowPrivilegedHostMounts: false, AllowShellExec: false, AllowSharedStorage: false, AllowDNSProviders: false, AllowCustomLabels: false,
-			AllowPlatformRunners: true,
-		},
 		{
 			Name: "Pro", Description: "Higher limits and custom TLS for production.",
 			IsDefault:                 true,
@@ -133,7 +125,9 @@ func SeedPlans(db *gorm.DB) error {
 			AllowPlatformRunners:   true,
 		},
 		{
-			Name: models.UnlimitedPlanName, Description: "No resource limits; all capabilities.", IsActive: true,
+			// System: the platform's own plan for the system workspace, not part of
+			// the catalog an operator publishes.
+			Name: models.UnlimitedPlanName, Description: "No resource limits; all capabilities.", IsActive: true, System: true,
 			MaxApps: u, MaxDatabaseInstances: u, MaxCronJobs: u, MaxVolumes: u, MaxNetworks: u, MaxAPIKeys: u, MaxMembers: u,
 			MaxDatabasesPerInstance: u, MaxCPUCores: u, MaxMemoryMB: u, MaxDatabaseInstanceSizeMB: u, MaxStorageMB: u,
 			AllowCustomTLS: true, AllowPrivilegedHostMounts: true, AllowShellExec: true, AllowSharedStorage: true, AllowDNSProviders: true, AllowCustomLabels: true,

--- a/internal/storage/seed_plans_test.go
+++ b/internal/storage/seed_plans_test.go
@@ -39,26 +39,18 @@ func TestSeededCatalogFitsTheCommunityCap(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var counted int
-	for _, p := range plans(t, db) {
-		if !p.System {
-			counted++
-		}
+	got := len(plans(t, db))
+	if got > enterprise.CommunityPlanLimit {
+		t.Errorf("seed creates %d plans, above the Community cap of %d — a fresh install would boot over its own limit",
+			got, enterprise.CommunityPlanLimit)
 	}
-	if counted > enterprise.CommunityPlanLimit {
-		t.Errorf("seed publishes %d catalog plans, above the Community cap of %d — a fresh install would boot over its own limit",
-			counted, enterprise.CommunityPlanLimit)
-	}
-	// And it should leave room: a cap with no headroom is indistinguishable from
-	// no catalog editing at all.
-	if counted == enterprise.CommunityPlanLimit {
-		t.Errorf("seed fills the Community cap exactly (%d); an operator cannot add a plan of their own", counted)
+
+	if got >= enterprise.CommunityPlanLimit {
+		t.Errorf("seed fills the Community cap exactly (%d of %d); an operator could never add a plan of their own",
+			got, enterprise.CommunityPlanLimit)
 	}
 }
 
-// Unlimited is the platform's own plan, pinned to the system workspace. It must
-// be flagged so it does not consume a catalog slot, and must exist at all —
-// workspace.pinUnlimitedPlan looks it up by name and falls back silently.
 func TestSeededUnlimitedPlanIsASystemPlan(t *testing.T) {
 	db := seedDB(t)
 	if err := SeedPlans(db); err != nil {
@@ -75,7 +67,7 @@ func TestSeededUnlimitedPlanIsASystemPlan(t *testing.T) {
 			models.UnlimitedPlanName)
 	}
 	if !unlimited.System {
-		t.Errorf("the %s plan is not marked System, so it consumes one of the edition's catalog slots",
+		t.Errorf("the %s plan is not marked System, so nothing stops it being renamed, deleted or made the default",
 			models.UnlimitedPlanName)
 	}
 }
@@ -110,7 +102,6 @@ func TestSeedPlansIsIdempotent(t *testing.T) {
 	}
 	before := len(plans(t, db))
 
-	// An operator deletes one and adds their own.
 	if err := db.Where("name = ?", "Pro").Delete(&models.Plan{}).Error; err != nil {
 		t.Fatal(err)
 	}

--- a/internal/storage/seed_plans_test.go
+++ b/internal/storage/seed_plans_test.go
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/miabi-io/miabi/internal/enterprise"
+	"github.com/miabi-io/miabi/internal/models"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func seedDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&models.Plan{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+func plans(t *testing.T, db *gorm.DB) []models.Plan {
+	t.Helper()
+	var out []models.Plan
+	if err := db.Order("id").Find(&out).Error; err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func TestSeededCatalogFitsTheCommunityCap(t *testing.T) {
+	db := seedDB(t)
+	if err := SeedPlans(db); err != nil {
+		t.Fatal(err)
+	}
+
+	var counted int
+	for _, p := range plans(t, db) {
+		if !p.System {
+			counted++
+		}
+	}
+	if counted > enterprise.CommunityPlanLimit {
+		t.Errorf("seed publishes %d catalog plans, above the Community cap of %d — a fresh install would boot over its own limit",
+			counted, enterprise.CommunityPlanLimit)
+	}
+	// And it should leave room: a cap with no headroom is indistinguishable from
+	// no catalog editing at all.
+	if counted == enterprise.CommunityPlanLimit {
+		t.Errorf("seed fills the Community cap exactly (%d); an operator cannot add a plan of their own", counted)
+	}
+}
+
+// Unlimited is the platform's own plan, pinned to the system workspace. It must
+// be flagged so it does not consume a catalog slot, and must exist at all —
+// workspace.pinUnlimitedPlan looks it up by name and falls back silently.
+func TestSeededUnlimitedPlanIsASystemPlan(t *testing.T) {
+	db := seedDB(t)
+	if err := SeedPlans(db); err != nil {
+		t.Fatal(err)
+	}
+	var unlimited *models.Plan
+	for i, p := range plans(t, db) {
+		if p.Name == models.UnlimitedPlanName {
+			unlimited = &plans(t, db)[i]
+		}
+	}
+	if unlimited == nil {
+		t.Fatalf("the %s plan is not seeded — the system workspace would fall back to the default plan's limits",
+			models.UnlimitedPlanName)
+	}
+	if !unlimited.System {
+		t.Errorf("the %s plan is not marked System, so it consumes one of the edition's catalog slots",
+			models.UnlimitedPlanName)
+	}
+}
+
+// Every workspace with no plan lands on the default, so exactly one plan must
+// carry the flag — and it must not be the system one.
+func TestSeededCatalogHasExactlyOneDefault(t *testing.T) {
+	db := seedDB(t)
+	if err := SeedPlans(db); err != nil {
+		t.Fatal(err)
+	}
+	var defaults []string
+	for _, p := range plans(t, db) {
+		if p.IsDefault {
+			defaults = append(defaults, p.Name)
+		}
+		if p.IsDefault && p.System {
+			t.Errorf("%q is both the default and a system plan — tenants would land on the platform's own plan", p.Name)
+		}
+	}
+	if len(defaults) != 1 {
+		t.Errorf("seed has %d default plans (%v), want exactly 1", len(defaults), defaults)
+	}
+}
+
+// Seeding is a first-boot action: it must never touch a catalog an operator has
+// since edited.
+func TestSeedPlansIsIdempotent(t *testing.T) {
+	db := seedDB(t)
+	if err := SeedPlans(db); err != nil {
+		t.Fatal(err)
+	}
+	before := len(plans(t, db))
+
+	// An operator deletes one and adds their own.
+	if err := db.Where("name = ?", "Pro").Delete(&models.Plan{}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&models.Plan{Name: "Starter", IsActive: true}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SeedPlans(db); err != nil {
+		t.Fatal(err)
+	}
+	after := plans(t, db)
+	if len(after) != before {
+		t.Errorf("re-seeding changed the catalog size from %d to %d", before, len(after))
+	}
+	for _, p := range after {
+		if p.Name == "Pro" {
+			t.Error("re-seeding restored a plan the operator had deleted")
+		}
+	}
+}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -21,6 +21,11 @@ export interface Plan {
   description: string
   is_default: boolean
   is_active: boolean
+  /** A plan the platform owns rather than one the operator publishes: the
+   *  built-in Unlimited plan, pinned to the system workspace. It does not count
+   *  against the edition's plan-catalog cap, and is not meant to be assigned to
+   *  a tenant. */
+  system?: boolean
   max_apps: number
   max_database_instances: number
   max_cron_jobs: number

--- a/web/src/views/admin/PlanDetail.vue
+++ b/web/src/views/admin/PlanDetail.vue
@@ -128,7 +128,7 @@ function fmtDate(s?: string): string {
               {{ plan.name }}
               <span v-if="plan.is_default" class="badge badge-success">default</span>
               <span v-if="plan.system" class="badge badge-info"
-                title="Owned by the platform: pinned to the system workspace, and not counted against your plan limit">system</span>
+                title="Owned by the platform: pinned to the system workspace, and not yours to rename, delete or make the default">system</span>
               <span v-if="plan.is_active" class="badge badge-dot badge-success">active</span>
               <span v-else class="badge badge-dot badge-danger">inactive</span>
             </h1>

--- a/web/src/views/admin/PlanDetail.vue
+++ b/web/src/views/admin/PlanDetail.vue
@@ -127,6 +127,8 @@ function fmtDate(s?: string): string {
             <h1>
               {{ plan.name }}
               <span v-if="plan.is_default" class="badge badge-success">default</span>
+              <span v-if="plan.system" class="badge badge-info"
+                title="Owned by the platform: pinned to the system workspace, and not counted against your plan limit">system</span>
               <span v-if="plan.is_active" class="badge badge-dot badge-success">active</span>
               <span v-else class="badge badge-dot badge-danger">inactive</span>
             </h1>
@@ -134,8 +136,11 @@ function fmtDate(s?: string): string {
           </div>
         </div>
         <div class="header-actions">
-          <button v-if="!plan.is_default" class="btn btn-secondary" @click="makeDefault">Set as default</button>
-          <button class="btn btn-danger" @click="showDelete = true">Delete</button>
+          <button v-if="!plan.is_default && !plan.system" class="btn btn-secondary" @click="makeDefault">Set as default</button>
+          <!-- The system plan is the platform's own: deleting it would drop the
+               system workspace onto the default plan's limits, silently. The API
+               refuses it too — this only keeps the console from offering it. -->
+          <button v-if="!plan.system" class="btn btn-danger" @click="showDelete = true">Delete</button>
         </div>
       </div>
 
@@ -146,7 +151,11 @@ function fmtDate(s?: string): string {
           <div class="form-row">
             <div class="form-group">
               <label class="form-label">Name</label>
-              <input v-model="form.name" class="form-input" required />
+              <!-- The system plan is resolved by name when it is pinned to the
+                   system workspace, so renaming it would quietly unpin it. Its
+                   limits stay editable. -->
+              <input v-model="form.name" class="form-input" required :disabled="plan.system" />
+              <p v-if="plan.system" class="form-hint">Fixed — the platform resolves this plan by name.</p>
             </div>
             <div class="form-group">
               <label class="form-label">Description</label>
@@ -155,7 +164,8 @@ function fmtDate(s?: string): string {
           </div>
           <div class="toggles">
             <label class="checkbox-label"><input v-model="form.is_active" type="checkbox" /> Active <span class="text-muted">(assignable to workspaces)</span></label>
-            <label class="checkbox-label"><input v-model="form.is_default" type="checkbox" /> Default plan <span class="text-muted">(applied to unassigned workspaces)</span></label>
+            <label class="checkbox-label"><input v-model="form.is_default" type="checkbox" :disabled="plan.system" /> Default plan <span class="text-muted">(applied to unassigned workspaces)</span></label>
+            <p v-if="plan.system" class="form-hint">A system plan cannot be the default — unassigned workspaces would get unlimited resources.</p>
           </div>
         </div>
       </div>

--- a/web/src/views/admin/Plans.vue
+++ b/web/src/views/admin/Plans.vue
@@ -186,7 +186,7 @@ async function setDefault(p: Plan) {
                   <span class="cell-title"><RouterLink :to="`/admin/plans/${p.id}`" @click.stop>{{ p.name }}</RouterLink><span
                     v-if="p.is_default" class="badge badge-success" style="margin-left: 6px">default</span><span
                     v-if="p.system" class="badge badge-info" style="margin-left: 6px"
-                    title="Owned by the platform: pinned to the system workspace, and not counted against your plan limit">system</span></span>
+                    title="Owned by the platform: pinned to the system workspace, and not yours to rename, delete or make the default">system</span></span>
                   <span class="cell-sub">{{ p.description || '—' }}</span>
                 </div>
               </td>

--- a/web/src/views/admin/Plans.vue
+++ b/web/src/views/admin/Plans.vue
@@ -183,7 +183,10 @@ async function setDefault(p: Plan) {
             <tr v-for="p in plans" :key="p.id" class="row-clickable" @click="openDetail(p)">
               <td>
                 <div class="cell-text">
-                  <span class="cell-title"><RouterLink :to="`/admin/plans/${p.id}`" @click.stop>{{ p.name }}</RouterLink><span v-if="p.is_default" class="badge badge-success" style="margin-left: 6px">default</span></span>
+                  <span class="cell-title"><RouterLink :to="`/admin/plans/${p.id}`" @click.stop>{{ p.name }}</RouterLink><span
+                    v-if="p.is_default" class="badge badge-success" style="margin-left: 6px">default</span><span
+                    v-if="p.system" class="badge badge-info" style="margin-left: 6px"
+                    title="Owned by the platform: pinned to the system workspace, and not counted against your plan limit">system</span></span>
                   <span class="cell-sub">{{ p.description || '—' }}</span>
                 </div>
               </td>
@@ -205,7 +208,10 @@ async function setDefault(p: Plan) {
                 <span v-else class="badge badge-dot badge-danger">inactive</span>
               </td>
               <td class="text-right" @click.stop>
-                <button v-if="!p.is_default" class="btn btn-sm btn-secondary" @click="setDefault(p)">Set as default</button>
+                <!-- Never offered for a system plan: it is the platform's own, and
+                     making it the default would put every unassigned workspace on
+                     unlimited resources. -->
+                <button v-if="!p.is_default && !p.system" class="btn btn-sm btn-secondary" @click="setDefault(p)">Set as default</button>
               </td>
             </tr>
           </tbody>

--- a/web/src/views/admin/WorkspaceDetail.vue
+++ b/web/src/views/admin/WorkspaceDetail.vue
@@ -26,6 +26,15 @@ const busy = ref(false)
 const plans = ref<Plan[]>([])
 const selectedPlanId = ref<number | null>(null)
 
+// The system plan grants unlimited resources and every capability, and the
+// platform pins it to its own workspace itself — so it is not on offer here. It
+// stays listed when this workspace is already on it, so the page reports what it
+// is on rather than showing a blank; the API refuses the change either way.
+const onSystemPlan = computed(() => plans.value.some((p) => p.system && p.id === ws.value?.plan_id))
+const assignablePlans = computed(() =>
+  plans.value.filter((p) => !p.system || p.id === ws.value?.plan_id),
+)
+
 async function load() {
   loading.value = true
   try {
@@ -336,13 +345,16 @@ function eventSeverity(e: AdminEvent): string {
         <div class="card-body" style="display: flex; align-items: flex-end; gap: 12px; flex-wrap: wrap">
           <div class="form-group" style="margin-bottom: 0; flex: 1; min-width: 220px">
             <label class="form-label">Assigned plan</label>
-            <select v-model="selectedPlanId" class="form-select">
+            <select v-model="selectedPlanId" class="form-select" :disabled="onSystemPlan">
               <option :value="null">Default plan</option>
-              <option v-for="p in plans" :key="p.id" :value="p.id">{{ p.name }}{{ p.is_default ? ' (default)' : '' }}</option>
+              <option v-for="p in assignablePlans" :key="p.id" :value="p.id">{{ p.name }}{{ p.is_default ? ' (default)' : '' }}{{ p.system ? ' (system)' : '' }}</option>
             </select>
-            <p class="form-hint">Caps this workspace's resources. Enforced only when plan enforcement is enabled platform-wide.</p>
+            <p v-if="onSystemPlan" class="form-hint">
+              This is the platform's own workspace, pinned to the system plan. Miabi manages that assignment.
+            </p>
+            <p v-else class="form-hint">Caps this workspace's resources. Enforced only when plan enforcement is enabled platform-wide.</p>
           </div>
-          <button class="btn btn-primary" :disabled="busy || selectedPlanId === (ws.plan_id ?? null)" @click="assignPlan">Save</button>
+          <button class="btn btn-primary" :disabled="busy || onSystemPlan || selectedPlanId === (ws.plan_id ?? null)" @click="assignPlan">Save</button>
         </div>
       </div>
 


### PR DESCRIPTION
* feat(plans): refuse assigning the system plan to a workspace
