### PR TITLE
fix(apps): fail the volume replication guards closed

### DIFF
--- a/internal/handlers/application_handler.go
+++ b/internal/handlers/application_handler.go
@@ -619,7 +619,8 @@ func (h *ApplicationHandler) AttachVolume(c *okapi.Context, req *AttachVolumeReq
 			return c.AbortNotFound("volume not found")
 		case errors.Is(err, application.ErrMountPathRequired):
 			return c.AbortBadRequest("path is required")
-		case errors.Is(err, application.ErrNodeMismatch), errors.Is(err, application.ErrLocalVolumeReplicated):
+		case errors.Is(err, application.ErrNodeMismatch), errors.Is(err, application.ErrLocalVolumeReplicated),
+			errors.Is(err, application.ErrVolumeUnverifiable):
 			return c.AbortBadRequest(err.Error())
 		default:
 			return c.AbortInternalServerError("failed to attach volume", err)
@@ -1247,15 +1248,14 @@ func (h *ApplicationHandler) mapErr(c *okapi.Context, err error) error {
 	case errors.Is(err, application.ErrNameInvalid):
 		return c.AbortBadRequest(err.Error())
 	case errors.Is(err, application.ErrImageNotPermitted):
-		// A tenant boundary, not a malformed field: the image exists, it just isn't
-		// this workspace's to run.
 		return c.AbortForbidden(err.Error())
 	case errors.Is(err, application.ErrImageRequired), errors.Is(err, application.ErrGitRepoRequired),
 		errors.Is(err, application.ErrBuildConfigOnImage), errors.Is(err, application.ErrInvalidBuildMethod),
 		errors.Is(err, application.ErrInvalidGPUCount):
 		return c.AbortBadRequest(err.Error())
 	case errors.Is(err, application.ErrResourceCap), errors.Is(err, application.ErrClusterDisabled),
-		errors.Is(err, application.ErrLocalVolumeReplicated), errors.Is(err, application.ErrTooManyReplicas),
+		errors.Is(err, application.ErrLocalVolumeReplicated), errors.Is(err, application.ErrVolumeUnverifiable),
+		errors.Is(err, application.ErrTooManyReplicas),
 		errors.Is(err, application.ErrPortRange), errors.Is(err, models.ErrRunAsUserInvalid),
 		errors.Is(err, models.ErrRunAsUserRoot):
 		return c.AbortBadRequest(err.Error())

--- a/internal/services/application/application.go
+++ b/internal/services/application/application.go
@@ -28,6 +28,7 @@ import (
 	"github.com/miabi-io/miabi/internal/slug"
 	"github.com/miabi-io/miabi/internal/storage/repositories"
 	"github.com/miabi-io/miabi/internal/worker"
+	"gorm.io/gorm"
 )
 
 var (
@@ -67,8 +68,11 @@ var (
 	ErrNotService            = errors.New("this operation is only valid for service-runtime (cluster) applications")
 	ErrLocalVolumeReplicated = errors.New("a replicated (replicas>1) service cannot mount a node-local volume; use a shared (nfs/cifs) volume or set replicas to 1")
 	ErrHostBindService       = errors.New("a service-runtime app cannot use a privileged host mount; host paths are node-local and don't follow a rescheduled task — use the container runtime or a managed volume")
-	ErrTooManyReplicas       = fmt.Errorf("replica count exceeds the maximum of %d", MaxReplicas)
-	ErrPortRange             = errors.New("container port must be between 1 and 65535")
+	// ErrVolumeUnverifiable fails the storage guards closed. A guard that cannot read a
+	// mounted volume cannot prove it is shared, and guessing "shared" forks the data.
+	ErrVolumeUnverifiable = errors.New("a mounted volume could not be read, so it cannot be confirmed as shared storage; replication is refused until it resolves")
+	ErrTooManyReplicas    = fmt.Errorf("replica count exceeds the maximum of %d", MaxReplicas)
+	ErrPortRange          = errors.New("container port must be between 1 and 65535")
 )
 
 // MaxReplicas caps a service app's replica count so a single request can't ask
@@ -147,7 +151,7 @@ type Service struct {
 	apps         *repositories.ApplicationRepository
 	deployments  *repositories.DeploymentRepository
 	releases     *repositories.ReleaseRepository
-	volumes      *repositories.VolumeRepository
+	volumes      volumeLookup
 	routes       *repositories.RouteRepository
 	networks     *repositories.NetworkRepository
 	stacks       *repositories.StackRepository
@@ -457,6 +461,12 @@ func normalizeHealthcheck(app *models.Application) {
 	if app.HealthcheckStartPeriodSeconds < 0 {
 		app.HealthcheckStartPeriodSeconds = 0
 	}
+}
+
+// volumeLookup resolves a mounted volume within its workspace. Narrowed to the one
+// method the storage guards need so they can be tested against a fake.
+type volumeLookup interface {
+	FindInWorkspace(workspaceID, id uint) (*models.Volume, error)
 }
 
 func NewService(
@@ -1223,6 +1233,22 @@ func (s *Service) validateRuntime(app *models.Application) error {
 	return s.requireSharedStorage(app, app.Replicas)
 }
 
+// resolveMountVolume reads a mount's volume for the storage guards.
+func (s *Service) resolveMountVolume(workspaceID, volumeID uint) (*models.Volume, error) {
+	if s.volumes == nil {
+		return nil, ErrVolumeUnverifiable
+	}
+	v, err := s.volumes.FindInWorkspace(workspaceID, volumeID)
+	switch {
+	case err == nil:
+		return v, nil
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		return nil, ErrVolumeNotFound
+	default:
+		return nil, fmt.Errorf("%w (volume %d: %v)", ErrVolumeUnverifiable, volumeID, err)
+	}
+}
+
 // requireSharedStorage guards a service app's storage against the ways a scheduled swarm task and
 // node-local data diverge: a privileged host-path bind can never follow a task to another node and is
 // rejected outright, and a node-local (rwo) volume is rejected once replicas > 1. No-op for container apps.
@@ -1237,9 +1263,9 @@ func (s *Service) requireSharedStorage(app *models.Application, replicas int) er
 		if m.VolumeID == 0 || replicas <= 1 {
 			continue
 		}
-		v, err := s.volumes.FindInWorkspace(app.WorkspaceID, m.VolumeID)
+		v, err := s.resolveMountVolume(app.WorkspaceID, m.VolumeID)
 		if err != nil {
-			continue
+			return err
 		}
 		if v.AccessMode != models.AccessRWX {
 			return ErrLocalVolumeReplicated
@@ -1259,8 +1285,9 @@ func (s *Service) hasNodeLocalStorage(app *models.Application) bool {
 		if m.VolumeID == 0 {
 			continue
 		}
-		if v, err := s.volumes.FindInWorkspace(app.WorkspaceID, m.VolumeID); err == nil && v.AccessMode != models.AccessRWX {
-			return true // rwo managed volume: node-local
+		v, err := s.resolveMountVolume(app.WorkspaceID, m.VolumeID)
+		if err != nil || v.AccessMode != models.AccessRWX {
+			return true // rwo managed volume, or one we cannot read: treat as node-local
 		}
 	}
 	return false
@@ -1274,8 +1301,7 @@ func (s *Service) reconcileAutoRuntime(appID uint) {
 	if err != nil || app.Metadata[models.MetaRuntimeAutoService] != "true" {
 		return
 	}
-	// Only re-evaluate before the first release exists; after that the runtime is
-	// settled and changing it mid-life would be a disruptive surprise.
+
 	downgrade := app.CurrentReleaseID == nil && app.RuntimeKind == models.RuntimeService && s.hasNodeLocalStorage(app)
 	if downgrade {
 		app.RuntimeKind = models.RuntimeContainer
@@ -1706,9 +1732,9 @@ func (s *Service) AttachConfig(app *models.Application, configID uint, key, path
 }
 
 func (s *Service) AttachVolume(app *models.Application, volumeID uint, path string) error {
-	vol, err := s.volumes.FindInWorkspace(app.WorkspaceID, volumeID)
+	vol, err := s.resolveMountVolume(app.WorkspaceID, volumeID)
 	if err != nil {
-		return ErrVolumeNotFound
+		return err
 	}
 	// A host-path volume binds an operator-managed path present on every node, so
 	// it is node-agnostic (unlike a node-local Docker volume, which must co-locate

--- a/internal/services/application/runtime_default_test.go
+++ b/internal/services/application/runtime_default_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/miabi-io/miabi/internal/models"
+	"gorm.io/gorm"
 )
 
 // TestDefaultToServiceRuntime pins the cluster-mode create default: an unspecified runtime becomes a
@@ -67,5 +68,108 @@ func TestRequireSharedStorageHostBind(t *testing.T) {
 	}
 	if err := s.requireSharedStorage(&models.Application{RuntimeKind: models.RuntimeService}, 3); err != nil {
 		t.Fatalf("service with no mounts must be allowed, got %v", err)
+	}
+}
+
+type fakeVolumes struct {
+	byID map[uint]*models.Volume
+	err  error
+}
+
+func (f fakeVolumes) FindInWorkspace(_, id uint) (*models.Volume, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	v, ok := f.byID[id]
+	if !ok {
+		return nil, gorm.ErrRecordNotFound // what the real repository returns
+	}
+	return v, nil
+}
+
+func serviceApp(replicas int, volumeID uint) *models.Application {
+	return &models.Application{
+		RuntimeKind: models.RuntimeService,
+		WorkspaceID: 1,
+		Replicas:    replicas,
+		Mounts:      []models.AppMount{{VolumeID: volumeID, Path: "/data"}},
+	}
+}
+
+// TestRequireSharedStorageVolumeAccessMode pins the replication guard over managed
+// volumes: rwx may be replicated, rwo may not, and one replica is always fine.
+func TestRequireSharedStorageVolumeAccessMode(t *testing.T) {
+	vols := fakeVolumes{byID: map[uint]*models.Volume{
+		1: {ID: 1, AccessMode: models.AccessRWO},
+		2: {ID: 2, AccessMode: models.AccessRWX},
+	}}
+	s := &Service{volumes: vols}
+
+	if err := s.requireSharedStorage(serviceApp(3, 1), 3); !errors.Is(err, ErrLocalVolumeReplicated) {
+		t.Fatalf("rwo volume + 3 replicas = %v, want ErrLocalVolumeReplicated", err)
+	}
+	if err := s.requireSharedStorage(serviceApp(1, 1), 1); err != nil {
+		t.Fatalf("rwo volume + 1 replica must be allowed, got %v", err)
+	}
+	if err := s.requireSharedStorage(serviceApp(3, 2), 3); err != nil {
+		t.Fatalf("rwx volume + 3 replicas must be allowed, got %v", err)
+	}
+}
+
+func TestRequireSharedStorageFailsClosed(t *testing.T) {
+	cases := []struct {
+		name string
+		vols volumeLookup
+		want error
+	}{
+		{"transient lookup error", fakeVolumes{err: errors.New("connection refused")}, ErrVolumeUnverifiable},
+		{"no repository wired", nil, ErrVolumeUnverifiable},
+		{"volume row missing", fakeVolumes{byID: map[uint]*models.Volume{}}, ErrVolumeNotFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Service{volumes: tc.vols}
+			if err := s.requireSharedStorage(serviceApp(3, 1), 3); !errors.Is(err, tc.want) {
+				t.Fatalf("replicating an unreadable volume = %v, want %v", err, tc.want)
+			}
+			// One replica never consults the volume, so it stays allowed.
+			if err := s.requireSharedStorage(serviceApp(1, 1), 1); err != nil {
+				t.Fatalf("1 replica must not consult the volume, got %v", err)
+			}
+		})
+	}
+}
+
+// TestAttachVolumeDistinguishesMissingFromUnreadable pins the two failures apart on the
+// attach path, which previously reported both as "volume not found": a row that is gone
+// stays ErrVolumeNotFound (404), one that could not be read is ErrVolumeUnverifiable.
+// Both return before the app is touched, so a zero-value Service is enough.
+func TestAttachVolumeDistinguishesMissingFromUnreadable(t *testing.T) {
+	app := serviceApp(1, 1)
+	missing := &Service{volumes: fakeVolumes{byID: map[uint]*models.Volume{}}}
+	if err := missing.AttachVolume(app, 1, "/data"); !errors.Is(err, ErrVolumeNotFound) {
+		t.Fatalf("attaching a missing volume = %v, want ErrVolumeNotFound", err)
+	}
+	unreadable := &Service{volumes: fakeVolumes{err: errors.New("connection refused")}}
+	if err := unreadable.AttachVolume(app, 1, "/data"); !errors.Is(err, ErrVolumeUnverifiable) {
+		t.Fatalf("attaching an unreadable volume = %v, want ErrVolumeUnverifiable", err)
+	}
+}
+
+func TestHasNodeLocalStorageFailsClosed(t *testing.T) {
+	rwx := &Service{volumes: fakeVolumes{byID: map[uint]*models.Volume{1: {ID: 1, AccessMode: models.AccessRWX}}}}
+	if rwx.hasNodeLocalStorage(serviceApp(1, 1)) {
+		t.Fatal("an rwx volume must not count as node-local")
+	}
+	rwo := &Service{volumes: fakeVolumes{byID: map[uint]*models.Volume{1: {ID: 1, AccessMode: models.AccessRWO}}}}
+	if !rwo.hasNodeLocalStorage(serviceApp(1, 1)) {
+		t.Fatal("an rwo volume must count as node-local")
+	}
+	unreadable := &Service{volumes: fakeVolumes{err: errors.New("connection refused")}}
+	if !unreadable.hasNodeLocalStorage(serviceApp(1, 1)) {
+		t.Fatal("an unreadable volume must count as node-local")
+	}
+	if !(&Service{}).hasNodeLocalStorage(serviceApp(1, 1)) {
+		t.Fatal("a missing volume repository must count as node-local")
 	}
 }


### PR DESCRIPTION
requireSharedStorage and hasNodeLocalStorage skipped any mount whose volume could not be read, so a transient database error downgraded a data-loss guard to a no-op and let replicas > 1 through on a volume nobody had confirmed was shared. Both now resolve through one helper that refuses instead of skipping.