### PR TITLE
feat(clusters): retire port-forward connectivity

### DIFF
--- a/cmd/miabi/server.go
+++ b/cmd/miabi/server.go
@@ -290,7 +290,7 @@ func runServer(cli *okapicli.CLI) {
 			// The embedded deploy worker re-syncs Goma, so its route service must apply the same
 			// domain-verification gate (and privileged-workspace waiver) as the HTTP service, or a
 			// deploy would re-render unverified or banned routes as live.
-			deployRouteSvc := route.NewService(repositories.NewRouteRepository(res.db), repositories.NewMiddlewareRepository(res.db), repositories.NewApplicationRepository(res.db), repositories.NewReleaseRepository(res.db), serverRepo, repositories.NewPortBindingRepository(res.db), proxyMgr, cfg.HostPortMin, cfg.HostPortMax)
+			deployRouteSvc := route.NewService(repositories.NewRouteRepository(res.db), repositories.NewMiddlewareRepository(res.db), repositories.NewApplicationRepository(res.db), repositories.NewReleaseRepository(res.db), serverRepo, proxyMgr)
 			deployRouteSvc.SetDomains(repositories.NewDomainRepository(res.db))
 			deployRouteSvc.SetWorkspacePolicy(repositories.NewWorkspaceRepository(res.db))
 			deployHandler := worker.NewDeployHandler(

--- a/cmd/miabi/worker.go
+++ b/cmd/miabi/worker.go
@@ -111,7 +111,7 @@ func runWorker() error {
 	// The worker re-syncs Goma on deploy, so its route service must apply the same
 	// domain-verification gate as the API server — otherwise a deploy would re-render
 	// unverified or banned routes as live.
-	workerRouteSvc := route.NewService(repositories.NewRouteRepository(db), repositories.NewMiddlewareRepository(db), appRepo, repositories.NewReleaseRepository(db), repositories.NewServerRepository(db), repositories.NewPortBindingRepository(db), proxyMgr, cfg.HostPortMin, cfg.HostPortMax)
+	workerRouteSvc := route.NewService(repositories.NewRouteRepository(db), repositories.NewMiddlewareRepository(db), appRepo, repositories.NewReleaseRepository(db), repositories.NewServerRepository(db), proxyMgr)
 	workerRouteSvc.SetDomains(repositories.NewDomainRepository(db))
 	workerRouteSvc.SetWorkspacePolicy(repositories.NewWorkspaceRepository(db))
 	deployHandler := worker.NewDeployHandler(

--- a/internal/handlers/cluster_handler.go
+++ b/internal/handlers/cluster_handler.go
@@ -22,9 +22,10 @@ import (
 // Docker Swarm. Swarm routes under /admin/clusters/{clusterID} target that cluster; the legacy
 // /admin/cluster routes target the default one. On plain Docker they report "not enabled".
 type ClusterHandler struct {
-	cluster *cluster.Service
-	nodes   *node.Service
-	audit   *audit.Logger
+	cluster           *cluster.Service
+	nodes             *node.Service
+	audit             *audit.Logger
+	applyConnectivity ConnectivityApplier
 }
 
 func NewClusterHandler(c *cluster.Service, n *node.Service, auditLog *audit.Logger) *ClusterHandler {

--- a/internal/handlers/clusters_handler.go
+++ b/internal/handlers/clusters_handler.go
@@ -4,12 +4,20 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 
 	"github.com/jkaninda/okapi"
 	"github.com/miabi-io/miabi/internal/models"
 	"github.com/miabi-io/miabi/internal/services/cluster"
+	"github.com/miabi-io/miabi/internal/services/node"
 )
+
+// ConnectivityApplier deploys or tears down a node's gateway after its connectivity changed.
+type ConnectivityApplier func(ctx context.Context, prev, srv *models.Server)
+
+// SetConnectivityApplier wires the node gateway lifecycle used by ConvertIngress.
+func (h *ClusterHandler) SetConnectivityApplier(fn ConnectivityApplier) { h.applyConnectivity = fn }
 
 // ListClusters returns every cluster, the default first, with its node count.
 func (h *ClusterHandler) ListClusters(c *okapi.Context) error {
@@ -101,6 +109,63 @@ func (h *ClusterHandler) SetClusterGateway(c *okapi.Context, req *SetClusterGate
 	return ok(c, cl)
 }
 
+// ConvertIngressRequest settles how a standalone cluster's node serves its apps.
+type ConvertIngressRequest struct {
+	Body struct {
+		// Action "gateway" serves them through the node's own gateway; "join" joins the node to a swarm
+		// cluster as a worker, whose gateway then serves them.
+		Action          string `json:"action" required:"true" enum:"gateway,join"`
+		TargetClusterID uint   `json:"target_cluster_id"`
+	} `json:"body"`
+}
+
+// ConvertIngress gives a standalone cluster's node a gateway to serve its apps: its own, or a swarm's.
+func (h *ClusterHandler) ConvertIngress(c *okapi.Context, req *ConvertIngressRequest) error {
+	id, err := resolveID(c.Param("clusterID"), h.cluster.ClusterIDByUID)
+	if err != nil {
+		return c.AbortBadRequest("invalid cluster id")
+	}
+	cl, err := h.cluster.Cluster(id)
+	if err != nil {
+		return h.mapClusterErr(c, err)
+	}
+	if cl.IsDefault || cl.Mode != models.ClusterModeStandalone {
+		return c.AbortBadRequest("only a standalone cluster's node can be converted")
+	}
+	prev, err := h.nodes.Get(cl.ManagerServerID)
+	if err != nil {
+		return c.AbortNotFound("node not found")
+	}
+	ctx := c.Request().Context()
+	served, connectivity := cl.ID, models.ConnectivityEdgeGateway
+	if req.Body.Action == "join" {
+		if req.Body.TargetClusterID == 0 {
+			return c.AbortBadRequest("choose the swarm cluster to join")
+		}
+		if err := h.cluster.JoinNode(ctx, req.Body.TargetClusterID, prev.ID); err != nil {
+			return h.mapErr(c, err, "failed to join the node")
+		}
+		served, connectivity = req.Body.TargetClusterID, models.ConnectivityCluster
+	}
+	if prev.Connectivity != connectivity {
+		srv, err := h.nodes.SetConnectivity(prev.ID, connectivity)
+		if err != nil {
+			return h.mapClusterErr(c, err)
+		}
+		if h.applyConnectivity != nil {
+			h.applyConnectivity(ctx, prev, srv)
+		}
+	}
+	if req.Body.Action == "gateway" {
+		if err := h.cluster.ConfirmGateway(cl.ID); err != nil {
+			return h.mapClusterErr(c, err)
+		}
+	}
+	h.cluster.ResyncRoutes(ctx, served)
+	h.record(c, "cluster.convert_ingress", cl.ID)
+	return message(c, "node converted")
+}
+
 func (h *ClusterHandler) mapClusterErr(c *okapi.Context, err error) error {
 	switch {
 	case errors.Is(err, cluster.ErrClusterNotFound):
@@ -108,7 +173,8 @@ func (h *ClusterHandler) mapClusterErr(c *okapi.Context, err error) error {
 	case errors.Is(err, cluster.ErrNameTooLong), errors.Is(err, cluster.ErrInvalidLocationCode),
 		errors.Is(err, cluster.ErrInvalidVisibility), errors.Is(err, cluster.ErrGatewayNeedsSwarm),
 		errors.Is(err, cluster.ErrGatewayNodeNotInCluster), errors.Is(err, cluster.ErrGatewayNodeNoGateway),
-		errors.Is(err, cluster.ErrInvalidIngressIP), errors.Is(err, cluster.ErrInvalidIngressHostname):
+		errors.Is(err, cluster.ErrInvalidIngressIP), errors.Is(err, cluster.ErrInvalidIngressHostname),
+		errors.Is(err, node.ErrInvalidConnectivity):
 		return c.AbortBadRequest(err.Error())
 	default:
 		return c.AbortInternalServerError("cluster operation failed", err)

--- a/internal/handlers/marketplace_handler.go
+++ b/internal/handlers/marketplace_handler.go
@@ -83,6 +83,9 @@ func (h *MarketplaceHandler) Install(c *okapi.Context, req *InstallRequest) erro
 			errors.Is(err, marketplace.ErrNoSharedInstance):
 			return c.AbortBadRequest(err.Error())
 		default:
+			if a := placementAbort(c, err); a != nil {
+				return a
+			}
 			return c.AbortInternalServerError("install failed", err)
 		}
 	}
@@ -119,12 +122,28 @@ func (h *MarketplaceHandler) StartInstall(c *okapi.Context, req *InstallRequest)
 			errors.Is(err, marketplace.ErrNoSharedInstance):
 			return c.AbortBadRequest(err.Error())
 		default:
+			if a := placementAbort(c, err); a != nil {
+				return a
+			}
 			return c.AbortInternalServerError("install failed", err)
 		}
 	}
 	actor := middlewares.UserID(c)
 	h.audit.Record(audit.Entry{ActorID: &actor, WorkspaceID: &wsID, Action: "marketplace.install", TargetType: "template:" + req.Body.Name, TargetID: req.Body.Name, IP: c.RealIP()})
 	return created(c, job)
+}
+
+// LocationDatabases lists the database instances an install into ?location= may reuse or pin; an empty
+// location is the workspace default.
+func (h *MarketplaceHandler) LocationDatabases(c *okapi.Context) error {
+	list, err := h.svc.LocationDatabases(middlewares.WorkspaceID(c), c.Query("location"), h.placer.admin(c))
+	if err != nil {
+		if a := placementAbort(c, err); a != nil {
+			return a
+		}
+		return c.AbortInternalServerError("failed to list databases", err)
+	}
+	return ok(c, list)
 }
 
 // InstallJob returns a one-shot snapshot of an install job (REST fallback).

--- a/internal/handlers/node_handler.go
+++ b/internal/handlers/node_handler.go
@@ -125,7 +125,7 @@ type CreateNodeRequest struct {
 		// PublicIP / PublicHostname are the node's externally reachable DNS target.
 		PublicIP       string `json:"public_ip"`
 		PublicHostname string `json:"public_hostname"`
-		Connectivity   string `json:"connectivity" enum:"port-forward,edge-gateway"`
+		Connectivity   string `json:"connectivity" enum:"edge-gateway,cluster"`
 		// AccessMode is how the control plane reaches this node's Docker engine.
 		AccessMode string `json:"access_mode" enum:"agent,api,socket"`
 		// DockerEndpoint is required for api: tcp://host:2376.

--- a/internal/handlers/node_handler.go
+++ b/internal/handlers/node_handler.go
@@ -221,7 +221,7 @@ func (h *NodeHandler) List(c *okapi.Context) error {
 func (h *NodeHandler) Create(c *okapi.Context, req *CreateNodeRequest) error {
 	srv, token, err := h.nodes.CreateNode(req.input())
 	if err != nil {
-		if errors.Is(err, node.ErrPortForwardRetired) {
+		if errors.Is(err, node.ErrInvalidConnectivity) {
 			return c.AbortBadRequest(err.Error())
 		}
 		if errors.Is(err, node.ErrNameRequired) {
@@ -339,6 +339,11 @@ func (h *NodeHandler) Workloads(c *okapi.Context) error {
 		return c.AbortInternalServerError("failed to count node workloads", err)
 	}
 	return ok(c, map[string]any{"apps": apps, "databases": dbs})
+}
+
+// ApplyConnectivity deploys or tears down a node's gateway after its connectivity changed elsewhere.
+func (h *NodeHandler) ApplyConnectivity(ctx context.Context, prev, srv *models.Server) {
+	h.applyConnectivity(ctx, prev, srv)
 }
 
 // applyConnectivity deploys or tears down the node gateway after a connectivity
@@ -674,7 +679,7 @@ func (h *NodeHandler) mapErr(c *okapi.Context, err error) error {
 		return c.AbortBadRequest("the local node cannot be modified this way")
 	case errors.Is(err, node.ErrConnectivityAckRequired):
 		return c.AbortWithError(409, err)
-	case errors.Is(err, node.ErrPortForwardRetired):
+	case errors.Is(err, node.ErrInvalidConnectivity):
 		return c.AbortBadRequest(err.Error())
 	default:
 		return c.AbortInternalServerError("node operation failed", err)

--- a/internal/handlers/port_binding_handler.go
+++ b/internal/handlers/port_binding_handler.go
@@ -163,7 +163,7 @@ func (h *PortBindingHandler) record(c *okapi.Context, wsID *uint, action string,
 
 func (h *PortBindingHandler) mapErr(c *okapi.Context, err error) error {
 	switch {
-	case errors.Is(err, portbinding.ErrHostPortTaken), errors.Is(err, portbinding.ErrManagedBinding):
+	case errors.Is(err, portbinding.ErrHostPortTaken):
 		return c.AbortWithError(409, err)
 	case errors.Is(err, portbinding.ErrPortNotExposed), errors.Is(err, portbinding.ErrHostPortRange), errors.Is(err, portbinding.ErrNotPending):
 		return c.AbortBadRequest(err.Error())

--- a/internal/handlers/route_handler.go
+++ b/internal/handlers/route_handler.go
@@ -372,7 +372,7 @@ func (h *RouteHandler) mapErr(c *okapi.Context, err error) error {
 		return c.AbortWithError(409, err)
 	case errors.Is(err, route.ErrNameRequired), errors.Is(err, route.ErrInvalidName), errors.Is(err, route.ErrCertRequired), errors.Is(err, route.ErrInvalidYAML), errors.Is(err, route.ErrDomainNotRegistered), errors.Is(err, route.ErrDomainBanned), errors.Is(err, route.ErrAdvancedTLSCert):
 		return c.AbortBadRequest(err.Error())
-	case errors.Is(err, route.ErrAppRequired), errors.Is(err, route.ErrNodeAddressRequired), errors.Is(err, route.ErrExternalAccessDisabled), errors.Is(err, route.ErrMiddlewareRequired):
+	case errors.Is(err, route.ErrAppRequired), errors.Is(err, route.ErrExternalAccessDisabled), errors.Is(err, route.ErrMiddlewareRequired):
 		return c.AbortBadRequest(err.Error())
 	case errors.Is(err, route.ErrMiddlewareDuplicate), errors.Is(err, route.ErrMaintenanceStatus), errors.Is(err, route.ErrMaintenanceMessage):
 		return c.AbortBadRequest(err.Error())

--- a/internal/models/cluster.go
+++ b/internal/models/cluster.go
@@ -56,8 +56,8 @@ type Cluster struct {
 	IngressHostname string            `json:"ingress_hostname,omitempty"`
 	Visibility      ClusterVisibility `json:"visibility" gorm:"not null;default:all"`
 	Cordoned        bool              `json:"cordoned" gorm:"not null;default:false"`
-	// LegacyIngress marks a cluster converted from a port-forward node: the central gateway still
-	// reaches its apps by host port until it gets a gateway of its own or joins a swarm.
+	// LegacyIngress marks a cluster whose port-forward node became an edge gateway at upgrade, until an
+	// admin confirms that gateway or joins the node to a swarm.
 	LegacyIngress bool      `json:"legacy_ingress" gorm:"not null;default:false"`
 	NodeCount     int64     `json:"node_count" gorm:"-"`
 	CreatedAt     time.Time `json:"created_at"`

--- a/internal/models/port.go
+++ b/internal/models/port.go
@@ -42,14 +42,7 @@ type PortBinding struct {
 	// ServerID is the node the host port is published on. Host ports are a
 	// per-host resource, so conflict checks + allocation are scoped to it
 	// (0 = the local/manager node). Backfilled from the owning app.
-	ServerID uint `json:"server_id" gorm:"index;not null;default:0"`
-	// Managed marks a control-plane auto-forward binding (created for a
-	// port-forward node's route ingress) rather than a user request. Managed
-	// bindings are auto-approved and never enter the admin review queue.
-	Managed bool `json:"managed" gorm:"not null;default:false"`
-	// BindIP is the host interface the port is published on ("" = all/0.0.0.0).
-	// Managed bindings use the node's private address so ingress stays private.
-	BindIP      string    `json:"bind_ip,omitempty"`
+	ServerID    uint      `json:"server_id" gorm:"index;not null;default:0"`
 	RequestedBy uint      `json:"requested_by"`
 	ReviewedBy  *uint     `json:"reviewed_by,omitempty"`
 	ReviewNote  string    `json:"review_note,omitempty"`

--- a/internal/models/route.go
+++ b/internal/models/route.go
@@ -101,8 +101,7 @@ type Route struct {
 	DNSTarget   string `json:"dns_target,omitempty" gorm:"-"`
 	DNSHostname string `json:"dns_hostname,omitempty" gorm:"-"`
 
-	// Backends are the actual upstream endpoints the gateway uses for this route
-	// (the node-local DNS alias, or a port-forward node's address:hostPort).
+	// Backends are the actual upstream endpoints (DNS aliases) the gateway uses for this route.
 	// Transient, populated on read so the UI shows the real backend.
 	Backends []string `json:"backends,omitempty" gorm:"-"`
 }

--- a/internal/models/server.go
+++ b/internal/models/server.go
@@ -59,12 +59,12 @@ const (
 type ServerConnectivity string
 
 const (
-	// ConnectivityPortForward: the central proxy forwards to the node's published
-	// host port (http://<address>:<hostPort>). For trusted/private networks.
-	ConnectivityPortForward ServerConnectivity = "port-forward"
 	// ConnectivityEdgeGateway: the node runs its own gateway (public ingress, its
 	// own TLS) that pulls its routes from the control plane's HTTP provider.
 	ConnectivityEdgeGateway ServerConnectivity = "edge-gateway"
+	// ConnectivityCluster: the node has no gateway of its own; its cluster's gateway serves its apps, over
+	// the overlay for a swarm member. The control-plane node is one too.
+	ConnectivityCluster ServerConnectivity = "cluster"
 )
 
 func (s *Server) Label() string {
@@ -86,7 +86,7 @@ type Server struct {
 	Name         string             `json:"name" gorm:"uniqueIndex;not null"`
 	DisplayName  string             `json:"display_name"`
 	ClusterID    uint               `json:"cluster_id" gorm:"index;not null;default:0"`
-	Connectivity ServerConnectivity `json:"connectivity" gorm:"not null;default:port-forward"`
+	Connectivity ServerConnectivity `json:"connectivity" gorm:"not null;default:cluster"`
 	// AccessMode is how the control plane reaches this node's Docker engine.
 	// Existing rows backfill to "agent" (column default); the local node is set
 	// to "socket" at bootstrap.

--- a/internal/routes/clusters_routes.go
+++ b/internal/routes/clusters_routes.go
@@ -78,5 +78,14 @@ func (r *Router) clustersRoutes() []okapi.RouteDefinition {
 			Summary:     "Pick the node that serves a swarm cluster's routes",
 			Request:     &handlers.SetClusterGatewayRequest{},
 		},
+		{
+			Method:      http.MethodPost,
+			Path:        "/{clusterID}/convert",
+			Group:       g,
+			Middlewares: admin,
+			Handler:     okapi.H(r.h.cluster.ConvertIngress),
+			Summary:     "Give a standalone cluster's node a gateway: its own, or a swarm's",
+			Request:     &handlers.ConvertIngressRequest{},
+		},
 	}...)...)
 }

--- a/internal/routes/monitoring_routes.go
+++ b/internal/routes/monitoring_routes.go
@@ -236,6 +236,14 @@ func (r *Router) marketplaceRoutes() []okapi.RouteDefinition {
 		},
 		{
 			Method:      http.MethodGet,
+			Path:        "/{workspace}/marketplace/databases",
+			Group:       ws,
+			Middlewares: scopedDev,
+			Handler:     r.h.marketplace.LocationDatabases,
+			Summary:     "List the database instances an install into ?location= may reuse",
+		},
+		{
+			Method:      http.MethodGet,
 			Path:        "/{workspace}/marketplace/installs/{installID}/upgrade/plan",
 			Group:       ws,
 			Middlewares: scopedDev,

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -436,7 +436,7 @@ func InitRoutes(app *okapi.Okapi, db *gorm.DB, redisClient *redis.Client, cfg *c
 	dockerImportService := dockerimport.NewService(nodeClients, appService, stackService, appRepo, releaseRepo, deploymentRepo, volumeRepo, networkRepo, stackRepo, portBindingRepo)
 	// Node housekeeping: reclaim disk + reconcile drift between Docker and the DB.
 	housekeepingService := housekeeping.NewService(nodeClients, appRepo, dbRepo, stackRepo, volumeRepo)
-	routeService := route.NewService(routeRepo, middlewareRepo, appRepo, releaseRepo, serverRepo, portBindingRepo, proxyMgr, cfg.HostPortMin, cfg.HostPortMax)
+	routeService := route.NewService(routeRepo, middlewareRepo, appRepo, releaseRepo, serverRepo, proxyMgr)
 	// Attach/detach an app from the shared proxy network as its routes come and go
 	// (only route-exposed apps stay on it), reconciled live without a redeploy.
 	proxyReconciler := worker.NewProxyNetworkReconciler(appRepo, releaseRepo, nodeClients)
@@ -445,16 +445,11 @@ func InitRoutes(app *okapi.Okapi, db *gorm.DB, redisClient *redis.Client, cfg *c
 	// ingress overlay on every cluster refresh, so a gateway recreate can't leave clustered apps
 	// publicly dark — plus once now, so a fresh boot doesn't wait a whole refresh interval.
 	clusterService.SetIngressReconciler(proxyReconciler.ReconcileIngressGateway)
-	// In cluster mode the gateway reaches a remote app over the ingress overlay by
-	// its DNS alias, so no host port is published for it — and canary weights, which
-	// the port-forward upstream cannot carry, start working on remote nodes.
+	// A swarm outside the default cluster is served by its own ingress node's gateway.
 	routeService.SetCluster(clusterService)
 	clusterService.SetGatewayListener(routeService.SyncCluster)
 	proxyReconciler.SetCluster(clusterService)
 	go func() { _ = proxyReconciler.ReconcileIngressGateway(context.Background()) }()
-	// Auto port-forwarding: when a port-forward app gains a route, redeploy it so
-	// the node actually publishes the allocated host port the gateway targets.
-	routeService.SetPortPublisher(appService)
 	// After a workspace proxy sync, tell affected edge-gateway nodes to pull their
 	// config immediately instead of waiting for the HTTP-provider poll interval.
 	routeService.SetEdgeReloader(newEdgeReloader(nodeService, nodeGateway))
@@ -1354,6 +1349,7 @@ func InitRoutes(app *okapi.Okapi, db *gorm.DB, redisClient *redis.Client, cfg *c
 	// Gate node container-log streaming by workspace membership: a platform admin
 	// can list/operate containers, but not read another workspace's container logs.
 	r.h.node.SetMembership(workspaceRepo)
+	r.h.cluster.SetConnectivityApplier(r.h.node.ApplyConnectivity)
 	// Block stop/remove of managed containers from the admin node view unless the
 	// operator has explicitly disabled security enforcement (break-glass).
 	r.h.node.SetSecurityEnforcement(r.cfg.SecurityEnforcement)
@@ -1452,6 +1448,14 @@ func InitRoutes(app *okapi.Okapi, db *gorm.DB, redisClient *redis.Client, cfg *c
 	// file watcher sees the converged state in a single reload.
 	if err := routeService.ResyncAllProxy(context.Background()); err != nil {
 		logger.Warn("proxy startup resync failed", "err", err)
+	}
+	// A node converted from port-forward at upgrade moves its routes and DNS to its own gateway.
+	if list, err := clusterService.Clusters(); err == nil {
+		for i := range list {
+			if list[i].LegacyIngress {
+				go routeService.SyncCluster(context.Background(), list[i].ID)
+			}
+		}
 	}
 
 	// The bundle service goes back to the caller so the embedded worker can run

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -419,8 +419,7 @@ func InitRoutes(app *okapi.Okapi, db *gorm.DB, redisClient *redis.Client, cfg *c
 	})
 	gpuService.SetQuota(quotaService)
 	appService := application.NewService(appRepo, deploymentRepo, releaseRepo, volumeRepo, routeRepo, networkRepo, stackRepo, appPortRepo, appEventRepo, nodeClients, producer, eventsService)
-	// Lets the app service (re)publish host ports when a port-forward app gains a
-	// route, and clean a deleted app's bindings.
+	// Lets the app service clean a deleted app's bindings.
 	appService.SetPortBindings(portBindingRepo)
 	storageService := storage.NewService(volumeRepo, appRepo, nodeClients)
 	portBindingService := portbinding.NewService(portBindingRepo, appRepo, appPortRepo, workspaceRepo, cfg.HostPortMin, cfg.HostPortMax)

--- a/internal/services/application/application.go
+++ b/internal/services/application/application.go
@@ -265,9 +265,7 @@ func (s *Service) swarmManager(ctx context.Context, app *models.Application) (do
 	return s.cluster.Manager(ctx, app.ClusterID)
 }
 
-// SetPortBindings wires the port-binding repository used by EnsurePublished to
-// learn which host ports an app's container must publish (injected after
-// construction).
+// SetPortBindings wires the port-binding repository, whose rows go with a deleted app.
 func (s *Service) SetPortBindings(r *repositories.PortBindingRepository) { s.portBindings = r }
 
 // ExternalLabelTaken reports whether another application already owns the given
@@ -2125,69 +2123,6 @@ func (s *Service) Redeploy(app *models.Application) (*models.Deployment, error) 
 		image = app.ImageRef("")
 	}
 	return s.enqueue(app.ID, app.ServerID, image, "auto", app.RegistryID, models.DeployRolling, false)
-}
-
-// EnsurePublished reconciles the host ports an app's running container publishes with its approved
-// bindings, enqueuing a rolling redeploy when they differ — Docker cannot add a port to a running
-// container. Idempotent and best-effort. Satisfies the route service's PortPublisher.
-func (s *Service) EnsurePublished(ctx context.Context, appID uint) error {
-	if s.portBindings == nil {
-		return nil
-	}
-	app, err := s.apps.FindByID(appID)
-	if err != nil {
-		return err
-	}
-	if app.CurrentReleaseID == nil {
-		return nil // not running yet — the first deploy publishes everything
-	}
-	rel, err := s.releases.FindActive(appID)
-	if err != nil || rel.ContainerID == "" {
-		return nil
-	}
-	eng, err := s.clients.For(app.ServerID)
-	if err != nil {
-		return nil // node offline — republishes on its next deploy
-	}
-	cfg, err := eng.InspectContainerConfig(ctx, rel.ContainerID)
-	if err != nil {
-		return nil
-	}
-	approved, err := s.portBindings.ListApprovedByApp(appID)
-	if err != nil {
-		return err
-	}
-	want := map[int]bool{}
-	for _, b := range approved {
-		want[b.HostPort] = true
-	}
-	live := map[int]bool{}
-	for _, p := range cfg.Ports {
-		if p.HostPort != 0 {
-			live[p.HostPort] = true
-		}
-	}
-	if !samePortSet(want, live) {
-		// A binding was added or removed since the last deploy: redeploy so the container publishes
-		// exactly the approved set. This asks for rolling, but the worker downgrades it to recreate
-		// whenever host ports are published — two containers cannot hold the same host port.
-		_, derr := s.Redeploy(app)
-		return derr
-	}
-	return nil
-}
-
-// samePortSet reports whether two host-port sets are equal.
-func samePortSet(a, b map[int]bool) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for p := range a {
-		if !b[p] {
-			return false
-		}
-	}
-	return true
 }
 
 func (s *Service) AutoRedeploy(app *models.Application) (*models.Deployment, error) {

--- a/internal/services/application/strategy_test.go
+++ b/internal/services/application/strategy_test.go
@@ -91,22 +91,3 @@ func TestNormalizeDeployConfig(t *testing.T) {
 		t.Errorf("interval = %d, want clamped to 10", app.CanaryStepIntervalSeconds)
 	}
 }
-
-func TestSamePortSet(t *testing.T) {
-	cases := []struct {
-		name string
-		a, b map[int]bool
-		want bool
-	}{
-		{"both empty", map[int]bool{}, map[int]bool{}, true},
-		{"equal", map[int]bool{1024: true, 8080: true}, map[int]bool{8080: true, 1024: true}, true},
-		{"added", map[int]bool{1024: true}, map[int]bool{1024: true, 9000: true}, false},
-		{"removed (route deleted)", map[int]bool{1024: true}, map[int]bool{}, false},
-		{"different", map[int]bool{1024: true}, map[int]bool{2048: true}, false},
-	}
-	for _, c := range cases {
-		if got := samePortSet(c.a, c.b); got != c.want {
-			t.Errorf("%s: samePortSet = %v, want %v", c.name, got, c.want)
-		}
-	}
-}

--- a/internal/services/apply/apply.go
+++ b/internal/services/apply/apply.go
@@ -2219,7 +2219,7 @@ func (s *Service) reconcileExposure(ctx context.Context, workspaceID uint, app *
 
 // reconcileBindings converges an app's host-port bindings to the manifest's publish/hostPort ports.
 // Presence-based: an existing binding for a still-desired port is left as-is, so a possibly auto-allocated
-// host port is not churned; bindings for ports no longer published are cancelled. Managed ones are untouched.
+// host port is not churned; bindings for ports no longer published are cancelled.
 func (s *Service) reconcileBindings(workspaceID, appID uint, spec *declarative.ApplicationSpec) error {
 	desired := map[int]declarative.PortSpec{}
 	for _, p := range spec.Ports {
@@ -2233,9 +2233,6 @@ func (s *Service) reconcileBindings(workspaceID, appID uint, spec *declarative.A
 	}
 	have := map[int]*models.PortBinding{}
 	for i := range existing {
-		if existing[i].Managed {
-			continue
-		}
 		have[existing[i].ContainerPort] = &existing[i]
 	}
 	for cport, p := range desired {
@@ -2263,8 +2260,8 @@ func (s *Service) reconcileBindings(workspaceID, appID uint, spec *declarative.A
 }
 
 // exposedPorts derives an app's live exposure: container ports that have a
-// generated external-access route, and container ports with a (non-managed)
-// host-port binding. Powers idempotent diffing.
+// generated external-access route, and container ports with a host-port binding.
+// Powers idempotent diffing.
 func (s *Service) exposedPorts(workspaceID, appID uint) (ext, pub map[int]bool) {
 	ext, pub = map[int]bool{}, map[int]bool{}
 	if routes, err := s.routes.ListByApp(workspaceID, appID); err == nil {
@@ -2277,9 +2274,7 @@ func (s *Service) exposedPorts(workspaceID, appID uint) (ext, pub map[int]bool) 
 	if s.bindings != nil {
 		if bs, err := s.bindings.ListByApp(workspaceID, appID); err == nil {
 			for i := range bs {
-				if !bs[i].Managed {
-					pub[bs[i].ContainerPort] = true
-				}
+				pub[bs[i].ContainerPort] = true
 			}
 		}
 	}

--- a/internal/services/cluster/gateway.go
+++ b/internal/services/cluster/gateway.go
@@ -83,10 +83,24 @@ func (s *Service) SetGateway(ctx context.Context, clusterID uint, p GatewayPatch
 		return nil, err
 	}
 	s.AttachGateway(ctx, c.ID)
-	if s.gatewayListener != nil {
-		go s.gatewayListener(context.WithoutCancel(ctx), c.ID)
-	}
+	s.ResyncRoutes(ctx, c.ID)
 	return s.Cluster(c.ID)
+}
+
+// ResyncRoutes re-syncs a cluster's routes in the background, after the gateway serving them changed.
+func (s *Service) ResyncRoutes(ctx context.Context, clusterID uint) {
+	if s.gatewayListener != nil {
+		go s.gatewayListener(context.WithoutCancel(ctx), clusterID)
+	}
+}
+
+// ConfirmGateway records that a node converted from port-forward serves its apps through its own gateway.
+func (s *Service) ConfirmGateway(clusterID uint) error {
+	c, err := s.Cluster(clusterID)
+	if err != nil {
+		return err
+	}
+	return s.store.UpdateColumns(c.ID, map[string]any{"legacy_ingress": false, "ingress_server_id": c.ManagerServerID})
 }
 
 // AttachGateway joins a swarm cluster's ingress-node gateway to the cluster's ingress overlay, which is how it

--- a/internal/services/cluster/gateway_test.go
+++ b/internal/services/cluster/gateway_test.go
@@ -22,7 +22,7 @@ func newGatewayService() *Service {
 	}
 	nodes := &fakeNodes{servers: []models.Server{
 		{ID: 11, ClusterID: 5, Connectivity: models.ConnectivityEdgeGateway},
-		{ID: 12, ClusterID: 5, Connectivity: models.ConnectivityPortForward},
+		{ID: 12, ClusterID: 5, Connectivity: models.ConnectivityCluster},
 		{ID: 13, ClusterID: 1, Connectivity: models.ConnectivityEdgeGateway},
 		{ID: 14, ClusterID: 6, Connectivity: models.ConnectivityEdgeGateway},
 	}}

--- a/internal/services/database/placement.go
+++ b/internal/services/database/placement.go
@@ -141,18 +141,23 @@ func (s *Service) tagLogical(d *models.Database, declName string, meta models.Me
 // FindReusableInstance returns the running instance a shared/auto placement would
 // reuse for engine, or nil. Exposed so a caller can pre-resolve a dependency's
 // target node without performing the placement.
-func (s *Service) FindReusableInstance(workspaceID uint, engine models.DBEngine) *models.DatabaseInstance {
-	return s.findReusable(workspaceID, engine, 0)
+// A non-zero clusterID keeps the search inside that location.
+func (s *Service) FindReusableInstance(workspaceID uint, engine models.DBEngine, clusterID uint) *models.DatabaseInstance {
+	return s.reusableIn(workspaceID, engine, clusterID, clusterID != 0)
 }
 
 // findReusable picks a running instance of engine, in the location of serverID when one is given:
 // private networks don't span locations.
 func (s *Service) findReusable(workspaceID uint, engine models.DBEngine, serverID uint) *models.DatabaseInstance {
+	cluster, scoped := s.clusterOfServer(serverID)
+	return s.reusableIn(workspaceID, engine, cluster, scoped)
+}
+
+func (s *Service) reusableIn(workspaceID uint, engine models.DBEngine, cluster uint, scoped bool) *models.DatabaseInstance {
 	list, err := s.List(workspaceID)
 	if err != nil {
 		return nil
 	}
-	cluster, scoped := s.clusterOfServer(serverID)
 	for i := range list {
 		if list[i].Engine != engine || list[i].Status != models.DBStatusRunning {
 			continue

--- a/internal/services/database/placement_test.go
+++ b/internal/services/database/placement_test.go
@@ -25,6 +25,8 @@ type dbInstRow struct {
 	Engine      string
 	Version     string
 	Status      string
+	ClusterID   uint
+	CreatedAt   time.Time
 }
 
 func (dbInstRow) TableName() string { return "database_instances" }
@@ -112,5 +114,28 @@ func TestFindDatabaseByDeclName(t *testing.T) {
 	}
 	if _, _, ok := s.FindDatabaseByDeclName(ws, ""); ok {
 		t.Error("FindDatabaseByDeclName(\"\"): empty name must never match")
+	}
+}
+
+// Reuse never crosses a location: an instance in another cluster is unreachable from the install's network.
+func TestFindReusableInstanceStaysInTheLocation(t *testing.T) {
+	s, db := newDeclNameSvc(t)
+	const ws = uint(1)
+	running, pg := string(models.DBStatusRunning), string(models.DBEnginePostgres)
+	if err := db.Create(&[]dbInstRow{
+		{ID: 1, UID: "pg-1", WorkspaceID: ws, Name: "pg-central", Engine: pg, Version: "17", Status: running, ClusterID: 1},
+		{ID: 2, UID: "pg-2", WorkspaceID: ws, Name: "pg-east", Engine: pg, Version: "17", Status: running, ClusterID: 2},
+	}).Error; err != nil {
+		t.Fatalf("seed instances: %v", err)
+	}
+
+	if got := s.FindReusableInstance(ws, models.DBEnginePostgres, 2); got == nil || got.ID != 2 {
+		t.Errorf("location 2 reused %v, want pg-east", got)
+	}
+	if got := s.FindReusableInstance(ws, models.DBEnginePostgres, 3); got != nil {
+		t.Errorf("a location with no postgres reused %q", got.Name)
+	}
+	if got := s.FindReusableInstance(ws, models.DBEnginePostgres, 0); got == nil {
+		t.Error("an unscoped search found nothing")
 	}
 }

--- a/internal/services/edgegateway/edgegateway.go
+++ b/internal/services/edgegateway/edgegateway.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 // Package edgegateway provisions the Goma Gateway container fronting an edge-gateway node's public
-// ingress. Unlike port-forward nodes, such a node terminates TLS locally and serves its own routes,
+// ingress. Unlike cluster-gateway nodes, such a node terminates TLS locally and serves its own routes,
 // pulled from the control plane's HTTP provider using the node's own agent token.
 package edgegateway
 

--- a/internal/services/marketplace/marketplace.go
+++ b/internal/services/marketplace/marketplace.go
@@ -718,15 +718,20 @@ func referencesDep(env map[string]string, token string) bool {
 
 // installNode decides the single node every resource in an install must land on, so each app can share a Docker
 // network with the databases it uses — a network cannot span nodes. A dependency binding to an existing
-// instance makes that instance's node authoritative; the first such binding wins. Otherwise 0, the local node.
-func (s *Service) installNode(workspaceID uint, m *manifest.Manifest, in InstallInput) uint {
+// instance in the install's cluster (any cluster when 0) makes that instance's node authoritative; the first
+// such binding wins. Otherwise 0, the local node.
+func (s *Service) installNode(workspaceID uint, m *manifest.Manifest, in InstallInput, clusterID uint) (uint, error) {
 	for _, d := range m.Databases {
 		// A pinned instance dictates the node outright.
 		if id := in.Placements[d.Name]; id != 0 {
-			if inst, err := s.dbs.Get(workspaceID, id); err == nil {
-				return inst.ServerID
+			inst, err := s.dbs.Get(workspaceID, id)
+			if err != nil {
+				continue
 			}
-			continue
+			if clusterID != 0 && inst.ClusterID != clusterID {
+				return 0, fmt.Errorf("%w: database %q is in another location than this install", ErrInvalidInput, inst.Name)
+			}
+			return inst.ServerID, nil
 		}
 		placement := d.Placement
 		if mode := manifest.Placement(strings.TrimSpace(in.PlacementModes[d.Name])); mode.Valid() {
@@ -738,12 +743,12 @@ func (s *Service) installNode(workspaceID uint, m *manifest.Manifest, in Install
 		reuses := placement == manifest.PlacementShared ||
 			(placement == manifest.PlacementAuto && models.EngineSupportsLogicalDatabases(engine))
 		if reuses {
-			if inst := s.dbs.FindReusableInstance(workspaceID, engine); inst != nil {
-				return inst.ServerID
+			if inst := s.dbs.FindReusableInstance(workspaceID, engine, clusterID); inst != nil {
+				return inst.ServerID, nil
 			}
 		}
 	}
-	return 0
+	return 0, nil
 }
 
 // record persists provenance (best-effort; a failure here never fails an install

--- a/internal/services/marketplace/placement.go
+++ b/internal/services/marketplace/placement.go
@@ -4,6 +4,7 @@
 package marketplace
 
 import (
+	"github.com/miabi-io/miabi/internal/models"
 	"github.com/miabi-io/miabi/internal/services/marketplace/manifest"
 	"github.com/miabi-io/miabi/internal/services/placement"
 )
@@ -11,17 +12,46 @@ import (
 // Placer resolves where an install lands. Satisfied by *placement.Service.
 type Placer interface {
 	Place(req placement.Request) (placement.Result, error)
+	ResolveLocation(workspaceID uint, location string, admin bool) (*models.Cluster, error)
 }
 
 // SetPlacer wires location placement for installs (nil-safe; nil lands installs on the local node).
 func (s *Service) SetPlacer(p Placer) { s.placer = p }
 
-// installTarget decides where every resource of an install lands. A dependency reusing an existing database
-// instance makes that instance's node authoritative; otherwise placement picks a node in the install's location.
+// installTarget decides where every resource of an install lands: in its location, and on the node of a
+// database instance it reuses there, since an app shares a Docker network with its databases.
 func (s *Service) installTarget(workspaceID uint, m *manifest.Manifest, in InstallInput) (placement.Result, error) {
-	colocate := s.installNode(workspaceID, m, in)
 	if s.placer == nil {
-		return placement.Result{ServerID: colocate}, nil
+		node, err := s.installNode(workspaceID, m, in, 0)
+		return placement.Result{ServerID: node}, err
 	}
-	return s.placer.Place(placement.Request{WorkspaceID: workspaceID, Location: in.Location, Colocate: colocate, Admin: in.Admin})
+	loc, err := s.placer.ResolveLocation(workspaceID, in.Location, in.Admin)
+	if err != nil {
+		return placement.Result{}, err
+	}
+	colocate, err := s.installNode(workspaceID, m, in, loc.ID)
+	if err != nil {
+		return placement.Result{}, err
+	}
+	return s.placer.Place(placement.Request{WorkspaceID: workspaceID, Location: loc.Name, Colocate: colocate, Admin: in.Admin})
+}
+
+// LocationDatabases lists the database instances an install into location may reuse or pin: only those in
+// that location, as private networks don't span locations. An empty location is the workspace default.
+func (s *Service) LocationDatabases(workspaceID uint, location string, admin bool) ([]models.DatabaseInstance, error) {
+	list, err := s.dbs.List(workspaceID)
+	if err != nil || s.placer == nil {
+		return list, err
+	}
+	loc, err := s.placer.ResolveLocation(workspaceID, location, admin)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]models.DatabaseInstance, 0, len(list))
+	for i := range list {
+		if list[i].ClusterID == loc.ID {
+			out = append(out, list[i])
+		}
+	}
+	return out, nil
 }

--- a/internal/services/node/service.go
+++ b/internal/services/node/service.go
@@ -35,7 +35,7 @@ var (
 	// ErrConnectivityAckRequired is returned when an update changes the node's
 	// reachability settings without the caller acknowledging the impact.
 	ErrConnectivityAckRequired = &connectivityAckError{}
-	ErrPortForwardRetired      = errors.New("port-forward connectivity is no longer available: use an edge gateway, or join the node to the cluster")
+	ErrInvalidConnectivity     = errors.New("a node either runs its own gateway (edge-gateway) or, as a swarm member, is served by its cluster's gateway (cluster)")
 )
 
 // NodeLimitError is returned when registering a node would exceed the edition's node cap. It exposes a
@@ -263,8 +263,8 @@ func (s *Service) CreateNode(in NodeInput) (*models.Server, string, error) {
 	if !models.ValidAccessMode(mode) {
 		mode = models.AccessAgent
 	}
-	if in.Connectivity == models.ConnectivityPortForward {
-		return nil, "", ErrPortForwardRetired
+	if in.Connectivity != "" && in.Connectivity != models.ConnectivityEdgeGateway {
+		return nil, "", ErrInvalidConnectivity
 	}
 	in.Connectivity = models.ConnectivityEdgeGateway
 	// The handle is derived from the label. slug.Unique suffixes a collision
@@ -319,8 +319,8 @@ func (s *Service) UpdateNode(id uint, in NodeInput) (*models.Server, error) {
 	if err != nil {
 		return nil, ErrNodeNotFound
 	}
-	if in.Connectivity == models.ConnectivityPortForward && srv.Connectivity != models.ConnectivityPortForward {
-		return nil, ErrPortForwardRetired
+	if err := s.checkConnectivity(srv, in.Connectivity); err != nil {
+		return nil, err
 	}
 	if reachabilityChanged(srv, in) && !in.Acknowledge {
 		return nil, ErrConnectivityAckRequired
@@ -331,7 +331,7 @@ func (s *Service) UpdateNode(id uint, in NodeInput) (*models.Server, error) {
 		}
 		srv.PublicIP = strings.TrimSpace(in.PublicIP)
 		srv.PublicHostname = strings.TrimSpace(in.PublicHostname)
-		if in.Connectivity == models.ConnectivityEdgeGateway || in.Connectivity == models.ConnectivityPortForward {
+		if validConnectivity(in.Connectivity) {
 			srv.Connectivity = in.Connectivity
 		}
 		if err := s.repo.Update(srv); err != nil {
@@ -345,7 +345,7 @@ func (s *Service) UpdateNode(id uint, in NodeInput) (*models.Server, error) {
 	if models.ValidAccessMode(in.AccessMode) {
 		srv.AccessMode = in.AccessMode
 	}
-	if in.Connectivity == models.ConnectivityEdgeGateway || in.Connectivity == models.ConnectivityPortForward {
+	if validConnectivity(in.Connectivity) {
 		srv.Connectivity = in.Connectivity
 	}
 	srv.DockerEndpoint = strings.TrimSpace(in.DockerEndpoint)
@@ -389,7 +389,7 @@ func (s *Service) RegisterClusterNode(clusterID uint, swarmNodeID, hostname stri
 		IsLocal:        false,
 		Role:           models.RoleNode,
 		AccessMode:     models.AccessAgent,
-		Connectivity:   models.ConnectivityPortForward,
+		Connectivity:   models.ConnectivityCluster,
 		Status:         models.ServerStatusUnknown,
 		SwarmNodeID:    swarmNodeID,
 		AutoJoined:     true,
@@ -513,10 +513,43 @@ func (*connectivityAckError) Error() string {
 }
 func (*connectivityAckError) Code() string { return "CONNECTIVITY_ACK_REQUIRED" }
 
-// validConnectivity reports whether c is one of the two known connectivity modes
-// (blank/unknown values are ignored by UpdateNode, so they are not "changes").
+// validConnectivity reports whether c is one of the known connectivity modes.
 func validConnectivity(c models.ServerConnectivity) bool {
-	return c == models.ConnectivityEdgeGateway || c == models.ConnectivityPortForward
+	return c == models.ConnectivityEdgeGateway || c == models.ConnectivityCluster
+}
+
+// checkConnectivity refuses a connectivity the node cannot have: only the control-plane node or a swarm
+// member can rely on its cluster's gateway, or nothing reaches its apps. Empty leaves it unchanged.
+func (s *Service) checkConnectivity(srv *models.Server, c models.ServerConnectivity) error {
+	switch {
+	case c == "" || c == srv.Connectivity || c == models.ConnectivityEdgeGateway:
+		return nil
+	case c != models.ConnectivityCluster:
+		return ErrInvalidConnectivity
+	case srv.IsLocal || s.clusters == nil:
+		return nil
+	}
+	cl, err := s.clusters.FindByID(srv.ClusterID)
+	if err != nil || cl.Mode != models.ClusterModeSwarm {
+		return ErrInvalidConnectivity
+	}
+	return nil
+}
+
+// SetConnectivity changes only how a node's apps are served, leaving its other reachability settings alone.
+func (s *Service) SetConnectivity(id uint, c models.ServerConnectivity) (*models.Server, error) {
+	srv, err := s.repo.FindByID(id)
+	if err != nil {
+		return nil, ErrNodeNotFound
+	}
+	if err := s.checkConnectivity(srv, c); err != nil {
+		return nil, err
+	}
+	srv.Connectivity = c
+	if err := s.repo.Update(srv); err != nil {
+		return nil, err
+	}
+	return srv, nil
 }
 
 // reachabilityChanged reports whether in would actually alter how the control plane reaches the node or how

--- a/internal/services/node/service_test.go
+++ b/internal/services/node/service_test.go
@@ -229,30 +229,27 @@ func TestNewNodesDefaultToEdgeGateway(t *testing.T) {
 	if srv.Connectivity != models.ConnectivityEdgeGateway {
 		t.Errorf("connectivity = %q, want edge-gateway", srv.Connectivity)
 	}
-	if _, _, err := s.CreateNode(NodeInput{DisplayName: "Lyon", Connectivity: models.ConnectivityPortForward}); !errors.Is(err, ErrPortForwardRetired) {
-		t.Errorf("port-forward create err = %v, want ErrPortForwardRetired", err)
+	if _, _, err := s.CreateNode(NodeInput{DisplayName: "Lyon", Connectivity: models.ConnectivityCluster}); !errors.Is(err, ErrInvalidConnectivity) {
+		t.Errorf("cluster create err = %v, want ErrInvalidConnectivity", err)
 	}
 }
 
-func TestOnlyLegacyNodesKeepPortForward(t *testing.T) {
-	repo := nameRepo(t)
-	s := NewService(repo, nil)
+// Port-forward is gone: a client still sending it is refused rather than silently ignored.
+func TestRetiredConnectivityIsRefused(t *testing.T) {
+	s := NewService(nameRepo(t), nil)
 	srv, _, err := s.CreateNode(NodeInput{DisplayName: "Paris"})
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
-
-	toPortForward := NodeInput{DisplayName: "Paris", Connectivity: models.ConnectivityPortForward, Acknowledge: true}
-	if _, err := s.UpdateNode(srv.ID, toPortForward); !errors.Is(err, ErrPortForwardRetired) {
-		t.Fatalf("switch to port-forward err = %v, want ErrPortForwardRetired", err)
+	if _, _, err := s.CreateNode(NodeInput{DisplayName: "Lyon", Connectivity: "port-forward"}); !errors.Is(err, ErrInvalidConnectivity) {
+		t.Errorf("create err = %v, want ErrInvalidConnectivity", err)
 	}
-
-	srv.Connectivity = models.ConnectivityPortForward
-	if err := repo.Update(srv); err != nil {
-		t.Fatalf("seed legacy node: %v", err)
+	in := NodeInput{DisplayName: "Paris", Connectivity: "port-forward", Acknowledge: true}
+	if _, err := s.UpdateNode(srv.ID, in); !errors.Is(err, ErrInvalidConnectivity) {
+		t.Errorf("update err = %v, want ErrInvalidConnectivity", err)
 	}
-	if _, err := s.UpdateNode(srv.ID, toPortForward); err != nil {
-		t.Errorf("editing a legacy port-forward node was refused: %v", err)
+	if _, err := s.SetConnectivity(srv.ID, "port-forward"); !errors.Is(err, ErrInvalidConnectivity) {
+		t.Errorf("set err = %v, want ErrInvalidConnectivity", err)
 	}
 }
 

--- a/internal/services/placement/placement.go
+++ b/internal/services/placement/placement.go
@@ -97,6 +97,12 @@ func (s *Service) onNode(serverID uint, location string) (Result, error) {
 	return Result{ClusterID: srv.ClusterID, ServerID: serverID}, nil
 }
 
+// ResolveLocation is the cluster a create naming location lands in: that location, else the workspace
+// default, else the first location the workspace may use.
+func (s *Service) ResolveLocation(workspaceID uint, location string, admin bool) (*models.Cluster, error) {
+	return s.resolveCluster(workspaceID, location, admin)
+}
+
 func allowed(c *models.Cluster, admin bool) bool {
 	return admin || c.Visibility != models.ClusterVisibilityRestricted
 }

--- a/internal/services/portbinding/overview.go
+++ b/internal/services/portbinding/overview.go
@@ -36,7 +36,6 @@ type PortEntry struct {
 	AppName       string    `json:"app_name,omitempty"`
 	ContainerPort int       `json:"container_port,omitempty"`
 	Container     string    `json:"container,omitempty"`
-	Managed       bool      `json:"managed,omitempty"`
 	RequestedBy   uint      `json:"requested_by,omitempty"`
 	CreatedAt     time.Time `json:"created_at,omitempty"`
 }
@@ -146,8 +145,7 @@ func (s *Service) reconcile(bindings []models.PortBinding, live map[string]strin
 		e := PortEntry{
 			HostPort: b.HostPort, Protocol: normProto(b.Protocol),
 			BindingID: b.ID, WorkspaceID: b.WorkspaceID, ApplicationID: b.ApplicationID,
-			ContainerPort: b.ContainerPort, Managed: b.Managed,
-			RequestedBy: b.RequestedBy, CreatedAt: b.CreatedAt,
+			ContainerPort: b.ContainerPort, RequestedBy: b.RequestedBy, CreatedAt: b.CreatedAt,
 			Container: live[key],
 		}
 		switch {

--- a/internal/services/portbinding/portbinding.go
+++ b/internal/services/portbinding/portbinding.go
@@ -29,7 +29,6 @@ var (
 	ErrHostPortRange  = errors.New("host port is outside the allowed range")
 	ErrHostPortTaken  = errors.New("host port is already in use")
 	ErrNotPending     = errors.New("binding is not pending review")
-	ErrManagedBinding = errors.New("this binding is managed automatically and cannot be changed")
 )
 
 // DockerClients resolves a node's Docker client so host-port conflicts can be
@@ -373,16 +372,11 @@ func (s *Service) ListByWorkspace(workspaceID uint) ([]models.PortBinding, error
 	return s.repo.ListByWorkspace(workspaceID)
 }
 
-// Cancel removes a workspace's own binding (e.g. withdraw a request). Managed
-// auto-forward bindings are control-plane owned and cannot be cancelled here —
-// they are released automatically when their route is removed.
+// Cancel removes a workspace's own binding (e.g. withdraw a request).
 func (s *Service) Cancel(workspaceID, id uint) error {
 	b, err := s.repo.FindInWorkspace(workspaceID, id)
 	if err != nil {
 		return ErrNotFound
-	}
-	if b.Managed {
-		return ErrManagedBinding
 	}
 	return s.repo.Delete(b.ID)
 }

--- a/internal/services/route/external_access.go
+++ b/internal/services/route/external_access.go
@@ -88,15 +88,11 @@ func (s *Service) SetExternalAccess(ctx context.Context, workspaceID, appID uint
 		}
 	}
 	base := sanitizeBase(cfg.BaseDomain)
-	// Exposing requires a base domain and a reachable node; disabling (no ports)
-	// must always proceed so the generated routes can be cleaned up even if the
-	// base domain was later cleared or the node lost its address.
+	// Exposing requires a base domain; disabling (no ports) must always proceed so the generated
+	// routes can be cleaned up even if the base domain was later cleared.
 	if len(want) > 0 {
 		if base == "" {
 			return nil, ErrExternalAccessDisabled
-		}
-		if err := s.requireRoutableNode(app); err != nil {
-			return nil, err
 		}
 		// Assign the stable subdomain label once, so the URL survives renames.
 		if strings.TrimSpace(app.ExternalLabel) == "" {

--- a/internal/services/route/ingress_test.go
+++ b/internal/services/route/ingress_test.go
@@ -4,7 +4,6 @@
 package route
 
 import (
-	"errors"
 	"strings"
 	"testing"
 
@@ -23,104 +22,61 @@ type serverRow struct {
 	Address        string
 	PublicIP       string
 	PublicHostname string
+	ClusterID      uint
 }
 
 func (serverRow) TableName() string { return "servers" }
 
 const (
-	localServer     = 1
-	portFwdServer   = 2
-	edgeServer      = 3
-	noAddrFwdServer = 4
+	localServer  = 1
+	memberServer = 2
+	edgeServer   = 3
 )
 
-func newIngressService(t *testing.T, clusterOn bool) *Service {
+func newIngressService(t *testing.T) *Service {
 	t.Helper()
 	name := strings.ReplaceAll(t.Name(), "/", "_")
 	db, err := gorm.Open(sqlite.Open("file:"+name+"?mode=memory&cache=shared"), &gorm.Config{})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
-	if err := db.AutoMigrate(&serverRow{}, &models.PortBinding{}); err != nil {
+	if err := db.AutoMigrate(&serverRow{}); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
 	servers := []serverRow{
-		{ID: localServer, IsLocal: true, PublicIP: "198.51.100.1"},
-		{ID: portFwdServer, Connectivity: string(models.ConnectivityPortForward), Address: "10.0.0.2"},
+		{ID: localServer, IsLocal: true, Connectivity: string(models.ConnectivityCluster), PublicIP: "198.51.100.1"},
+		{ID: memberServer, Connectivity: string(models.ConnectivityCluster)},
 		{ID: edgeServer, Connectivity: string(models.ConnectivityEdgeGateway), PublicIP: "203.0.113.3"},
-		{ID: noAddrFwdServer, Connectivity: string(models.ConnectivityPortForward)},
 	}
 	if err := db.Create(&servers).Error; err != nil {
 		t.Fatalf("seed servers: %v", err)
 	}
-	binding := &models.PortBinding{ApplicationID: 7, ServerID: portFwdServer, ContainerPort: 8080, HostPort: 30001,
-		Protocol: "tcp", Status: models.PortBindingApproved}
-	if err := db.Create(binding).Error; err != nil {
-		t.Fatalf("seed binding: %v", err)
-	}
-	s := &Service{servers: repositories.NewServerRepository(db), ports: repositories.NewPortBindingRepository(db)}
-	if clusterOn {
-		s.SetCluster(fakeCluster{on: true})
-	}
-	return s
+	return &Service{servers: repositories.NewServerRepository(db)}
 }
 
-func TestRenderBackendsFollowsClusterMode(t *testing.T) {
-	routed := &models.Application{ID: 7, ServerID: portFwdServer, Alias: "mb-app-tok-7"}
-	unrouted := &models.Application{ID: 8, ServerID: portFwdServer, Alias: "mb-app-tok-8"}
-
-	t.Run("off: port-forward node uses its host port", func(t *testing.T) {
-		s := newIngressService(t, false)
-		if got := s.renderBackends(routed, 8080); len(got) != 1 || got[0].Endpoint != "http://10.0.0.2:30001" {
-			t.Errorf("renderBackends = %+v, want the host-port upstream", got)
-		}
-		if got := s.displayBackends(routed, 8080); len(got) != 1 || got[0] != "http://10.0.0.2:30001" {
-			t.Errorf("displayBackends = %v, want the host-port upstream", got)
-		}
-	})
-
-	t.Run("on: port-forward node uses the alias", func(t *testing.T) {
-		s := newIngressService(t, true)
-		for _, app := range []*models.Application{routed, unrouted} {
-			want := "http://" + app.Alias + ":8080"
-			if got := s.renderBackends(app, 8080); len(got) != 1 || got[0].Endpoint != want {
-				t.Errorf("app %d: renderBackends = %+v, want %s", app.ID, got, want)
-			}
-			if got := s.displayBackends(app, 8080); len(got) != 1 || got[0] != want {
-				t.Errorf("app %d: displayBackends = %v, want %s", app.ID, got, want)
-			}
-		}
-	})
-
-	t.Run("on: canary split survives a leftover host port", func(t *testing.T) {
-		s := newIngressService(t, true)
-		rel := uint(9)
-		canary := *routed
-		canary.CanaryReleaseID, canary.CanaryWeight = &rel, 20
-		got := s.renderBackends(&canary, 8080)
-		if len(got) != 2 || got[0].Weight != 80 || got[1].Weight != 20 {
-			t.Errorf("renderBackends = %+v, want an 80/20 stable+canary split", got)
-		}
-	})
-}
-
-func TestRequireRoutableNodeFollowsClusterMode(t *testing.T) {
-	app := &models.Application{ID: 10, ServerID: noAddrFwdServer}
-
-	if err := newIngressService(t, false).requireRoutableNode(app); !errors.Is(err, ErrNodeAddressRequired) {
-		t.Errorf("off: err = %v, want ErrNodeAddressRequired", err)
+// Every upstream is an alias: whichever gateway serves an app shares a network with it.
+func TestGatewayBackends(t *testing.T) {
+	s := newIngressService(t)
+	app := &models.Application{ID: 7, ServerID: memberServer, Alias: "mb-app-tok-7"}
+	if got := s.displayBackends(app, 8080); len(got) != 1 || got[0] != "http://mb-app-tok-7:8080" {
+		t.Errorf("displayBackends = %v, want the alias", got)
 	}
-	t.Run("on", func(t *testing.T) {
-		if err := newIngressService(t, true).requireRoutableNode(app); err != nil {
-			t.Errorf("on: err = %v, want nil — the alias upstream needs no node address", err)
-		}
-	})
+	rel := uint(9)
+	canary := *app
+	canary.CanaryReleaseID, canary.CanaryWeight = &rel, 20
+	if got := gatewayBackends(&canary, 8080); len(got) != 2 || got[0].Weight != 80 || got[1].Weight != 20 {
+		t.Errorf("gatewayBackends = %+v, want an 80/20 stable+canary split", got)
+	}
+	svc := &models.Application{ID: 8, RuntimeKind: models.RuntimeService, Alias: "mb-app-tok-8"}
+	if got := gatewayBackends(svc, 80); len(got) != 1 || got[0].Endpoint != "http://mb-app-tok-8:80" {
+		t.Errorf("service backends = %+v, want its VIP alias", got)
+	}
 }
 
 // Regression: a service-runtime app is always served by the central gateway, but its DNS pointed at the
 // edge-gateway node it was assigned to, whose gateway has no route for it.
-func TestEdgeGatewayAndDNSTarget(t *testing.T) {
-	s := newIngressService(t, false)
+func TestGatewayServerAndDNSTarget(t *testing.T) {
+	s := newIngressService(t)
 
 	tests := []struct {
 		name     string
@@ -131,7 +87,7 @@ func TestEdgeGatewayAndDNSTarget(t *testing.T) {
 		{"container app on an edge node", &models.Application{ServerID: edgeServer}, true, "203.0.113.3"},
 		{"service app on an edge node", &models.Application{ServerID: edgeServer, RuntimeKind: models.RuntimeService}, false, "198.51.100.1"},
 		{"container app on the local node", &models.Application{ServerID: localServer}, false, "198.51.100.1"},
-		{"container app on a port-forward node", &models.Application{ServerID: portFwdServer}, false, "198.51.100.1"},
+		{"container app on a cluster member", &models.Application{ServerID: memberServer}, false, "198.51.100.1"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -148,13 +104,13 @@ func TestEdgeGatewayAndDNSTarget(t *testing.T) {
 // The control-plane gateway cannot join a remote swarm's overlay, so the swarm's ingress node serves every app
 // in it, service apps included, whichever node they run on.
 func TestRemoteSwarmIsServedByItsIngressNode(t *testing.T) {
-	s := newIngressService(t, false)
+	s := newIngressService(t)
 	gw := &models.Cluster{ID: 9, Mode: models.ClusterModeSwarm, IngressServerID: edgeServer}
 	s.SetCluster(fakeCluster{on: true, gateway: gw})
 
 	for _, app := range []*models.Application{
-		{ClusterID: 9, ServerID: noAddrFwdServer, Alias: "mb-app-x-7"},
-		{ClusterID: 9, ServerID: noAddrFwdServer, RuntimeKind: models.RuntimeService, Alias: "mb-app-x-8"},
+		{ClusterID: 9, ServerID: memberServer, Alias: "mb-app-x-7"},
+		{ClusterID: 9, ServerID: memberServer, RuntimeKind: models.RuntimeService, Alias: "mb-app-x-8"},
 	} {
 		if id, ok := s.gatewayServer(app); !ok || id != edgeServer {
 			t.Errorf("app %s: gatewayServer = %d, %v, want the ingress node", app.Alias, id, ok)
@@ -162,19 +118,16 @@ func TestRemoteSwarmIsServedByItsIngressNode(t *testing.T) {
 		if ip, _ := s.dnsTarget(app); ip != "203.0.113.3" {
 			t.Errorf("app %s: dnsTarget = %q, want the ingress node's address", app.Alias, ip)
 		}
-		if err := s.requireRoutableNode(app); err != nil {
-			t.Errorf("app %s: requireRoutableNode = %v, want nil", app.Alias, err)
-		}
 		if got := s.displayBackends(app, 8080); len(got) != 1 || got[0] != "http://"+app.Alias+":8080" {
 			t.Errorf("app %s: displayBackends = %v, want its alias", app.Alias, got)
 		}
 	}
 
 	gw.IngressIP = "192.0.2.10"
-	if ip, _ := s.dnsTarget(&models.Application{ClusterID: 9, ServerID: noAddrFwdServer}); ip != "192.0.2.10" {
+	if ip, _ := s.dnsTarget(&models.Application{ClusterID: 9, ServerID: memberServer}); ip != "192.0.2.10" {
 		t.Errorf("dnsTarget = %q, want the cluster's ingress address", ip)
 	}
-	if _, ok := s.gatewayServer(&models.Application{ClusterID: 1, ServerID: portFwdServer}); ok {
+	if _, ok := s.gatewayServer(&models.Application{ClusterID: 1, ServerID: memberServer}); ok {
 		t.Error("an app outside the swarm was handed to its gateway")
 	}
 }

--- a/internal/services/route/route.go
+++ b/internal/services/route/route.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"slices"
 	"strings"
 	"time"
@@ -39,7 +38,6 @@ var (
 	ErrDomainNotRegistered = errors.New("no matching domain is registered in this workspace; add the domain first")
 	ErrDomainBanned        = errors.New("this domain has been banned by a platform administrator")
 	ErrHostTaken           = errors.New("hostname is already used by another route")
-	ErrNodeAddressRequired = errors.New("the node has no address set; set its private address before adding a route")
 	ErrAdvancedTLSCert     = errors.New("set TLS via the route's TLS mode and a managed certificate, not an inline tls certificate in advanced config")
 	ErrMiddlewareRequired  = errors.New("middleware name is required")
 	ErrMiddlewareNotFound  = errors.New("middleware not found in this workspace")
@@ -92,34 +90,23 @@ type Service struct {
 	apps        *repositories.ApplicationRepository
 	releases    *repositories.ReleaseRepository
 	servers     *repositories.ServerRepository
-	ports       *repositories.PortBindingRepository
 	proxy       proxy.Manager
 	certs       CertResolver
 	attacher    ProxyAttacher
-	publisher   PortPublisher
 	domains     DomainLister
 	wsPolicy    WorkspacePolicy
 	dnsAddr     DNSAddresser
 	reloader    EdgeReloader
 	cluster     ClusterCap
-	minPort     int
-	maxPort     int
 }
 
-// ClusterCap reports whether a cluster runs a swarm and whether a gateway of its own serves it.
-// Implemented by services/cluster.
+// ClusterCap reports whether a gateway of its own serves a cluster. Implemented by services/cluster.
 type ClusterCap interface {
-	IsSwarm(clusterID uint) bool
 	OwnGateway(clusterID uint) (*models.Cluster, bool)
 }
 
-// SetCluster wires swarm detection (nil-safe; nil = never cluster mode, so
-// remote nodes keep being reached by published host port).
+// SetCluster wires cluster gateways (nil-safe; nil = every cluster is served as the default one).
 func (s *Service) SetCluster(c ClusterCap) { s.cluster = c }
-
-func (s *Service) isSwarm(clusterID uint) bool {
-	return s.cluster != nil && s.cluster.IsSwarm(clusterID)
-}
 
 // EdgeReloader notifies edge-gateway nodes to pull their configuration immediately after a change,
 // instead of waiting for their HTTP-provider poll interval. Calls are best-effort. Optional: when
@@ -369,17 +356,6 @@ func (s *Service) persistRouteStatus(rt *models.Route, status models.RouteStatus
 	}
 }
 
-// PortPublisher ensures a port-forward app's container actually publishes the host ports its routes
-// need, rolling-redeploying if the live container is missing them. Implemented by the application
-// service; injected after construction to avoid an import cycle. nil means no auto-redeploy.
-type PortPublisher interface {
-	EnsurePublished(ctx context.Context, appID uint) error
-}
-
-// SetPortPublisher wires the publisher used to (re)publish host ports when a
-// port-forward app gains a route.
-func (s *Service) SetPortPublisher(p PortPublisher) { s.publisher = p }
-
 // ProxyAttacher reconciles whether an application's running container(s) are attached to the shared
 // reverse-proxy network, so only route-exposed apps join it. Implemented by the deploy worker, which
 // holds the per-node Docker clients; optional (nil means attachment is decided only at deploy time).
@@ -405,11 +381,9 @@ func NewService(
 	apps *repositories.ApplicationRepository,
 	releases *repositories.ReleaseRepository,
 	servers *repositories.ServerRepository,
-	ports *repositories.PortBindingRepository,
 	proxyMgr proxy.Manager,
-	minPort, maxPort int,
 ) *Service {
-	return &Service{routes: routes, middlewares: middlewares, apps: apps, releases: releases, servers: servers, ports: ports, proxy: proxyMgr, minPort: minPort, maxPort: maxPort}
+	return &Service{routes: routes, middlewares: middlewares, apps: apps, releases: releases, servers: servers, proxy: proxyMgr}
 }
 
 type Input struct {
@@ -448,9 +422,6 @@ func (s *Service) Create(ctx context.Context, workspaceID uint, in Input) (*mode
 	app, err := s.apps.FindInWorkspace(workspaceID, in.ApplicationID)
 	if err != nil {
 		return nil, ErrAppRequired
-	}
-	if err := s.requireRoutableNode(app); err != nil {
-		return nil, err
 	}
 	in.Hosts = normalizeHosts(in.Hosts)
 	if strings.TrimSpace(in.AdvancedConfig) == "" && len(in.Hosts) == 0 {
@@ -530,11 +501,6 @@ func (s *Service) Update(ctx context.Context, workspaceID, id uint, in Input) (*
 			return nil, ErrAppRequired
 		}
 		rt.ApplicationID = app.ID
-	}
-	if app, aerr := s.apps.FindByID(rt.ApplicationID); aerr == nil {
-		if err := s.requireRoutableNode(app); err != nil {
-			return nil, err
-		}
 	}
 	if in.Name != "" {
 		name := strings.TrimSpace(in.Name)
@@ -908,32 +874,6 @@ func (s *Service) SyncRoute(ctx context.Context, appID uint) error {
 	}
 	// Keep the app's public A/AAAA/CNAME records in sync with its routed hosts
 	s.reconcileAppDNS(ctx, app, routes)
-
-	if app.RuntimeKind == models.RuntimeService {
-		return s.SyncWorkspaceProxy(ctx, app.WorkspaceID)
-	}
-
-	if _, ok := s.gatewayServer(app); ok {
-		return s.SyncWorkspaceProxy(ctx, app.WorkspaceID)
-	}
-
-	enabledPorts := map[int]bool{}
-	if app.CurrentReleaseID != nil {
-		for i := range routes {
-			rt := &routes[i]
-			port := routePort(rt, app)
-			if rt.Enabled {
-				enabledPorts[port] = true
-			}
-			_ = s.backendsFor(app, port)
-		}
-	}
-	if srv := s.serverFor(app); !s.useAliasUpstream(srv) {
-		s.reconcileManagedPorts(app.ID, enabledPorts)
-		if s.publisher != nil {
-			_ = s.publisher.EnsurePublished(ctx, app.ID)
-		}
-	}
 	return s.SyncWorkspaceProxy(ctx, app.WorkspaceID)
 }
 
@@ -998,7 +938,7 @@ func (s *Service) SyncWorkspaceProxy(ctx context.Context, workspaceID uint) erro
 			rt := &routes[j]
 			serve, status, reason := routeServeState(rt, domains, gate, privileged)
 			port := routePort(rt, app)
-			rr := renderedRoute(rt, s.renderBackends(app, port), !serve)
+			rr := renderedRoute(rt, gatewayBackends(app, port), !serve)
 			if pair, ok := s.certPair(rt); ok {
 				rr.Certs = []proxy.CertPair{pair}
 			}
@@ -1067,56 +1007,6 @@ func (s *Service) ResyncAllProxy(ctx context.Context) error {
 		}
 	}
 	return nil
-}
-
-func (s *Service) renderBackends(app *models.Application, port int) []proxy.Backend {
-	if app.RuntimeKind == models.RuntimeService {
-		return []proxy.Backend{{Endpoint: fmt.Sprintf("%s://%s:%d", portScheme(app, port), node.AppAlias(app), port)}}
-	}
-	srv, _ := s.servers.FindByID(app.ServerID)
-	if !s.useAliasUpstream(srv) {
-		if hp := s.hostPort(app.ID, port); hp > 0 && strings.TrimSpace(srv.Address) != "" {
-			return []proxy.Backend{{Endpoint: fmt.Sprintf("%s://%s:%d", portScheme(app, port), srv.Address, hp)}}
-		}
-		return nil
-	}
-	return aliasBackends(app, port, portScheme(app, port))
-}
-
-func (s *Service) serverFor(app *models.Application) *models.Server {
-	srv, err := s.servers.FindByID(app.ServerID)
-	if err != nil {
-		return nil
-	}
-	return srv
-}
-
-// requireRoutableNode rejects routing an app the gateway must reach by host port when its node has no
-// address (otherwise the route would be a dead upstream). Alias upstreams need no node address.
-func (s *Service) requireRoutableNode(app *models.Application) error {
-	if _, ok := s.gatewayServer(app); ok {
-		return nil
-	}
-	srv := s.serverFor(app)
-	if !s.useAliasUpstream(srv) && strings.TrimSpace(srv.Address) == "" {
-		return ErrNodeAddressRequired
-	}
-	return nil
-}
-
-// reconcileManagedPorts deletes the app's managed (auto-forward) bindings whose container port is no
-// longer referenced by an enabled route. The published port on the running container is harmless until the
-// next deploy drops it; the gateway already stops targeting it when the route is removed.
-func (s *Service) reconcileManagedPorts(appID uint, keep map[int]bool) {
-	managed, err := s.ports.ListManagedByApp(appID)
-	if err != nil {
-		return
-	}
-	for i := range managed {
-		if !keep[managed[i].ContainerPort] {
-			_ = s.ports.Delete(managed[i].ID)
-		}
-	}
 }
 
 func (s *Service) clusterGateway(clusterID uint) (*models.Cluster, bool) {
@@ -1202,14 +1092,6 @@ func (s *Service) enrichDNS(rt *models.Route) {
 }
 
 func (s *Service) displayBackends(app *models.Application, port int) []string {
-	if _, served := s.gatewayServer(app); !served && app.RuntimeKind != models.RuntimeService {
-		if srv := s.serverFor(app); !s.useAliasUpstream(srv) {
-			if hp := s.hostPort(app.ID, port); hp > 0 && strings.TrimSpace(srv.Address) != "" {
-				return []string{fmt.Sprintf("%s://%s:%d", portScheme(app, port), srv.Address, hp)}
-			}
-			return nil
-		}
-	}
 	backends := gatewayBackends(app, port)
 	out := make([]string, 0, len(backends))
 	for _, b := range backends {
@@ -1274,39 +1156,6 @@ func routePort(rt *models.Route, app *models.Application) int {
 	return port
 }
 
-// backendsFor builds the central proxy's upstreams for an app's route: the app's
-// DNS alias where the gateway can reach it, otherwise a published host port on its
-// node (see useAliasUpstream).
-func (s *Service) backendsFor(app *models.Application, port int) []proxy.Backend {
-	srv, _ := s.servers.FindByID(app.ServerID)
-	if s.useAliasUpstream(srv) {
-		return aliasBackends(app, port, portScheme(app, port))
-	}
-
-	hp, _ := s.ensureRemotePort(app, srv, port)
-	if hp > 0 && strings.TrimSpace(srv.Address) != "" {
-		return []proxy.Backend{{Endpoint: fmt.Sprintf("%s://%s:%d", portScheme(app, port), srv.Address, hp)}}
-	}
-	return nil
-}
-
-func (s *Service) useAliasUpstream(srv *models.Server) bool {
-	return !isRemotePortForward(srv) || s.isSwarm(srv.ClusterID)
-}
-
-// isRemotePortForward reports whether srv is a remote node reached by publishing
-// host ports (the auto-port-forward case).
-func isRemotePortForward(srv *models.Server) bool {
-	return srv != nil && !srv.IsLocal && srv.Connectivity == models.ConnectivityPortForward
-}
-
-func privateBindIP(srv *models.Server) string {
-	if ip := net.ParseIP(strings.TrimSpace(srv.Address)); ip != nil && ip.To4() != nil {
-		return ip.String()
-	}
-	return ""
-}
-
 // aliasBackends builds node-local DNS-alias upstreams (control-plane Goma for the
 // local node, or the node's own gateway for edge-gateway nodes), with canary
 // weighting. scheme (http|https) is the app port's application protocol.
@@ -1362,66 +1211,6 @@ func portScheme(app *models.Application, port int) string {
 		}
 	}
 	return "http"
-}
-
-func (s *Service) hostPort(appID uint, containerPort int) int {
-	bindings, err := s.ports.ListApprovedByApp(appID)
-	if err != nil {
-		return 0
-	}
-	for _, b := range bindings {
-		if b.ContainerPort == containerPort {
-			return b.HostPort
-		}
-	}
-	return 0
-}
-
-// ensureRemotePort returns the host port published for a port-forward node app's container port,
-// auto-provisioning an approved binding the first time the app is routed — these are control-plane-managed,
-// so it allocates from the node's range directly. Idempotent; created is true only for a new binding.
-func (s *Service) ensureRemotePort(app *models.Application, srv *models.Server, containerPort int) (int, bool) {
-	if hp := s.hostPort(app.ID, containerPort); hp > 0 {
-		return hp, false
-	}
-	hp := s.allocateHostPort(app.ServerID)
-	if hp == 0 {
-		logger.Warn("host-port range exhausted; route has no upstream",
-			"app", app.ID, "server", app.ServerID, "range", fmt.Sprintf("%d-%d", s.minPort, s.maxPort))
-		return 0, false
-	}
-	b := &models.PortBinding{
-		WorkspaceID:   app.WorkspaceID,
-		ApplicationID: app.ID,
-		ServerID:      app.ServerID,
-		ContainerPort: containerPort,
-		Protocol:      "tcp",
-		HostPort:      hp,
-		Status:        models.PortBindingApproved,
-		Managed:       true,
-		BindIP:        privateBindIP(srv),
-		ReviewNote:    "Auto-provisioned for port-forward node ingress",
-	}
-	if err := s.ports.Create(b); err != nil {
-		return 0, false
-	}
-	return hp, true
-}
-
-// allocateHostPort scans the configured host-port range for a port not already
-// claimed on the given node, returning 0 when the range is exhausted. Host ports
-// are per-node, so the same number can be reused across different nodes.
-func (s *Service) allocateHostPort(serverID uint) int {
-	for p := s.minPort; p <= s.maxPort; p++ {
-		inUse, err := s.ports.HostPortInUse(serverID, p, "tcp", 0)
-		if err != nil {
-			return 0
-		}
-		if !inUse {
-			return p
-		}
-	}
-	return 0
 }
 
 // RouteNamesForNode returns the Goma route names a node serves, as they appear in

--- a/internal/services/route/route_test.go
+++ b/internal/services/route/route_test.go
@@ -67,41 +67,6 @@ func TestPortScheme(t *testing.T) {
 	}
 }
 
-func TestIsRemotePortForward(t *testing.T) {
-	cases := []struct {
-		name string
-		srv  *models.Server
-		want bool
-	}{
-		{"nil", nil, false},
-		{"local manager", &models.Server{IsLocal: true, Connectivity: models.ConnectivityPortForward}, false},
-		{"remote port-forward", &models.Server{Connectivity: models.ConnectivityPortForward}, true},
-		{"remote edge-gateway", &models.Server{Connectivity: models.ConnectivityEdgeGateway}, false},
-	}
-	for _, c := range cases {
-		if got := isRemotePortForward(c.srv); got != c.want {
-			t.Errorf("%s: isRemotePortForward = %v, want %v", c.name, got, c.want)
-		}
-	}
-}
-
-func TestPrivateBindIP(t *testing.T) {
-	cases := []struct {
-		addr, want string
-	}{
-		{"10.0.0.7", "10.0.0.7"},       // private IPv4 → bind to it
-		{"203.0.113.5", "203.0.113.5"}, // any IPv4 is returned (privacy via firewall)
-		{"node.example.com", ""},       // hostname → all interfaces
-		{"", ""},                       // unset → all interfaces
-		{"fd00::1", ""},                // IPv6 → all interfaces (avoid host:port ambiguity)
-	}
-	for _, c := range cases {
-		if got := privateBindIP(&models.Server{Address: c.addr}); got != c.want {
-			t.Errorf("privateBindIP(%q) = %q, want %q", c.addr, got, c.want)
-		}
-	}
-}
-
 func TestSanitizeBase(t *testing.T) {
 	cases := map[string]string{
 		"apps.example.com":    "apps.example.com",
@@ -195,51 +160,12 @@ func (f fakeCluster) OwnGateway(id uint) (*models.Cluster, bool) {
 	return f.gateway, f.gateway != nil && f.gateway.ID == id
 }
 
-// A port-forward node is reached by a published host port — until cluster mode is
-// on, at which point the app is on the shared ingress overlay and the gateway
-// dials its DNS alias instead, on any node, with nothing published.
-func TestUseAliasUpstream(t *testing.T) {
-	local := &models.Server{IsLocal: true}
-	edge := &models.Server{Connectivity: models.ConnectivityEdgeGateway}
-	portFwd := &models.Server{Connectivity: models.ConnectivityPortForward}
-
-	tests := []struct {
-		name      string
-		srv       *models.Server
-		clusterOn bool
-		want      bool
-	}{
-		{name: "local node always uses its alias", srv: local, want: true},
-		{name: "edge-gateway node shares a network with its own gateway", srv: edge, want: true},
-		{name: "port-forward node without cluster publishes a host port", srv: portFwd, want: false},
-		{name: "port-forward node with cluster reaches the alias over the ingress overlay", srv: portFwd, clusterOn: true, want: true},
-		{name: "unknown node falls back to the alias", srv: nil, want: true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s := &Service{}
-			if tt.clusterOn {
-				s.SetCluster(fakeCluster{on: true})
-			}
-			if got := s.useAliasUpstream(tt.srv); got != tt.want {
-				t.Errorf("useAliasUpstream = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-// Regression: on a port-forward node the host-port upstream can only name one
-// container, so a canary there received 0% of traffic while the UI reported its
-// weight. In cluster mode the alias upstream must carry the split.
-func TestCanaryWeightSurvivesOnAPortForwardNodeInClusterMode(t *testing.T) {
+// Regression: the old host-port upstream could only name one container, so a canary received 0% of traffic
+// while the UI reported its weight. The alias upstream must carry the split.
+func TestCanaryWeightSplitsTheAliasUpstream(t *testing.T) {
 	rel := uint(9)
 	app := &models.Application{Alias: "mb-app-tok-7", CanaryReleaseID: &rel, CanaryWeight: 20}
 
-	s := &Service{}
-	s.SetCluster(fakeCluster{on: true})
-	if !s.useAliasUpstream(&models.Server{Connectivity: models.ConnectivityPortForward}) {
-		t.Fatal("cluster mode must route a port-forward node over its alias")
-	}
 	b := aliasBackends(app, 80, "http")
 	if len(b) != 2 {
 		t.Fatalf("want a weighted stable+canary split, got %d backend(s): %+v", len(b), b)

--- a/internal/storage/migration/upgrade/steps_2026_09_11_port_forward.go
+++ b/internal/storage/migration/upgrade/steps_2026_09_11_port_forward.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package upgrade
+
+import (
+	"context"
+
+	"github.com/jkaninda/logger"
+	"gorm.io/gorm"
+)
+
+type portBindingRow struct {
+	ID uint `gorm:"primaryKey"`
+}
+
+func (portBindingRow) TableName() string { return "port_bindings" }
+
+// portForwardStep retires port-forward connectivity (plans/multi-cluster-plan.md §7). The control-plane node
+// and swarm members are served by their cluster's gateway; any other port-forward node becomes an edge
+// gateway, flagged on its cluster so the console offers to confirm that or join it to a swarm. Safe to re-run.
+func portForwardStep(ctx context.Context, db *gorm.DB) error {
+	if !db.Migrator().HasTable(&clusterRow{}) || !db.Migrator().HasTable(&clusterServerRow{}) {
+		return nil
+	}
+	return db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var servers []clusterServerRow
+		if err := tx.Where("connectivity = ?", "port-forward").Find(&servers).Error; err != nil {
+			return err
+		}
+		for _, srv := range servers {
+			var mode string
+			if err := tx.Model(&clusterRow{}).Select("mode").Where("id = ?", srv.ClusterID).Scan(&mode).Error; err != nil {
+				return err
+			}
+			to := "edge-gateway"
+			if srv.IsLocal || mode == "swarm" {
+				to = "cluster"
+			}
+			if err := tx.Model(&clusterServerRow{}).Where("id = ?", srv.ID).Update("connectivity", to).Error; err != nil {
+				return err
+			}
+			if to == "cluster" {
+				continue
+			}
+			if err := tx.Model(&clusterRow{}).Where("id = ? AND is_default = ?", srv.ClusterID, false).
+				Updates(map[string]any{"legacy_ingress": true, "ingress_server_id": srv.ID}).Error; err != nil {
+				return err
+			}
+			logger.Warn("converted a port-forward node to an edge gateway: it needs public ports 80 and 443, "+
+				"or join it to a swarm cluster from its cluster page", "node", srv.Name)
+		}
+		if !tx.Migrator().HasTable(&portBindingRow{}) {
+			return nil
+		}
+		if tx.Migrator().HasColumn(&portBindingRow{}, "managed") {
+			if err := tx.Where("managed = ?", true).Delete(&portBindingRow{}).Error; err != nil {
+				return err
+			}
+			if err := tx.Migrator().DropColumn(&portBindingRow{}, "managed"); err != nil {
+				return err
+			}
+		}
+		if tx.Migrator().HasColumn(&portBindingRow{}, "bind_ip") {
+			return tx.Migrator().DropColumn(&portBindingRow{}, "bind_ip")
+		}
+		return nil
+	})
+}
+
+func init() {
+	steps = append(steps, Step{
+		Name:    "port_forward_retire",
+		Version: "1.10.0",
+		Run:     portForwardStep,
+	})
+}

--- a/internal/storage/migration/upgrade/steps_2026_09_11_port_forward_test.go
+++ b/internal/storage/migration/upgrade/steps_2026_09_11_port_forward_test.go
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package upgrade
+
+import (
+	"context"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type bindingFixture struct {
+	ID      uint `gorm:"primaryKey"`
+	Managed bool
+	BindIP  string
+}
+
+func (bindingFixture) TableName() string { return "port_bindings" }
+
+func TestPortForwardStep(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&clusterRow{}, &serverFixture{}, &bindingFixture{}); err != nil {
+		t.Fatal(err)
+	}
+	must := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	must(db.Create(&[]clusterRow{
+		{ID: 1, Name: "default", IsDefault: true, Mode: "swarm", Visibility: "all"},
+		{ID: 2, Name: "lyon", Mode: "standalone", ManagerServerID: 12, Visibility: "all"},
+	}).Error)
+	must(db.Create(&[]serverFixture{
+		{ID: 10, Name: "manager", IsLocal: true, Connectivity: "port-forward", ClusterID: 1},
+		{ID: 11, Name: "worker", Connectivity: "port-forward", ClusterID: 1},
+		{ID: 12, Name: "lyon", Connectivity: "port-forward", ClusterID: 2},
+		{ID: 13, Name: "paris", Connectivity: "edge-gateway", ClusterID: 1},
+	}).Error)
+	must(db.Create(&[]bindingFixture{{ID: 1, Managed: true, BindIP: "10.0.0.12"}, {ID: 2}}).Error)
+
+	for run := 0; run < 2; run++ {
+		must(portForwardStep(context.Background(), db))
+	}
+
+	want := map[uint]string{10: "cluster", 11: "cluster", 12: "edge-gateway", 13: "edge-gateway"}
+	var servers []serverFixture
+	must(db.Find(&servers).Error)
+	for _, s := range servers {
+		if s.Connectivity != want[s.ID] {
+			t.Errorf("node %s connectivity = %q, want %q", s.Name, s.Connectivity, want[s.ID])
+		}
+	}
+
+	var lyon clusterRow
+	must(db.First(&lyon, 2).Error)
+	if !lyon.LegacyIngress || lyon.IngressServerID != 12 {
+		t.Errorf("converted cluster = legacy %v, ingress node %d; want flagged and served by node 12", lyon.LegacyIngress, lyon.IngressServerID)
+	}
+	var def clusterRow
+	must(db.First(&def, 1).Error)
+	if def.LegacyIngress {
+		t.Error("the default cluster was flagged for conversion")
+	}
+
+	var n int64
+	must(db.Table("port_bindings").Count(&n).Error)
+	if n != 1 {
+		t.Errorf("port bindings = %d, want only the user-requested one left", n)
+	}
+	for _, col := range []string{"managed", "bind_ip"} {
+		if db.Migrator().HasColumn(&portBindingRow{}, col) {
+			t.Errorf("port_bindings.%s was not dropped", col)
+		}
+	}
+}

--- a/internal/storage/repositories/cluster_repo.go
+++ b/internal/storage/repositories/cluster_repo.go
@@ -196,7 +196,6 @@ func (r *ClusterRepository) CreateStandalone(srv *models.Server, name string) (*
 		Mode:            models.ClusterModeStandalone,
 		ManagerServerID: srv.ID,
 		Visibility:      models.ClusterVisibilityAll,
-		LegacyIngress:   srv.Connectivity == models.ConnectivityPortForward,
 	}
 	if srv.Connectivity == models.ConnectivityEdgeGateway {
 		c.IngressServerID = srv.ID

--- a/internal/storage/repositories/port_repo.go
+++ b/internal/storage/repositories/port_repo.go
@@ -79,12 +79,10 @@ func (r *PortBindingRepository) ListByWorkspace(workspaceID uint) ([]models.Port
 	return bindings, err
 }
 
-// ListByStatus returns user-requested bindings across all workspaces in a given
-// status (the admin review queue). Managed (auto-forward) bindings are excluded
-// — they are control-plane resources, never reviewed.
+// ListByStatus returns bindings across all workspaces in a given status (the admin review queue).
 func (r *PortBindingRepository) ListByStatus(status models.PortBindingStatus) ([]models.PortBinding, error) {
 	var bindings []models.PortBinding
-	err := r.db.Where("status = ? AND managed = ?", status, false).Order("created_at ASC").Find(&bindings).Error
+	err := r.db.Where("status = ?", status).Order("created_at ASC").Find(&bindings).Error
 	return bindings, err
 }
 
@@ -102,13 +100,6 @@ func (r *PortBindingRepository) ListActive() ([]models.PortBinding, error) {
 func (r *PortBindingRepository) ListApprovedByApp(appID uint) ([]models.PortBinding, error) {
 	var bindings []models.PortBinding
 	err := r.db.Where("application_id = ? AND status = ?", appID, models.PortBindingApproved).Find(&bindings).Error
-	return bindings, err
-}
-
-// ListManagedByApp returns the app's managed (auto-forward) bindings.
-func (r *PortBindingRepository) ListManagedByApp(appID uint) ([]models.PortBinding, error) {
-	var bindings []models.PortBinding
-	err := r.db.Where("application_id = ? AND managed = ?", appID, true).Find(&bindings).Error
 	return bindings, err
 }
 

--- a/internal/storage/repositories/server_repo.go
+++ b/internal/storage/repositories/server_repo.go
@@ -116,7 +116,7 @@ func (r *ServerRepository) EnsureLocal(name, endpoint string) (*models.Server, e
 		return nil, err
 	}
 	// Control-plane node defaults to manager + edge-gateway so it can run its own
-	// Goma gateway for public ingress + TLS. Admin can switch back to port-forward.
+	// Goma gateway for public ingress + TLS. Admin can switch it to cluster (the central gateway).
 	s = &models.Server{
 		Name: name, DisplayName: name, DockerEndpoint: endpoint, IsLocal: true,
 		Role: models.RoleManager, Connectivity: models.ConnectivityEdgeGateway,

--- a/internal/worker/deploy.go
+++ b/internal/worker/deploy.go
@@ -490,15 +490,10 @@ func (h *DeployHandler) run(ctx context.Context, app *models.Application, dep *m
 	// Publish admin-approved host port bindings. A canary shares the host with the stable container,
 	// so it must not re-publish the same host ports; the canary is reachable over the proxy weight only.
 	ports := map[string]string{}
-	bindIPs := map[string]string{}
 	if h.portBindings != nil && !canary {
 		if approved, err := h.portBindings.ListApprovedByApp(app.ID); err == nil {
 			for _, b := range approved {
-				key := fmt.Sprintf("%d/%s", b.ContainerPort, b.Protocol)
-				ports[key] = fmt.Sprintf("%d", b.HostPort)
-				if b.BindIP != "" {
-					bindIPs[key] = b.BindIP // publish on the node's private interface
-				}
+				ports[fmt.Sprintf("%d/%s", b.ContainerPort, b.Protocol)] = fmt.Sprintf("%d", b.HostPort)
 			}
 		}
 	}
@@ -580,7 +575,6 @@ func (h *DeployHandler) run(ctx context.Context, app *models.Application, dep *m
 		Binds:            rc.Binds,
 		Networks:         rc.Networks,
 		Ports:            ports,
-		PortBindIPs:      bindIPs,
 		NetworkAliases:   []string{upstreamAlias}, // upstream alias for the proxy (stable or canary)
 		AliasesByNetwork: aliasesByNet,
 		MemoryBytes:      rc.MemoryBytes,

--- a/web/src/api/clusters.ts
+++ b/web/src/api/clusters.ts
@@ -8,6 +8,11 @@ export interface ClusterUpdate {
   cordoned?: boolean
 }
 
+export interface ConvertIngressInput {
+  action: 'gateway' | 'join'
+  target_cluster_id?: number
+}
+
 export interface ClusterGatewayInput {
   server_id: number
   ingress_ip?: string
@@ -21,4 +26,6 @@ export const clustersApi = {
   update: (id: number, body: ClusterUpdate) => api.patch<ApiResponse<Cluster>>(`/admin/clusters/${id}`, body),
   setGateway: (id: number, body: ClusterGatewayInput) =>
     api.put<ApiResponse<Cluster>>(`/admin/clusters/${id}/gateway`, body),
+  convertIngress: (id: number, body: ConvertIngressInput) =>
+    api.post<ApiResponse<{ message: string }>>(`/admin/clusters/${id}/convert`, body),
 }

--- a/web/src/api/marketplace.ts
+++ b/web/src/api/marketplace.ts
@@ -1,5 +1,5 @@
 import api, { sseUrl } from './client'
-import type { ApiResponse } from './types'
+import type { ApiResponse, DatabaseInstance } from './types'
 
 // TemplateInput is an install-wizard question.
 export interface TemplateInput {
@@ -234,6 +234,9 @@ export const marketplaceApi = {
   // Async install: start a job, then stream its progress over SSE.
   startInstall: (ws: number, input: InstallInput) =>
     api.post<ApiResponse<InstallJob>>(`${w(ws)}/marketplace/install/jobs`, input),
+  // Database instances an install into a location may reuse or pin ('' = the workspace default).
+  databases: (ws: number, location = '') =>
+    api.get<ApiResponse<DatabaseInstance[]>>(`${w(ws)}/marketplace/databases${location ? `?location=${encodeURIComponent(location)}` : ''}`),
   installJob: (ws: number, id: string) =>
     api.get<ApiResponse<InstallJob>>(`${w(ws)}/marketplace/install/jobs/${id}`),
   installJobEventsUrl: (ws: number, id: string) =>

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -800,8 +800,6 @@ export interface PortBinding {
   host_port: number
   status: PortBindingStatus
   server_id?: number
-  managed?: boolean
-  bind_ip?: string
   requested_by: number
   reviewed_by?: number
   review_note?: string
@@ -1221,8 +1219,7 @@ export interface Route {
   has_custom_cert: boolean
   dns_target?: string
   dns_hostname?: string
-  // Actual upstream endpoints the gateway uses (alias, or a port-forward node's
-  // address:hostPort). Populated on read.
+  // Actual upstream endpoints the gateway uses. Populated on read.
   backends?: string[]
   created_at?: string
 }
@@ -1815,7 +1812,7 @@ export interface AuditLogDetail extends AuditLog {
   actor_email?: string
 }
 
-export type ServerConnectivity = 'port-forward' | 'edge-gateway'
+export type ServerConnectivity = 'edge-gateway' | 'cluster'
 
 export type ServerRole = 'manager' | 'node'
 
@@ -2702,7 +2699,6 @@ export interface PortEntry {
   app_name?: string
   container_port?: number
   container?: string
-  managed?: boolean
   requested_by?: number
   created_at?: string
 }

--- a/web/src/constants/node.ts
+++ b/web/src/constants/node.ts
@@ -27,9 +27,9 @@ export const CONNECTIVITY_TYPES: NodeOption[] = [
     description: 'The node runs its own gateway for public ingress and TLS termination at the edge.',
   },
   {
-    value: 'port-forward',
-    label: 'Port forwarding (legacy)',
-    description: 'A central proxy forwards traffic to node:port. No longer offered for new nodes: a node without public ports should join the cluster instead.',
+    value: 'cluster',
+    label: 'Cluster gateway',
+    description: "The node runs no gateway of its own: its swarm cluster's gateway serves its apps over the overlay. Only for swarm members.",
   },
 ]
 

--- a/web/src/views/admin/ClusterDetail.vue
+++ b/web/src/views/admin/ClusterDetail.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useNotificationStore } from '@/stores/notification'
 import { clustersApi } from '@/api/clusters'
@@ -107,6 +107,41 @@ async function saveGateway() {
     notify.apiError(e, 'Failed to update the gateway')
   } finally {
     saving.value = false
+  }
+}
+
+const needsIngress = computed(() =>
+  !!cluster.value && !isDefault.value && cluster.value.mode === 'standalone' &&
+  (cluster.value.legacy_ingress || (!!managerNode.value && managerNode.value.connectivity !== 'edge-gateway')),
+)
+const swarmTargets = ref<Cluster[]>([])
+const convertTarget = ref(0)
+const converting = ref(false)
+watch(needsIngress, async (needed) => {
+  if (!needed) return
+  try {
+    swarmTargets.value = ((await clustersApi.list()).data.data ?? []).filter((c) => c.mode === 'swarm' && c.id !== cluster.value?.id)
+    convertTarget.value = swarmTargets.value[0]?.id ?? 0
+  } catch {
+    swarmTargets.value = []
+  }
+})
+async function convertIngress(action: 'gateway' | 'join') {
+  if (!cluster.value) return
+  converting.value = true
+  try {
+    await clustersApi.convertIngress(cluster.value.id, { action, target_cluster_id: action === 'join' ? convertTarget.value : undefined })
+    if (action === 'join') {
+      notify.success('Node joined the swarm cluster')
+      router.push(`/admin/clusters/${convertTarget.value}`)
+    } else {
+      notify.success('Gateway confirmed')
+      await load()
+    }
+  } catch (e) {
+    notify.apiError(e)
+  } finally {
+    converting.value = false
   }
 }
 
@@ -406,7 +441,6 @@ function swarmClass(n: Server): string {
           <dt>Gateway</dt>
           <dd>
             <router-link v-if="ingressNode" :to="`/admin/nodes/${ingressNode.id}`">{{ ingressNode.display_name || ingressNode.name }}</router-link>
-            <span v-else-if="cluster.legacy_ingress">Central gateway, by host port</span>
             <span v-else>—</span>
             <span v-if="canSetGateway && (cluster.ingress_hostname || cluster.ingress_ip)" class="badge badge-muted mono">{{ cluster.ingress_hostname || cluster.ingress_ip }}</span>
             <button v-if="canSetGateway" class="btn btn-ghost btn-sm" @click="openGateway">Change</button>
@@ -417,12 +451,31 @@ function swarmClass(n: Server): string {
             <span v-if="cluster.cordoned" class="badge badge-warning">cordoned</span>
           </dd>
         </dl>
-        <div v-if="cluster.legacy_ingress" class="pending-hint">
+        <div v-if="needsIngress" class="pending-hint">
           <span class="mdi mdi-alert-outline"></span>
-          <span>
-            This cluster was converted from a port-forward node. Give the node its own gateway, or join it to the
-            default cluster as a worker: port-forward connectivity is being retired.
-          </span>
+          <div>
+            <p v-if="cluster.legacy_ingress" style="margin: 0 0 8px">
+              Port forwarding is retired, so this node now runs its own gateway, which needs public ports 80 and 443.
+              If it has none, join it to a swarm cluster, whose gateway then serves its apps.
+            </p>
+            <p v-else style="margin: 0 0 8px">
+              This node runs no gateway of its own, so its apps are not publicly routed. Give it one, or join it to a
+              swarm cluster.
+            </p>
+            <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap">
+              <button class="btn btn-secondary btn-sm" :disabled="converting" @click="convertIngress('gateway')">
+                {{ cluster.legacy_ingress ? 'Keep its own gateway' : 'Give it a gateway' }}
+              </button>
+              <template v-if="swarmTargets.length">
+                <select v-model.number="convertTarget" class="form-select" style="width: auto" aria-label="Swarm cluster">
+                  <option v-for="t in swarmTargets" :key="t.id" :value="t.id">{{ t.display_name || t.name }}</option>
+                </select>
+                <button class="btn btn-secondary btn-sm" :disabled="converting || !convertTarget" @click="convertIngress('join')">
+                  Join as a worker
+                </button>
+              </template>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/web/src/views/admin/Clusters.vue
+++ b/web/src/views/admin/Clusters.vue
@@ -51,7 +51,7 @@ onMounted(load)
                         v-if="c.legacy_ingress"
                         class="badge badge-warning"
                         style="margin-left: 8px"
-                        title="Converted from a port-forward node: the central gateway still reaches its apps by host port"
+                        title="Converted from a port-forward node: confirm its own gateway or join it to a swarm cluster"
                       >legacy ingress</span>
                     </span>
                     <span class="cell-sub mono">{{ c.name }}</span>

--- a/web/src/views/admin/NodeDetail.vue
+++ b/web/src/views/admin/NodeDetail.vue
@@ -689,7 +689,7 @@ async function regenerate() {
 const showEdit = ref(false)
 const editSaving = ref(false)
 const editForm = ref<CreateNodePayload>({
-  display_name: '', address: '', public_ip: '', public_hostname: '', connectivity: 'port-forward', access_mode: 'agent',
+  display_name: '', address: '', public_ip: '', public_hostname: '', connectivity: 'edge-gateway', access_mode: 'agent',
   docker_endpoint: '', tls_ca_cert: '', tls_cert: '', tls_key: '',
 })
 function openEdit() {
@@ -704,7 +704,7 @@ function openEdit() {
   // changed one is rejected by the server.
   editForm.value = {
     display_name: n.display_name || n.name, address: n.address || '', public_ip: n.public_ip || '', public_hostname: n.public_hostname || '',
-    connectivity: n.connectivity || 'port-forward',
+    connectivity: n.connectivity || 'edge-gateway',
     access_mode: n.access_mode || 'agent', docker_endpoint: n.docker_endpoint || '',
     tls_ca_cert: '', tls_cert: '', tls_key: '',
   }
@@ -747,14 +747,14 @@ const connSaving = ref(false)
 const connAck = ref(false)
 const connImpact = ref<NodeWorkloads | null>(null)
 const connForm = ref<CreateNodePayload>({
-  display_name: '', address: '', public_ip: '', public_hostname: '', connectivity: 'port-forward',
+  display_name: '', address: '', public_ip: '', public_hostname: '', connectivity: 'edge-gateway',
   access_mode: 'agent', docker_endpoint: '', tls_ca_cert: '', tls_cert: '', tls_key: '',
 })
 const connEndpointPlaceholder = computed(() => connForm.value.access_mode === 'api' ? 'tcp://10.0.0.10:2376' : '')
 const connAccessModeDesc = computed(() => nodeOptionDescription(ACCESS_MODES, connForm.value.access_mode))
 const connConnectivityDesc = computed(() => nodeOptionDescription(CONNECTIVITY_TYPES, connForm.value.connectivity))
 const connectivityOptions = computed(() =>
-  CONNECTIVITY_TYPES.filter((o) => o.value !== 'port-forward' || node.value?.connectivity === 'port-forward'),
+  CONNECTIVITY_TYPES.filter((o) => o.value !== 'cluster' || node.value?.is_local || node.value?.in_swarm || node.value?.connectivity === 'cluster'),
 )
 async function openConnectivity() {
   if (!node.value) return
@@ -767,7 +767,7 @@ async function openConnectivity() {
   // (display name / public addresses) alongside the connectivity changes.
   connForm.value = {
     display_name: n.display_name || n.name, address: n.address || '', public_ip: n.public_ip || '', public_hostname: n.public_hostname || '',
-    connectivity: n.connectivity || 'port-forward',
+    connectivity: n.connectivity || 'edge-gateway',
     access_mode: n.access_mode || 'agent', docker_endpoint: n.docker_endpoint || '',
     tls_ca_cert: '', tls_cert: '', tls_key: '',
   }
@@ -839,7 +839,7 @@ function fmtSize(n?: number): string {
   return `${v.toFixed(v < 10 && i > 0 ? 1 : 0)} ${units[i]}`
 }
 function connectivityLabel(): string {
-  return isEdge.value ? 'Edge gateway (own TLS)' : 'Port forwarding'
+  return isEdge.value ? 'Edge gateway (own TLS)' : 'Cluster gateway'
 }
 const gwBadge = computed(() => {
   if (!gateway.value?.deployed) return { cls: 'badge-neutral', text: 'not deployed' }

--- a/web/src/views/admin/Nodes.vue
+++ b/web/src/views/admin/Nodes.vue
@@ -182,7 +182,7 @@ async function copy(text: string) {
 }
 
 function connectivityLabel(c?: ServerConnectivity): string {
-  return c === 'edge-gateway' ? 'Edge gateway' : 'Port forwarding'
+  return c === 'edge-gateway' ? 'Edge gateway' : 'Cluster gateway'
 }
 function statusClass(n: Server): string {
   if (n.is_local || n.agent_connected) return 'badge-success badge-dot'
@@ -351,7 +351,7 @@ function swarmClass(n: Server): string {
               </template>
 
               <div v-if="form.access_mode !== 'api'" class="form-group">
-                <label class="form-label">Address <span class="cell-sub">(host/IP the proxy reaches published ports at)</span></label>
+                <label class="form-label">Address <span class="cell-sub">(the node's private host or IP)</span></label>
                 <input v-model="form.address" class="form-input" placeholder="e.g. 10.0.0.7" />
               </div>
               <div class="form-group" style="margin-bottom: 0">

--- a/web/src/views/admin/Ports.vue
+++ b/web/src/views/admin/Ports.vue
@@ -206,8 +206,6 @@ const STATE_CLASS: Record<string, string> = {
               <td class="mono">{{ e.host_port }}/{{ e.protocol }}</td>
               <td>
                 <span class="badge" :class="STATE_CLASS[e.state]">{{ STATE_LABEL[e.state] }}</span>
-                <span v-if="e.managed" class="badge badge-neutral" style="margin-left: 6px"
-                  title="Created by Miabi for route ingress; not a user request">auto</span>
               </td>
               <td>
                 <template v-if="e.state === 'unmanaged'">

--- a/web/src/views/apps/AppDetail.vue
+++ b/web/src/views/apps/AppDetail.vue
@@ -127,7 +127,7 @@ async function saveExternalAccess() {
   }
 }
 // Turn external access off entirely: clears the selection and removes all
-// generated routes (and their managed host ports on port-forward nodes).
+// generated routes.
 function disableExternalAccess() {
   extSelected.value = new Set()
   saveExternalAccess()
@@ -2686,15 +2686,14 @@ async function detachDatabase(d: AppDatabase) {
             <tbody>
               <tr v-for="b in appBindings" :key="b.id">
                 <td class="cell-title">
-                  {{ b.bind_ip ? b.bind_ip + ':' : '' }}{{ b.host_port }} → {{ b.container_port }}/{{ b.protocol }}
-                  <span v-if="b.managed" class="badge badge-info" title="Auto-provisioned for this app's route ingress; managed by Miabi" style="margin-left: 6px">auto</span>
+                  {{ b.host_port }} → {{ b.container_port }}/{{ b.protocol }}
                 </td>
                 <td>
                   <span class="badge badge-dot" :class="bindBadge(b.status)">{{ b.status }}</span>
                   <span v-if="b.review_note" class="cell-sub" style="margin-left: 8px">{{ b.review_note }}</span>
                 </td>
                 <td class="text-right">
-                  <button v-if="ws.canEdit && !b.managed" class="btn-icon btn-icon-danger" :title="b.status === 'approved' ? 'Release host port' : 'Cancel request'" :aria-label="b.status === 'approved' ? 'Release host port' : 'Cancel request'" @click="removeBind(b)"><span class="mdi" :class="b.status === 'approved' ? 'mdi-delete-outline' : 'mdi-close'"></span></button>
+                  <button v-if="ws.canEdit" class="btn-icon btn-icon-danger" :title="b.status === 'approved' ? 'Release host port' : 'Cancel request'" :aria-label="b.status === 'approved' ? 'Release host port' : 'Cancel request'" @click="removeBind(b)"><span class="mdi" :class="b.status === 'approved' ? 'mdi-delete-outline' : 'mdi-close'"></span></button>
                 </td>
               </tr>
             </tbody>

--- a/web/src/views/marketplace/TemplateInstall.vue
+++ b/web/src/views/marketplace/TemplateInstall.vue
@@ -5,7 +5,6 @@ import { useWorkspaceStore } from '@/stores/workspace'
 import { useNotificationStore } from '@/stores/notification'
 import { marketplaceApi } from '@/api/marketplace'
 import type { CatalogEntry, TemplateManifest, ManifestDatabase, InstallJob, TemplateInstallView, UpgradePlan } from '@/api/marketplace'
-import { databaseApi } from '@/api/resources'
 import { apiErrorMessage } from '@/api/client'
 import { displayFor, resourceName } from '@/utils/installNames'
 import type { DatabaseInstance } from '@/api/types'
@@ -154,16 +153,27 @@ function onVersionChange(e: Event) {
 
 watch(version, loadDetail)
 
+// Only instances in the chosen location can be reused or pinned: private networks don't span locations.
+async function loadInstances() {
+  if (!ws.currentWorkspaceId) return
+  try {
+    instances.value = (await marketplaceApi.databases(ws.currentWorkspaceId, form.value.location)).data.data ?? []
+  } catch {
+    instances.value = []
+  }
+  for (const db of manifest.value?.databases ?? []) {
+    const v = form.value.placement[db.name]
+    if (v && v !== 'auto' && v !== 'dedicated' && !instances.value.some((i) => String(i.id) === v)) {
+      form.value.placement[db.name] = defaultPlacement(db)
+    }
+  }
+}
+watch(() => form.value.location, loadInstances)
+
 onMounted(async () => {
   // Load instances before the manifest so placement defaults (e.g. a "shared"
   // template) can pre-select an existing instance.
-  if (ws.currentWorkspaceId) {
-    try {
-      instances.value = (await databaseApi.list(ws.currentWorkspaceId)).data.data ?? []
-    } catch {
-      instances.value = []
-    }
-  }
+  await loadInstances()
   await Promise.all([loadDetail(), loadInstalls()])
   // Deep link: marketplace/<slug>?upgrade opens the upgrade plan for this
   // template's install (used by the app detail "Upgrade via Marketplace" action

--- a/web/src/views/networking/RouteDetail.vue
+++ b/web/src/views/networking/RouteDetail.vue
@@ -70,8 +70,7 @@ async function saveChain() {
 const availableMw = computed(() => allMiddlewares.value.filter((m) => !attachedMw.value.includes(m.name)))
 
 const port = computed(() => item.value?.target_port || app.value?.port || 80)
-// Prefer the real backend resolved server-side (e.g. a port-forward node's
-// address:hostPort); fall back to the in-network alias for display.
+// Prefer the backend resolved server-side; fall back to the in-network alias for display.
 const stableEndpoint = computed(() => item.value?.backends?.[0] || (app.value ? `http://mb-app-${app.value.id}:${port.value}` : ''))
 const canaryEndpoint = computed(() => item.value?.backends?.[1] || (app.value ? `http://mb-app-${app.value.id}-canary:${port.value}` : ''))
 


### PR DESCRIPTION
* [fix: changing the manager from edge gateway to cluster](https://github.com/miabi-io/miabi/commit/7cb3b77e650289a1b7a36348e451555f2c404bc5)
* [fix(marketplace): keep install databases in the chosen location](https://github.com/miabi-io/miabi/commit/e0359853690eca4a381bda9677ab089ffb966f68)