### PR TITLE
fix(metrics): scale resource stat units past KB and MB

### DIFF
--- a/web/src/utils/format.spec.ts
+++ b/web/src/utils/format.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { fmtSize } from './format'
+
+describe('fmtSize', () => {
+  it('scales past KB instead of reporting everything in one unit', () => {
+    expect(fmtSize(512)).toBe('512 B')
+    expect(fmtSize(1536)).toBe('1.5 KB')
+    expect(fmtSize(5 * 1024 * 1024)).toBe('5.0 MB')
+    expect(fmtSize(3 * 1024 * 1024 * 1024)).toBe('3.0 GB')
+    expect(fmtSize(2 * 1024 ** 4)).toBe('2.0 TB')
+  })
+
+  it('drops the decimal once the number is large enough to carry the precision', () => {
+    expect(fmtSize(42 * 1024 * 1024)).toBe('42 MB')
+    expect(fmtSize(750 * 1024)).toBe('750 KB')
+  })
+
+  it('handles the values a container reports before it has moved any traffic', () => {
+    expect(fmtSize(0)).toBe('0 B')
+    expect(fmtSize(undefined)).toBe('0 B')
+    expect(fmtSize(null)).toBe('0 B')
+  })
+
+  it('stops at the largest unit it knows', () => {
+    expect(fmtSize(1024 ** 6)).toBe('1024 PB')
+  })
+})

--- a/web/src/views/apps/AppDetail.vue
+++ b/web/src/views/apps/AppDetail.vue
@@ -28,6 +28,7 @@ import CanaryPanel from '@/components/CanaryPanel.vue'
 import AppAccessPanel from '@/components/AppAccessPanel.vue'
 import type { Application, AppOverview, Deployment, Release, AppEnvVar, Route, Network, Stack, Volume, StatsSample, Registry, GitRepository, AppEvent, AppPort, PortBinding, AppDatabase, ConnectionInfo, DeployStrategy, RestartPolicy, ImagePullPolicy, BuildMethod, HealthcheckType, ResourceLimits, LiveStatus, HostMountPreset, DatabaseInstance, LogicalDatabase, NodePlacement, PipelineDefinition } from '@/api/types'
 import AppModal from '@/components/AppModal.vue'
+import { fmtSize } from '@/utils/format'
 
 // Secret-reference example built here so `}}` doesn't break the template's
 // mustache parser.
@@ -1583,12 +1584,6 @@ function fmtUptime(s: number): string {
   return `${Math.floor(s / 86400)}d`
 }
 
-function fmtMB(bytes?: number) {
-  return ((bytes ?? 0) / 1048576).toFixed(0)
-}
-function fmtKB(bytes?: number) {
-  return ((bytes ?? 0) / 1024).toFixed(0)
-}
 
 // Tone for a resource-usage bar by threshold.
 function usageTone(pct: number): string {
@@ -1951,19 +1946,19 @@ async function detachDatabase(d: AppDatabase) {
         </div>
         <div class="stat-card">
           <div class="stat-header"><span class="stat-label">Memory</span><span class="stat-icon stat-icon-info"><span class="mdi mdi-memory"></span></span></div>
-          <div class="stat-value">{{ fmtMB(metrics.memory_usage_bytes) }} MB</div>
+          <div class="stat-value">{{ fmtSize(metrics.memory_usage_bytes) }}</div>
           <div class="usage-bar"><div class="usage-fill" :class="usageTone(metrics.memory_percent)" :style="{ width: Math.min(100, metrics.memory_percent) + '%' }"></div></div>
           <div class="stat-sub">
-            {{ metrics.memory_percent.toFixed(1) }}%<template v-if="metrics.memory_limit_bytes"> of {{ fmtMB(metrics.memory_limit_bytes) }} MB</template>
+            {{ metrics.memory_percent.toFixed(1) }}%<template v-if="metrics.memory_limit_bytes"> of {{ fmtSize(metrics.memory_limit_bytes) }}</template>
           </div>
         </div>
         <div class="stat-card">
           <div class="stat-header"><span class="stat-label">Net in</span><span class="stat-icon stat-icon-success"><span class="mdi mdi-download"></span></span></div>
-          <div class="stat-value">{{ fmtKB(metrics.network_rx_bytes) }} KB</div>
+          <div class="stat-value">{{ fmtSize(metrics.network_rx_bytes) }}</div>
         </div>
         <div class="stat-card">
           <div class="stat-header"><span class="stat-label">Net out</span><span class="stat-icon stat-icon-warning"><span class="mdi mdi-upload"></span></span></div>
-          <div class="stat-value">{{ fmtKB(metrics.network_tx_bytes) }} KB</div>
+          <div class="stat-value">{{ fmtSize(metrics.network_tx_bytes) }}</div>
         </div>
       </div>
       <div v-else class="card mb-4">

--- a/web/src/views/databases/DatabaseDetail.vue
+++ b/web/src/views/databases/DatabaseDetail.vue
@@ -11,6 +11,7 @@ import ConfirmDialog from '@/components/ConfirmDialog.vue'
 import MetadataCard from '@/components/MetadataCard.vue'
 import OwnerChip from '@/components/OwnerChip.vue'
 import ResourceIcon from '@/components/ResourceIcon.vue'
+import { fmtSize } from '@/utils/format'
 import { engineLogo, engineMdi } from '@/utils/resourceIcon'
 import { copyText } from '@/utils/clipboard'
 import type { DatabaseInstance, DBStatus, UpgradeProgress, LogicalDatabase, ConnectionInfo, ForwardSession, Backup, BackupSchedule, Application, Network, UpgradeOptions, UpgradePlan, StatsSample } from '@/api/types'
@@ -161,12 +162,6 @@ function stopMetricsPoll() {
 }
 
 // Resource-usage helpers (shared shape with the AppDetail overview).
-function fmtMB(bytes?: number): string {
-  return ((bytes ?? 0) / 1048576).toFixed(0)
-}
-function fmtKB(bytes?: number): string {
-  return ((bytes ?? 0) / 1024).toFixed(0)
-}
 function usageTone(pct: number): string {
   if (pct >= 90) return 'usage-danger'
   if (pct >= 70) return 'usage-warn'
@@ -735,19 +730,19 @@ onUnmounted(() => { stopStatusStream(); stopMetricsPoll(); if (backstop) clearIn
         </div>
         <div class="stat-card">
           <div class="stat-header"><span class="stat-label">Memory</span><span class="stat-icon stat-icon-info"><span class="mdi mdi-memory"></span></span></div>
-          <div class="stat-value">{{ fmtMB(metrics.memory_usage_bytes) }} MB</div>
+          <div class="stat-value">{{ fmtSize(metrics.memory_usage_bytes) }}</div>
           <div class="usage-bar"><div class="usage-fill" :class="usageTone(metrics.memory_percent)" :style="{ width: Math.min(100, metrics.memory_percent) + '%' }"></div></div>
           <div class="stat-sub">
-            {{ metrics.memory_percent.toFixed(1) }}%<template v-if="metrics.memory_limit_bytes"> of {{ fmtMB(metrics.memory_limit_bytes) }} MB</template>
+            {{ metrics.memory_percent.toFixed(1) }}%<template v-if="metrics.memory_limit_bytes"> of {{ fmtSize(metrics.memory_limit_bytes) }}</template>
           </div>
         </div>
         <div class="stat-card">
           <div class="stat-header"><span class="stat-label">Net in</span><span class="stat-icon stat-icon-success"><span class="mdi mdi-download"></span></span></div>
-          <div class="stat-value">{{ fmtKB(metrics.network_rx_bytes) }} KB</div>
+          <div class="stat-value">{{ fmtSize(metrics.network_rx_bytes) }}</div>
         </div>
         <div class="stat-card">
           <div class="stat-header"><span class="stat-label">Net out</span><span class="stat-icon stat-icon-warning"><span class="mdi mdi-upload"></span></span></div>
-          <div class="stat-value">{{ fmtKB(metrics.network_tx_bytes) }} KB</div>
+          <div class="stat-value">{{ fmtSize(metrics.network_tx_bytes) }}</div>
         </div>
       </div>
       <div v-else class="card mb-4">


### PR DESCRIPTION
The Net in / Net out and Memory cards on the application and database detail pages divided once and hardcoded the unit in the template