### PR TITLE
feat(stacks): mark member apps stale when a shared env var changes

### DIFF
--- a/internal/handlers/stack_handler.go
+++ b/internal/handlers/stack_handler.go
@@ -5,6 +5,7 @@ package handlers
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 
 	"github.com/jkaninda/okapi"
@@ -202,6 +203,35 @@ func (h *StackHandler) DeployAll(c *okapi.Context) error {
 	return ok(c, results)
 }
 
+// DeployOutdated redeploys only the member applications whose configuration has
+// moved on since their last deploy.
+func (h *StackHandler) DeployOutdated(c *okapi.Context) error {
+	id, err := h.id(c)
+	if err != nil {
+		return c.AbortBadRequest("invalid stack id")
+	}
+	wsID := middlewares.WorkspaceID(c)
+	results, err := h.svc.DeployOutdated(wsID, id)
+	if err != nil {
+		return h.mapErr(c, err)
+	}
+	h.record(c, wsID, "stack.deploy_outdated", id)
+	return ok(c, results)
+}
+
+// staleMsg tells the caller how far the change has spread: a shared env var is
+// only live once each member application is redeployed.
+func staleMsg(base string, apps int) string {
+	switch {
+	case apps == 0:
+		return base
+	case apps == 1:
+		return base + " — 1 app needs a redeploy"
+	default:
+		return fmt.Sprintf("%s — %d apps need a redeploy", base, apps)
+	}
+}
+
 // Events returns the stack's combined application activity feed.
 func (h *StackHandler) Events(c *okapi.Context) error {
 	id, err := h.id(c)
@@ -235,11 +265,12 @@ func (h *StackHandler) SetEnvVar(c *okapi.Context, req *SetStackEnvVarRequest) e
 		return c.AbortBadRequest("invalid stack id")
 	}
 	wsID := middlewares.WorkspaceID(c)
-	if err := h.svc.SetEnvVar(wsID, id, req.Body.Key, req.Body.Value, req.Body.IsSecret); err != nil {
+	stale, err := h.svc.SetEnvVar(wsID, id, req.Body.Key, req.Body.Value, req.Body.IsSecret)
+	if err != nil {
 		return h.mapErr(c, err)
 	}
 	h.record(c, wsID, "stack.env_set", id)
-	return message(c, "environment variable set")
+	return message(c, staleMsg("environment variable set", stale))
 }
 
 // ImportEnvVars bulk-upserts the stack's shared env vars from a .env block.
@@ -249,12 +280,33 @@ func (h *StackHandler) ImportEnvVars(c *okapi.Context, req *ImportEnvVarsRequest
 		return c.AbortBadRequest("invalid stack id")
 	}
 	wsID := middlewares.WorkspaceID(c)
-	n, err := h.svc.ImportEnvVars(wsID, id, req.Body.Content, req.Body.IsSecret)
+	n, stale, err := h.svc.ImportEnvVars(wsID, id, req.Body.Content, req.Body.IsSecret)
 	if err != nil {
 		return h.mapErr(c, err)
 	}
 	h.record(c, wsID, "stack.env_import", id)
-	return ok(c, map[string]any{"imported": n})
+	return ok(c, map[string]any{"imported": n, "apps_pending_redeploy": stale})
+}
+
+// RevealEnvVar returns a shared env var's decrypted value (workspace Admin only,
+// audited). Mirrors the per-app reveal: a stack secret that can only be
+// overwritten and never read back is write-only storage, not a secret store.
+func (h *StackHandler) RevealEnvVar(c *okapi.Context) error {
+	id, err := h.id(c)
+	if err != nil {
+		return c.AbortBadRequest("invalid stack id")
+	}
+	wsID := middlewares.WorkspaceID(c)
+	key := c.Param("key")
+	val, err := h.svc.RevealEnvVar(wsID, id, key)
+	if err != nil {
+		if errors.Is(err, stack.ErrEnvVarNotFound) {
+			return c.AbortNotFound("environment variable not found")
+		}
+		return h.mapErr(c, err)
+	}
+	h.record(c, wsID, "stack.env_reveal", id)
+	return ok(c, map[string]string{"key": key, "value": val})
 }
 
 // DeleteEnvVar removes a shared environment variable from the stack.
@@ -264,11 +316,12 @@ func (h *StackHandler) DeleteEnvVar(c *okapi.Context) error {
 		return c.AbortBadRequest("invalid stack id")
 	}
 	wsID := middlewares.WorkspaceID(c)
-	if err := h.svc.DeleteEnvVar(wsID, id, c.Param("key")); err != nil {
+	stale, err := h.svc.DeleteEnvVar(wsID, id, c.Param("key"))
+	if err != nil {
 		return h.mapErr(c, err)
 	}
 	h.record(c, wsID, "stack.env_delete", id)
-	return message(c, "environment variable removed")
+	return message(c, staleMsg("environment variable removed", stale))
 }
 
 // Import creates a stack and its apps from a docker-compose file.

--- a/internal/models/stack.go
+++ b/internal/models/stack.go
@@ -47,4 +47,9 @@ type StackEnvVar struct {
 	IsSecret  bool      `json:"is_secret" gorm:"not null;default:false"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
+
+	// OverriddenBy names the member applications that define the same key. An
+	// app-level variable wins, so a shared value can be inert for some members;
+	// derived on read rather than stored.
+	OverriddenBy []string `json:"overridden_by,omitempty" gorm:"-"`
 }

--- a/internal/routes/stack_routes.go
+++ b/internal/routes/stack_routes.go
@@ -121,6 +121,14 @@ func (r *Router) stackRoutes() []okapi.RouteDefinition {
 			Summary:     "Deploy all applications in a stack",
 		},
 		{
+			Method:      http.MethodPost,
+			Path:        base + "/{stackID}/deploy-outdated",
+			Group:       g,
+			Middlewares: scoped(models.WorkspaceRoleDeveloper),
+			Handler:     r.h.stack.DeployOutdated,
+			Summary:     "Deploy only the stack's applications that need a redeploy",
+		},
+		{
 			Method:      http.MethodGet,
 			Path:        base + "/{stackID}/events",
 			Group:       g,
@@ -153,6 +161,14 @@ func (r *Router) stackRoutes() []okapi.RouteDefinition {
 			Handler:     okapi.H(r.h.stack.ImportEnvVars),
 			Summary:     "Bulk-import shared env vars from .env",
 			Request:     &handlers.ImportEnvVarsRequest{},
+		},
+		{
+			Method:      http.MethodGet,
+			Path:        base + "/{stackID}/env/{key}/reveal",
+			Group:       g,
+			Middlewares: scoped(models.WorkspaceRoleAdmin),
+			Handler:     r.h.stack.RevealEnvVar,
+			Summary:     "Reveal a shared env var's value (admin)",
 		},
 		{
 			Method:      http.MethodDelete,

--- a/internal/services/marketplace/marketplace.go
+++ b/internal/services/marketplace/marketplace.go
@@ -478,7 +478,7 @@ func (s *Service) install(ctx context.Context, workspaceID uint, in InstallInput
 		}
 		secret := secretSet(m.Stack.SecretEnv)
 		for k, v := range stackEnv {
-			if err := s.stacks.SetEnvVar(workspaceID, result.Stack.ID, k, v, secret[k]); err != nil {
+			if _, err := s.stacks.SetEnvVar(workspaceID, result.Stack.ID, k, v, secret[k]); err != nil {
 				return nil, fmt.Errorf("set stack env %s: %w", k, err)
 			}
 		}

--- a/internal/services/marketplace/upgrade.go
+++ b/internal/services/marketplace/upgrade.go
@@ -465,7 +465,7 @@ func (s *Service) applyStackEnv(workspaceID uint, rec *models.TemplateInstall, o
 			res.Warnings = append(res.Warnings, fmt.Sprintf("stack env %s references data that can't be resolved on upgrade — set it manually", key))
 			continue
 		}
-		if serr := s.stacks.SetEnvVar(workspaceID, *rec.StackID, key, rendered, secret[key]); serr != nil {
+		if _, serr := s.stacks.SetEnvVar(workspaceID, *rec.StackID, key, rendered, secret[key]); serr != nil {
 			res.Warnings = append(res.Warnings, fmt.Sprintf("set stack env %s: %v", key, serr))
 			continue
 		}

--- a/internal/services/stack/env_stale_test.go
+++ b/internal/services/stack/env_stale_test.go
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package stack
+
+import (
+	"testing"
+
+	"github.com/miabi-io/miabi/internal/models"
+	"github.com/miabi-io/miabi/internal/storage/repositories"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func release(id uint) *uint { return &id }
+
+// A shared env var reaches a member's container only at deploy time, so changing
+// one must leave every already-deployed member marked — and an app that has never
+// been deployed untouched, since it has no stale container to replace.
+func TestMarkMembersStaleSkipsAppsThatNeverDeployed(t *testing.T) {
+	fake := &fakeApp{}
+	s := NewService(nil, nil, nil, nil, fake, fakeVols{}, nil, nil)
+
+	st := &models.Stack{ID: 1, Apps: []models.Application{
+		{ID: 1, Name: "web", CurrentReleaseID: release(10)},
+		{ID: 2, Name: "draft"}, // never deployed
+		{ID: 3, Name: "worker", CurrentReleaseID: release(11)},
+	}}
+
+	if n := s.markMembersStale(st); n != 2 {
+		t.Fatalf("marked %d apps, want 2", n)
+	}
+	if len(fake.marked) != 2 || fake.marked[0] != 1 || fake.marked[1] != 3 {
+		t.Fatalf("marked %v, want the two deployed apps", fake.marked)
+	}
+}
+
+func TestMarkMembersStaleOnAnEmptyStack(t *testing.T) {
+	s := NewService(nil, nil, nil, nil, &fakeApp{}, fakeVols{}, nil, nil)
+	if n := s.markMembersStale(&models.Stack{ID: 1}); n != 0 {
+		t.Fatalf("marked %d apps on an empty stack, want 0", n)
+	}
+}
+
+// Tracking staleness only pays off if acting on it is precise: a shared env change
+// must not become a reason to restart apps that are already current.
+func TestDeployAppsOutdatedOnlySkipsCurrentApps(t *testing.T) {
+	fake := &fakeApp{}
+	s := NewService(nil, nil, nil, nil, fake, fakeVols{}, nil, nil)
+
+	apps := []models.Application{
+		{ID: 1, Name: "web", RedeployRequired: true},
+		{ID: 2, Name: "worker"},
+		{ID: 3, Name: "cache", RedeployRequired: true},
+	}
+
+	results := s.deployApps(apps, true)
+	if len(results) != 2 {
+		t.Fatalf("%d deploys queued, want 2", len(results))
+	}
+	for _, id := range fake.deployed {
+		if id == 2 {
+			t.Fatal("redeployed an app that was already current")
+		}
+	}
+}
+
+func TestDeployAppsDeploysEverythingWhenNotFiltering(t *testing.T) {
+	fake := &fakeApp{}
+	s := NewService(nil, nil, nil, nil, fake, fakeVols{}, nil, nil)
+
+	apps := []models.Application{
+		{ID: 1, Name: "web", RedeployRequired: true},
+		{ID: 2, Name: "worker"},
+	}
+	if results := s.deployApps(apps, false); len(results) != 2 {
+		t.Fatalf("%d deploys queued, want 2", len(results))
+	}
+}
+
+// overridesFor needs the real application repository, so it is exercised through
+// its own sqlite fixture; app_env_vars carries no Postgres-only column defaults.
+func newOverrideService(t *testing.T) (*Service, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&models.AppEnvVar{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	s := NewService(nil, repositories.NewApplicationRepository(db), nil, nil, &fakeApp{}, fakeVols{}, nil, nil)
+	return s, db
+}
+
+// An app-level variable silently wins over the stack's, so the list has to name
+// the members a shared value will never reach.
+func TestOverridesForNamesTheAppsThatShadowAKey(t *testing.T) {
+	s, db := newOverrideService(t)
+	rows := []models.AppEnvVar{
+		{ApplicationID: 1, Key: "DATABASE_URL"},
+		{ApplicationID: 3, Key: "DATABASE_URL"},
+		{ApplicationID: 2, Key: "LOG_LEVEL"},
+	}
+	if err := db.Create(&rows).Error; err != nil {
+		t.Fatalf("seed env vars: %v", err)
+	}
+
+	st := &models.Stack{ID: 1, Apps: []models.Application{
+		{ID: 1, Name: "api"}, {ID: 2, Name: "worker"}, {ID: 3, Name: "web"},
+	}}
+
+	got := s.overridesFor(st)
+	if len(got["DATABASE_URL"]) != 2 || got["DATABASE_URL"][0] != "api" || got["DATABASE_URL"][1] != "web" {
+		t.Fatalf("DATABASE_URL overridden by %v, want [api web] in name order", got["DATABASE_URL"])
+	}
+	if len(got["LOG_LEVEL"]) != 1 || got["LOG_LEVEL"][0] != "worker" {
+		t.Fatalf("LOG_LEVEL overridden by %v, want [worker]", got["LOG_LEVEL"])
+	}
+	if _, ok := got["UNSET"]; ok {
+		t.Fatal("a key no app defines must not appear")
+	}
+}
+
+// A member outside the stack must not be reported as overriding it.
+func TestOverridesForIgnoresAppsOutsideTheStack(t *testing.T) {
+	s, db := newOverrideService(t)
+	if err := db.Create(&models.AppEnvVar{ApplicationID: 99, Key: "DATABASE_URL"}).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	st := &models.Stack{ID: 1, Apps: []models.Application{{ID: 1, Name: "api"}}}
+	if got := s.overridesFor(st); len(got) != 0 {
+		t.Fatalf("overrides = %v, want none", got)
+	}
+}
+
+func TestOverridesForOnAStackWithNoApps(t *testing.T) {
+	s, _ := newOverrideService(t)
+	if got := s.overridesFor(&models.Stack{ID: 1}); got != nil {
+		t.Fatalf("overrides = %v, want nil", got)
+	}
+}

--- a/internal/services/stack/stack.go
+++ b/internal/services/stack/stack.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/miabi-io/miabi/internal/docker"
@@ -39,6 +40,7 @@ var (
 	ErrAppInOtherStack = errors.New("application already belongs to another stack")
 	ErrInvalidAction   = errors.New("invalid stack action")
 	ErrKeyRequired     = errors.New("environment variable key is required")
+	ErrEnvVarNotFound  = errors.New("environment variable not found")
 )
 
 // AppService is the slice of *application.Service the stack service drives:
@@ -401,9 +403,18 @@ func (s *Service) DeployAll(workspaceID, stackID uint) ([]DeployResult, error) {
 	if err != nil {
 		return nil, ErrNotFound
 	}
-	results := make([]DeployResult, 0, len(st.Apps))
-	for i := range st.Apps {
-		app := &st.Apps[i]
+	return s.deployApps(st.Apps, false), nil
+}
+
+// deployApps enqueues a deploy per application, optionally skipping those already
+// current. Best-effort: one app's failure to enqueue doesn't stop the others.
+func (s *Service) deployApps(apps []models.Application, onlyOutdated bool) []DeployResult {
+	results := make([]DeployResult, 0, len(apps))
+	for i := range apps {
+		app := &apps[i]
+		if onlyOutdated && !app.RedeployRequired {
+			continue
+		}
 		res := DeployResult{AppID: app.ID, AppName: app.Name, Status: "queued"}
 		dep, derr := s.app.Deploy(app, nil, "", "")
 		if derr != nil {
@@ -413,7 +424,19 @@ func (s *Service) DeployAll(workspaceID, stackID uint) ([]DeployResult, error) {
 		}
 		results = append(results, res)
 	}
-	return results, nil
+	return results
+}
+
+// DeployOutdated enqueues a deploy for only the member applications whose
+// configuration has moved on since their last one. Preferred over DeployAll after
+// a shared env change: it leaves apps that are already current — and apps never
+// deployed at all — alone, rather than restarting a whole stack to fix part of it.
+func (s *Service) DeployOutdated(workspaceID, stackID uint) ([]DeployResult, error) {
+	st, err := s.repo.FindInWorkspaceWithApps(workspaceID, stackID)
+	if err != nil {
+		return nil, ErrNotFound
+	}
+	return s.deployApps(st.Apps, true), nil
 }
 
 // StatusCounts is an aggregate of member-app statuses for the health badge.
@@ -460,72 +483,161 @@ func (s *Service) Events(workspaceID, stackID uint, limit int) ([]models.AppEven
 	return s.events.ListByApps(ids, limit)
 }
 
-// ListEnvVars returns the stack's shared env vars (secret values masked).
+// ListEnvVars returns the stack's shared env vars (secret values masked), each
+// annotated with the member applications that shadow it.
 func (s *Service) ListEnvVars(workspaceID, stackID uint) ([]models.StackEnvVar, error) {
-	if _, err := s.repo.FindInWorkspace(workspaceID, stackID); err != nil {
+	st, err := s.repo.FindInWorkspaceWithApps(workspaceID, stackID)
+	if err != nil {
 		return nil, ErrNotFound
 	}
 	vars, err := s.env.ListByStack(stackID)
 	if err != nil {
 		return nil, err
 	}
+	overrides := s.overridesFor(st)
 	for i := range vars {
 		if vars[i].IsSecret {
 			vars[i].Value = "••••••••"
 		}
+		vars[i].OverriddenBy = overrides[vars[i].Key]
 	}
 	return vars, nil
 }
 
-// SetEnvVar upserts a shared env var on the stack (secret values encrypted).
-func (s *Service) SetEnvVar(workspaceID, stackID uint, key, value string, isSecret bool) error {
+// overridesFor maps each key to the member applications that define it themselves.
+// An app-level variable wins over the stack's, so without this a shared value can
+// be set, seen in the list, and quietly ignored by the app it was meant for.
+func (s *Service) overridesFor(st *models.Stack) map[string][]string {
+	if len(st.Apps) == 0 {
+		return nil
+	}
+	ids := make([]uint, 0, len(st.Apps))
+	names := make(map[uint]string, len(st.Apps))
+	for i := range st.Apps {
+		app := &st.Apps[i]
+		ids = append(ids, app.ID)
+		names[app.ID] = app.Name
+	}
+	owners, err := s.apps.EnvKeyOwners(ids)
+	if err != nil {
+		return nil // annotation is advisory; the list is still correct without it
+	}
+	out := make(map[string][]string, len(owners))
+	for key, appIDs := range owners {
+		for _, id := range appIDs {
+			if n := names[id]; n != "" {
+				out[key] = append(out[key], n)
+			}
+		}
+		sort.Strings(out[key])
+	}
+	return out
+}
+
+// RevealEnvVar returns a shared env var's decrypted value. Mirrors the per-app
+// reveal: list and set are lower-privileged, but reading a secret's plaintext is
+// gated to workspace admins by the route and audited by the handler.
+func (s *Service) RevealEnvVar(workspaceID, stackID uint, key string) (string, error) {
 	if _, err := s.repo.FindInWorkspace(workspaceID, stackID); err != nil {
-		return ErrNotFound
+		return "", ErrNotFound
+	}
+	vars, err := s.env.ListByStack(stackID)
+	if err != nil {
+		return "", err
+	}
+	for _, v := range vars {
+		if v.Key == key {
+			if v.IsSecret {
+				return crypto.Decrypt(v.Value)
+			}
+			return v.Value, nil
+		}
+	}
+	return "", ErrEnvVarNotFound
+}
+
+// SetEnvVar upserts a shared env var on the stack (secret values encrypted) and
+// returns how many member applications it left needing a redeploy.
+func (s *Service) SetEnvVar(workspaceID, stackID uint, key, value string, isSecret bool) (int, error) {
+	st, err := s.repo.FindInWorkspaceWithApps(workspaceID, stackID)
+	if err != nil {
+		return 0, ErrNotFound
 	}
 	key = strings.TrimSpace(key)
 	if key == "" {
-		return ErrKeyRequired
+		return 0, ErrKeyRequired
 	}
 	stored := value
 	if isSecret {
 		enc, err := crypto.EncryptWS(workspaceID, value)
 		if err != nil {
-			return err
+			return 0, err
 		}
 		stored = enc
 	}
-	return s.env.Upsert(&models.StackEnvVar{StackID: stackID, Key: key, Value: stored, IsSecret: isSecret})
+	if err := s.env.Upsert(&models.StackEnvVar{StackID: stackID, Key: key, Value: stored, IsSecret: isSecret}); err != nil {
+		return 0, err
+	}
+	return s.markMembersStale(st), nil
 }
 
-// ImportEnvVars bulk-upserts shared env vars from .env-style content,
-// encrypting them when isSecret. Returns the number set.
-func (s *Service) ImportEnvVars(workspaceID, stackID uint, content string, isSecret bool) (int, error) {
-	if _, err := s.repo.FindInWorkspace(workspaceID, stackID); err != nil {
-		return 0, ErrNotFound
+// markMembersStale flags every already-deployed member application as needing a
+// redeploy, and reports how many it flagged.
+//
+// A stack env var is injected into each member's container at deploy time, so
+// changing one leaves every running member behind its own configuration. Without
+// this the drift is invisible until something unrelated triggers a deploy.
+func (s *Service) markMembersStale(st *models.Stack) int {
+	n := 0
+	for i := range st.Apps {
+		// An app that has never been deployed has no stale container to replace;
+		// MarkRedeployRequired reports that by marking nothing.
+		if marked, err := s.app.MarkRedeployRequired(&st.Apps[i]); err == nil && marked {
+			n++
+		}
+	}
+	return n
+}
+
+// ImportEnvVars bulk-upserts shared env vars from .env-style content, encrypting
+// them when isSecret. Returns the number set and how many member applications
+// were left needing a redeploy.
+func (s *Service) ImportEnvVars(workspaceID, stackID uint, content string, isSecret bool) (imported, stale int, err error) {
+	st, err := s.repo.FindInWorkspaceWithApps(workspaceID, stackID)
+	if err != nil {
+		return 0, 0, ErrNotFound
 	}
 	pairs := dotenv.Parse(content)
 	for _, p := range pairs {
 		stored := p.Value
 		if isSecret {
-			enc, err := crypto.EncryptWS(workspaceID, p.Value)
-			if err != nil {
-				return 0, err
+			enc, encErr := crypto.EncryptWS(workspaceID, p.Value)
+			if encErr != nil {
+				return 0, 0, encErr
 			}
 			stored = enc
 		}
-		if err := s.env.Upsert(&models.StackEnvVar{StackID: stackID, Key: p.Key, Value: stored, IsSecret: isSecret}); err != nil {
-			return 0, err
+		if uerr := s.env.Upsert(&models.StackEnvVar{StackID: stackID, Key: p.Key, Value: stored, IsSecret: isSecret}); uerr != nil {
+			return 0, 0, uerr
 		}
 	}
-	return len(pairs), nil
+	if len(pairs) == 0 {
+		return 0, 0, nil
+	}
+	return len(pairs), s.markMembersStale(st), nil
 }
 
-// DeleteEnvVar removes a shared env var from the stack.
-func (s *Service) DeleteEnvVar(workspaceID, stackID uint, key string) error {
-	if _, err := s.repo.FindInWorkspace(workspaceID, stackID); err != nil {
-		return ErrNotFound
+// DeleteEnvVar removes a shared env var from the stack and returns how many
+// member applications it left needing a redeploy.
+func (s *Service) DeleteEnvVar(workspaceID, stackID uint, key string) (int, error) {
+	st, err := s.repo.FindInWorkspaceWithApps(workspaceID, stackID)
+	if err != nil {
+		return 0, ErrNotFound
 	}
-	return s.env.Delete(stackID, key)
+	if err := s.env.Delete(stackID, key); err != nil {
+		return 0, err
+	}
+	return s.markMembersStale(st), nil
 }
 
 // IDByUID resolves a stack's portable uid to its numeric id.

--- a/internal/services/stack/stack_test.go
+++ b/internal/services/stack/stack_test.go
@@ -16,9 +16,11 @@ import (
 // the stack.AppService interface (lifecycle methods used here, the rest are
 // no-ops for these tests).
 type fakeApp struct {
-	errByID map[uint]error
-	stops   []uint
-	waited  []uint
+	errByID  map[uint]error
+	stops    []uint
+	waited   []uint
+	marked   []uint
+	deployed []uint
 }
 
 func (f *fakeApp) Start(_ context.Context, app *models.Application) (*models.Deployment, error) {
@@ -36,9 +38,18 @@ func (f *fakeApp) WaitRunning(_ context.Context, app *models.Application) error 
 	return nil
 }
 func (f *fakeApp) Deploy(app *models.Application, _ *uint, _ string, _ models.DeployStrategy) (*models.Deployment, error) {
+	f.deployed = append(f.deployed, app.ID)
 	return &models.Deployment{ApplicationID: app.ID}, nil
 }
+
+// MarkRedeployRequired mirrors the real one: an app that has never been deployed
+// has no stale container, so nothing is marked.
 func (f *fakeApp) MarkRedeployRequired(app *models.Application) (bool, error) {
+	if app.CurrentReleaseID == nil {
+		return false, nil
+	}
+	app.RedeployRequired = true
+	f.marked = append(f.marked, app.ID)
 	return true, nil
 }
 func (f *fakeApp) Delete(_ context.Context, _ *models.Application) error { return nil }

--- a/internal/services/wsbackup/restore.go
+++ b/internal/services/wsbackup/restore.go
@@ -539,7 +539,7 @@ func (r *restoreRun) applyStacks(ctx context.Context) {
 			continue
 		}
 		for _, e := range k.Env {
-			if err := r.svc.Stack.SetEnvVar(r.target, created.ID, e.Key, e.Value, e.IsSecret); err != nil {
+			if _, err := r.svc.Stack.SetEnvVar(r.target, created.ID, e.Key, e.Value, e.IsSecret); err != nil {
 				logger.Warn("bundle: could not restore stack env", "stack", k.Name, "key", e.Key, "error", err)
 			}
 		}

--- a/internal/storage/repositories/application_repo.go
+++ b/internal/storage/repositories/application_repo.go
@@ -268,6 +268,25 @@ func (r *ApplicationRepository) ListEnvVars(appID uint) ([]models.AppEnvVar, err
 	return vars, err
 }
 
+// EnvKeyOwners maps each env-var key defined by the given applications to the ids
+// of the applications defining it. One query, so showing which stack variables a
+// member shadows does not cost a round trip per app.
+func (r *ApplicationRepository) EnvKeyOwners(appIDs []uint) (map[string][]uint, error) {
+	out := map[string][]uint{}
+	if len(appIDs) == 0 {
+		return out, nil
+	}
+	var rows []models.AppEnvVar
+	if err := r.db.Select("application_id", "key").
+		Where("application_id IN ?", appIDs).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	for _, v := range rows {
+		out[v.Key] = append(out[v.Key], v.ApplicationID)
+	}
+	return out, nil
+}
+
 // IDByUID resolves an application's uid to its numeric id.
 func (r *ApplicationRepository) IDByUID(uid string) (uint, error) {
 	return idByUID[models.Application](r.db, uid)

--- a/web/src/api/stacks.ts
+++ b/web/src/api/stacks.ts
@@ -52,12 +52,22 @@ export const stackApi = {
   restart: (ws: number, id: number, rolling = false) =>
     api.post<ApiResponse<StackActionResult[]>>(`${base(ws)}/${id}/restart${rolling ? '?rolling=true' : ''}`),
   deploy: (ws: number, id: number) => api.post<ApiResponse<StackDeployResult[]>>(`${base(ws)}/${id}/deploy`),
+  // Deploy only the members whose configuration has moved on since their last one.
+  deployOutdated: (ws: number, id: number) =>
+    api.post<ApiResponse<StackDeployResult[]>>(`${base(ws)}/${id}/deploy-outdated`),
   events: (ws: number, id: number) => api.get<ApiResponse<AppEvent[]>>(`${base(ws)}/${id}/events`),
   envVars: (ws: number, id: number) => api.get<ApiResponse<StackEnvVar[]>>(`${base(ws)}/${id}/env`),
   setEnvVar: (ws: number, id: number, key: string, value: string, isSecret: boolean) =>
     api.put<ApiResponse<{ message: string }>>(`${base(ws)}/${id}/env`, { key, value, is_secret: isSecret }),
   importEnvVars: (ws: number, id: number, content: string, isSecret: boolean) =>
-    api.post<ApiResponse<{ imported: number }>>(`${base(ws)}/${id}/env/import`, { content, is_secret: isSecret }),
+    api.post<ApiResponse<{ imported: number; apps_pending_redeploy: number }>>(
+      `${base(ws)}/${id}/env/import`, { content, is_secret: isSecret },
+    ),
+  // Admin-only and audited, mirroring the per-app reveal.
+  revealEnvVar: (ws: number, id: number, key: string) =>
+    api.get<ApiResponse<{ key: string; value: string }>>(
+      `${base(ws)}/${id}/env/${encodeURIComponent(key)}/reveal`,
+    ),
   deleteEnvVar: (ws: number, id: number, key: string) =>
     api.delete<ApiResponse<{ message: string }>>(`${base(ws)}/${id}/env/${encodeURIComponent(key)}`),
   remove: (ws: number, id: number, withApps = false) =>

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -1113,6 +1113,8 @@ export interface StackEnvVar {
   key: string
   value: string
   is_secret: boolean
+  /** Member apps that define the same key; their value wins over the stack's. */
+  overridden_by?: string[]
 }
 
 export interface Stack {

--- a/web/src/views/stacks/StackDetail.vue
+++ b/web/src/views/stacks/StackDetail.vue
@@ -6,6 +6,7 @@ import { useNotificationStore } from '@/stores/notification'
 import { stackApi, type StackActionResult } from '@/api/stacks'
 import { appApi } from '@/api/apps'
 import type { Stack, Application, StackEnvVar, AppEvent } from '@/api/types'
+import { useWorkspaceStream } from '@/views/dashboard/useWorkspaceStream'
 import MetadataCard from '@/components/MetadataCard.vue'
 import EnvVarModal from '@/components/EnvVarModal.vue'
 import ConfirmDialog from '@/components/ConfirmDialog.vue'
@@ -37,6 +38,9 @@ const showEnvModal = ref(false)
 const editingEnvKey = ref<string | null>(null)
 const envForm = ref({ key: '', value: '', secret: false })
 const savingEnv = ref(false)
+// Revealed secret values, keyed by variable name; mirrors the per-app reveal.
+const revealedEnv = ref<Record<string, string>>({})
+const revealingEnv = ref('')
 const showEnvImport = ref(false)
 const envImport = ref({ content: '', secret: false })
 const importingEnv = ref(false)
@@ -58,21 +62,43 @@ function aggregateClass() {
   return 'badge-warning'
 }
 
-async function load() {
+// silent is used by the live reconcile: a background refresh must not blank the
+// page behind a spinner.
+async function load(silent = false) {
   if (!wid.value) return
-  loading.value = true
+  if (!silent) loading.value = true
   try {
     stack.value = (await stackApi.get(wid.value, stackId.value)).data.data
     allApps.value = (await appApi.list(wid.value)).data.data ?? []
     envVars.value = (await stackApi.envVars(wid.value, stackId.value)).data.data ?? []
+    if (!silent) revealedEnv.value = {}
     events.value = (await stackApi.events(wid.value, stackId.value)).data.data ?? []
   } catch (e) {
-    notify.apiError(e)
+    if (!silent) notify.apiError(e)
   } finally {
     loading.value = false
   }
 }
-watch([stackId, wid], load, { immediate: true })
+
+// Deploys are enqueued, not applied inline: the worker clears redeploy_required
+// long after the request returns, so without the event stream the page stays
+// stale until a manual refresh. Only a member's activity earns a refetch.
+let memberActivity = false
+const { open: openStream } = useWorkspaceStream(() => {
+  if (!memberActivity) return
+  memberActivity = false
+  load(true)
+})
+
+watch([stackId, wid], ([, id]) => {
+  load()
+  openStream(id ?? null, (e) => {
+    if (!(stack.value?.apps ?? []).some((a) => a.id === e.application_id)) return
+    memberActivity = true
+    // Prepend for immediacy; the reconcile a moment later replaces the list.
+    if (!events.value.some((x) => x.id === e.id)) events.value = [e, ...events.value].slice(0, 30)
+  })
+}, { immediate: true })
 
 function summarize(results: StackActionResult[], verb: string) {
   const ok = results.filter((r) => r.status === 'ok').length
@@ -93,6 +119,26 @@ async function lifecycle(action: 'start' | 'stop' | 'restart', rolling = false) 
         ? (await stackApi.restart(wid.value, stackId.value, rolling)).data.data ?? []
         : (await stackApi[action](wid.value, stackId.value)).data.data ?? []
     summarize(results, action === 'start' ? 'started' : action === 'stop' ? 'stopped' : 'restarted')
+    load()
+  } catch (e) {
+    notify.apiError(e)
+  } finally {
+    busyAction.value = ''
+  }
+}
+
+// A shared env var only reaches a container at deploy time, so a member deployed
+// before the change is running stale configuration until it is redeployed.
+const outdated = computed(() => (stack.value?.apps ?? []).filter((a) => a.redeploy_required))
+
+async function deployOutdated() {
+  if (!wid.value || busyAction.value) return
+  busyAction.value = 'deploy-outdated'
+  try {
+    const results = (await stackApi.deployOutdated(wid.value, stackId.value)).data.data ?? []
+    const queued = results.filter((r) => r.status === 'queued').length
+    const failed = results.filter((r) => r.status === 'failed').length
+    notify[failed ? 'error' : 'success'](`${queued} deploy${queued === 1 ? '' : 's'} queued${failed ? `, ${failed} failed` : ''}`)
     load()
   } catch (e) {
     notify.apiError(e)
@@ -193,14 +239,34 @@ async function saveEnv(v: { key: string; value: string; secret: boolean }) {
   if (!wid.value || !v.key) return
   savingEnv.value = true
   try {
-    await stackApi.setEnvVar(wid.value, stackId.value, v.key, v.value, v.secret)
-    notify.success((editingEnvKey.value ? 'Variable updated' : 'Variable added') + ' — applies on each app’s next deploy')
+    const res = (await stackApi.setEnvVar(wid.value, stackId.value, v.key, v.value, v.secret)).data.data
+    notify.success(res.message)
     showEnvModal.value = false
     envVars.value = (await stackApi.envVars(wid.value, stackId.value)).data.data ?? []
+    load() // refresh the members' redeploy_required for the banner and badges
   } catch (e) {
     notify.apiError(e)
   } finally {
     savingEnv.value = false
+  }
+}
+
+async function toggleReveal(v: StackEnvVar) {
+  if (revealedEnv.value[v.key] !== undefined) {
+    const next = { ...revealedEnv.value }
+    delete next[v.key]
+    revealedEnv.value = next
+    return
+  }
+  if (!wid.value) return
+  revealingEnv.value = v.key
+  try {
+    const value = (await stackApi.revealEnvVar(wid.value, stackId.value, v.key)).data.data.value
+    revealedEnv.value = { ...revealedEnv.value, [v.key]: value }
+  } catch (err) {
+    notify.apiError(err, 'Failed to reveal value')
+  } finally {
+    revealingEnv.value = ''
   }
 }
 
@@ -209,6 +275,7 @@ async function deleteEnv(key: string) {
   try {
     await stackApi.deleteEnvVar(wid.value, stackId.value, key)
     envVars.value = envVars.value.filter((v) => v.key !== key)
+    load()
   } catch (e) {
     notify.apiError(e)
   }
@@ -219,10 +286,15 @@ async function importEnv() {
   importingEnv.value = true
   try {
     const res = (await stackApi.importEnvVars(wid.value, stackId.value, envImport.value.content, envImport.value.secret)).data.data
-    notify.success(`Imported ${res?.imported ?? 0} variable(s)`)
+    const pending = res?.apps_pending_redeploy ?? 0
+    notify.success(
+      `Imported ${res?.imported ?? 0} variable(s)` +
+      (pending ? ` — ${pending} app${pending === 1 ? '' : 's'} need${pending === 1 ? 's' : ''} a redeploy` : ''),
+    )
     showEnvImport.value = false
     envImport.value = { content: '', secret: false }
     envVars.value = (await stackApi.envVars(wid.value, stackId.value)).data.data ?? []
+    load()
   } catch (e) {
     notify.apiError(e)
   } finally {
@@ -316,6 +388,25 @@ const appName = (id: number) => allApps.value.find((a) => a.id === id)?.name ?? 
           <span class="mdi mdi-plus"></span> Add application
         </button>
       </div>
+      <!-- A shared env var reaches a container only at deploy time, so say plainly
+           which members are still running the old values and offer the fix. -->
+      <div v-if="outdated.length" class="stale-banner">
+        <span class="mdi mdi-alert-outline"></span>
+        <span class="stale-text">
+          <strong>{{ outdated.length }}</strong>
+          {{ outdated.length === 1 ? 'application is' : 'applications are' }} running configuration
+          older than this stack's. Redeploy to apply the shared environment.
+        </span>
+        <button
+          v-if="ws.canEdit"
+          class="btn btn-sm btn-primary"
+          :disabled="!!busyAction"
+          @click="deployOutdated"
+        >
+          {{ busyAction === 'deploy-outdated' ? 'Deploying…' : `Redeploy ${outdated.length}` }}
+        </button>
+      </div>
+
       <div v-if="loading && !stack.apps" class="card-body"><span class="spinner"></span></div>
       <div v-else-if="!stack.apps || stack.apps.length === 0" class="empty-state">
         <span class="mdi mdi-cube-outline" style="font-size: 44px; color: var(--text-muted)"></span>
@@ -331,7 +422,16 @@ const appName = (id: number) => allApps.value.find((a) => a.id === id)?.name ?? 
                 <div class="cell-id">
                   <span class="avatar avatar-sm">{{ (a.display_name || a.name).charAt(0).toUpperCase() }}</span>
                   <span class="cell-text">
-                    <span class="cell-title">{{ a.display_name || a.name }}</span>
+                    <span class="cell-title">
+                      {{ a.display_name || a.name }}
+                      <span
+                        v-if="a.redeploy_required"
+                        class="badge badge-warning"
+                        title="Configuration changed since this app was last deployed — redeploy to apply it"
+                      >
+                        <span class="mdi mdi-alert-outline"></span> Redeploy required
+                      </span>
+                    </span>
                     <span class="cell-sub">{{ a.name }}</span>
                   </span>
                 </div>
@@ -363,9 +463,40 @@ const appName = (id: number) => allApps.value.find((a) => a.id === id)?.name ?? 
         <table v-if="envVars.length" style="margin-bottom: 12px">
           <tbody>
             <tr v-for="v in envVars" :key="v.id">
-              <td class="cell-title" style="font-family: monospace">{{ v.key }}</td>
-              <td class="cell-sub" style="font-family: monospace">{{ v.is_secret ? '••••••••' : v.value }}</td>
+              <td class="cell-title" style="font-family: monospace">
+                {{ v.key }}
+                <span v-if="v.is_secret" class="badge badge-neutral env-tag" title="Encrypted at rest">
+                  <span class="mdi mdi-lock-outline"></span> secret
+                </span>
+                <!-- An app's own variable wins, so a shared value can be set here
+                     and never reach the app it was meant for. -->
+                <span
+                  v-if="v.overridden_by?.length"
+                  class="badge badge-warning env-tag"
+                  :title="`Overridden by ${v.overridden_by.join(', ')} — these apps define their own ${v.key} and will ignore this value`"
+                >
+                  <span class="mdi mdi-arrow-down-bold-outline"></span>
+                  overridden in {{ v.overridden_by.join(', ') }}
+                </span>
+              </td>
+              <td class="cell-sub" style="font-family: monospace">
+                <template v-if="v.is_secret">
+                  <code v-if="revealedEnv[v.key] !== undefined">{{ revealedEnv[v.key] }}</code>
+                  <span v-else aria-label="Hidden secret value">••••••••</span>
+                </template>
+                <code v-else>{{ v.value }}</code>
+              </td>
               <td class="text-right">
+                <button
+                  v-if="v.is_secret && ws.isWorkspaceAdmin"
+                  class="btn-icon btn-icon-muted"
+                  :title="revealedEnv[v.key] !== undefined ? 'Hide value' : 'Reveal value'"
+                  :aria-label="revealedEnv[v.key] !== undefined ? 'Hide value' : 'Reveal value'"
+                  :disabled="revealingEnv === v.key"
+                  @click="toggleReveal(v)"
+                >
+                  <span class="mdi" :class="revealingEnv === v.key ? 'mdi-loading mdi-spin' : (revealedEnv[v.key] !== undefined ? 'mdi-eye-off-outline' : 'mdi-eye-outline')"></span>
+                </button>
                 <button v-if="ws.canEdit" class="btn-icon btn-icon-muted" title="Edit" aria-label="Edit" @click="openEnvEdit(v)"><span class="mdi mdi-pencil-outline"></span></button>
                 <button v-if="ws.canEdit" class="btn-icon btn-icon-danger" title="Delete" aria-label="Delete" @click="deleteEnv(v.key)"><span class="mdi mdi-delete-outline"></span></button>
               </td>
@@ -529,6 +660,34 @@ const appName = (id: number) => allApps.value.find((a) => a.id === id)?.name ?? 
 </template>
 
 <style scoped>
+.env-tag {
+  margin-left: 6px;
+  font-family: var(--font-sans, sans-serif);
+  font-weight: 500;
+  vertical-align: middle;
+}
+
+.stale-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border-primary);
+  background: var(--warning-50, var(--bg-secondary));
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.stale-banner > .mdi {
+  font-size: 18px;
+  color: var(--warning-600);
+  flex-shrink: 0;
+}
+
+.stale-text {
+  flex: 1;
+}
+
 .text-muted { color: var(--text-muted); }
 .header-divider { width: 1px; height: 22px; background: var(--border-secondary); margin: 0 4px; }
 .form-hint code { background: var(--bg-tertiary); padding: 1px 6px; border-radius: 4px; }


### PR DESCRIPTION
feat(stacks): name the apps that override a shared env var
feat(stacks): reveal a shared secret's value (admin)
fix(web): settle the stack page after a deploy without a refresh