### PR TITLE
feat(clusters): node pools and plan placement

### DIFF
--- a/cmd/miabi/server.go
+++ b/cmd/miabi/server.go
@@ -41,6 +41,7 @@ import (
 	"github.com/miabi-io/miabi/internal/services/monitoring"
 	"github.com/miabi-io/miabi/internal/services/node"
 	"github.com/miabi-io/miabi/internal/services/notify"
+	"github.com/miabi-io/miabi/internal/services/placement"
 	"github.com/miabi-io/miabi/internal/services/platformbackup"
 	"github.com/miabi-io/miabi/internal/services/platformimage"
 	"github.com/miabi-io/miabi/internal/services/portforward"
@@ -384,6 +385,9 @@ func runServer(cli *okapicli.CLI) {
 			deployHandler.SetSecurity(securityResolver, cfg.SecurityInitImage)
 			deployHandler.SetGrantGuard(grantGuard)
 			deployHandler.SetBuilderPolicy(securityQuota)
+			poolPlacement := placement.NewService(repositories.NewClusterRepository(res.db), repositories.NewServerRepository(res.db), nil)
+			poolPlacement.SetPolicy(securityQuota)
+			deployHandler.SetPoolPolicy(poolPlacement)
 			gpuScheduler := gpu.NewService(
 				repositories.NewGPUDeviceRepository(res.db),
 				repositories.NewServerRepository(res.db),

--- a/cmd/miabi/worker.go
+++ b/cmd/miabi/worker.go
@@ -31,6 +31,7 @@ import (
 	"github.com/miabi-io/miabi/internal/services/keyring"
 	"github.com/miabi-io/miabi/internal/services/node"
 	"github.com/miabi-io/miabi/internal/services/notify"
+	"github.com/miabi-io/miabi/internal/services/placement"
 	"github.com/miabi-io/miabi/internal/services/platformbackup"
 	"github.com/miabi-io/miabi/internal/services/platformimage"
 	"github.com/miabi-io/miabi/internal/services/quota"
@@ -200,6 +201,9 @@ func runWorker() error {
 	configService := configsvc.NewService(repositories.NewConfigRepository(db))
 	deployHandler.SetConfigs(configService)
 	deployHandler.SetBuilderPolicy(securityQuota)
+	poolPlacement := placement.NewService(repositories.NewClusterRepository(db), repositories.NewServerRepository(db), nil)
+	poolPlacement.SetPolicy(securityQuota)
+	deployHandler.SetPoolPolicy(poolPlacement)
 	gpuScheduler := gpu.NewService(
 		repositories.NewGPUDeviceRepository(db),
 		repositories.NewServerRepository(db),

--- a/internal/enterprise/ee.go
+++ b/internal/enterprise/ee.go
@@ -33,6 +33,7 @@ const (
 	FlagCustomRoles                  = "custom_roles"        // data-driven RBAC roles
 	FlagResourcePolicies             = "resource_policies"   // per-resource permission grants
 	FlagQuotaOverride                = "quota_override"      // per-workspace plan quota overrides
+	FlagPlacementPolicy              = "placement_policy"    // bind plans to locations and node pools
 	FlagAuditLog                     = "audit_log"           // view the audit log
 	FlagAuditExport                  = "audit_export"        // audit log export + retention
 	FlagSIEMStream                   = "siem_stream"         // live audit streaming to a SIEM
@@ -68,6 +69,7 @@ var AllFlags = []FlagInfo{
 	{FlagCustomRoles, "data-driven RBAC roles"},
 	{FlagResourcePolicies, "per-resource permission grants"},
 	{FlagQuotaOverride, "per-workspace plan quota overrides"},
+	{FlagPlacementPolicy, "bind plans to locations and node pools"},
 	{FlagAuditLog, "view the audit log"},
 	{FlagAuditExport, "audit log export + retention"},
 	{FlagSIEMStream, "live audit streaming to a SIEM"},
@@ -116,7 +118,7 @@ var Tiers = []Tier{
 		Desc: "Small businesses & teams",
 		Flags: []string{
 			FlagMultiSSO, FlagSSOHiddenProvider, FlagSSOSAML, FlagSSOLDAP, FlagSCIM,
-			FlagCustomRoles, FlagResourcePolicies, FlagQuotaOverride, FlagUserWorkspaceLimit,
+			FlagCustomRoles, FlagResourcePolicies, FlagQuotaOverride, FlagPlacementPolicy, FlagUserWorkspaceLimit,
 			FlagUserWorkspaceMembershipLimit,
 			FlagAuditLog, FlagAuditExport, FlagPlatformBackup, FlagAnnouncements,
 			FlagPrivateRegistry, FlagRegistryS3, FlagPlatformRunners, FlagSecurityProfile,

--- a/internal/enterprise/placement_flag_test.go
+++ b/internal/enterprise/placement_flag_test.go
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package enterprise
+
+import (
+	"slices"
+	"testing"
+)
+
+// Plan placement is sold from the Business tier up, so the flag must be grantable and those tiers must grant it.
+func TestPlacementPolicyEntitlement(t *testing.T) {
+	if !IsKnownFlag(FlagPlacementPolicy) {
+		t.Fatalf("%s is missing from AllFlags, so no license can grant it", FlagPlacementPolicy)
+	}
+	for _, tier := range []string{TierBusiness, TierEnterprise} {
+		p, ok := TierByName(tier)
+		if !ok {
+			t.Fatalf("tier %q is not defined", tier)
+		}
+		if !slices.Contains(p.Flags, FlagPlacementPolicy) {
+			t.Errorf("tier %q does not grant %s", tier, FlagPlacementPolicy)
+		}
+	}
+	if p, _ := TierByName(TierProfessional); slices.Contains(p.Flags, FlagPlacementPolicy) {
+		t.Errorf("tier %q grants %s", TierProfessional, FlagPlacementPolicy)
+	}
+}

--- a/internal/handlers/node_handler.go
+++ b/internal/handlers/node_handler.go
@@ -63,7 +63,9 @@ type NodeHandler struct {
 	// containers from the admin node view (MIABI_SECURITY_ENFORCEMENT, default on).
 	secEnforce bool
 	hostProc   string // procfs dir for local-node host metrics (default /host/proc)
-	upgrader   websocket.Upgrader
+	// poolLabeler mirrors a node's pool onto its Swarm node label; nil leaves it to the cluster refresh.
+	poolLabeler func(context.Context, *models.Server) error
+	upgrader    websocket.Upgrader
 }
 
 // WorkspaceMembership lists the workspaces a user belongs to. It gates node container-log
@@ -339,6 +341,40 @@ func (h *NodeHandler) Workloads(c *okapi.Context) error {
 		return c.AbortInternalServerError("failed to count node workloads", err)
 	}
 	return ok(c, map[string]any{"apps": apps, "databases": dbs})
+}
+
+// SetPoolLabeler wires mirroring a node's pool onto its Swarm node label.
+func (h *NodeHandler) SetPoolLabeler(fn func(ctx context.Context, srv *models.Server) error) {
+	h.poolLabeler = fn
+}
+
+// SetNodePoolRequest puts a node in a pool.
+type SetNodePoolRequest struct {
+	Body struct {
+		// Pool is the pool name, e.g. "pro"; empty takes the node out of its pool.
+		Pool string `json:"pool"`
+	} `json:"body"`
+}
+
+// SetPool puts a node in a pool and mirrors it onto the node's Swarm label.
+func (h *NodeHandler) SetPool(c *okapi.Context, req *SetNodePoolRequest) error {
+	id, err := h.id(c)
+	if err != nil {
+		return c.AbortBadRequest("invalid node id")
+	}
+	srv, err := h.nodes.SetPool(id, req.Body.Pool)
+	if errors.Is(err, node.ErrInvalidPool) {
+		return c.AbortBadRequest(err.Error())
+	}
+	if err != nil {
+		return h.mapErr(c, err)
+	}
+	if h.poolLabeler != nil {
+		// Best-effort: the cluster refresh re-asserts the label once the swarm is reachable.
+		_ = h.poolLabeler(c.Request().Context(), srv)
+	}
+	h.record(c, "node.pool", srv.ID)
+	return ok(c, srv)
 }
 
 // ApplyConnectivity deploys or tears down a node's gateway after its connectivity changed elsewhere.

--- a/internal/handlers/plan_handler.go
+++ b/internal/handlers/plan_handler.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 
 	"github.com/jkaninda/okapi"
@@ -60,6 +61,8 @@ type PlanBody struct {
 	AllowGPU                  bool   `json:"allow_gpu"`
 	SecurityProfile           string `json:"security_profile"`          // "default" | "restricted"
 	AllowOfficialImageUser    bool   `json:"allow_official_image_user"` // exempt official-template apps from the restricted UID
+	// Placement binds the plan to locations and a node pool (Enterprise placement_policy).
+	Placement models.PlanPlacement `json:"placement"`
 }
 
 type CreatePlanRequest struct {
@@ -150,6 +153,24 @@ func (b PlanBody) apply(p *models.Plan) {
 	p.AllowGPU = b.AllowGPU
 	p.SecurityProfile = models.NormalizeSecurityProfile(b.SecurityProfile)
 	p.AllowOfficialImageUser = b.AllowOfficialImageUser
+	p.Placement = b.Placement
+}
+
+var errInvalidPlanPool = errors.New("a pool name is lowercase letters, digits and hyphens (max 32), e.g. pro")
+
+// checkPlacement refuses an invalid pool, and binding to locations or a pool without placement_policy.
+// Clearing or resending an unchanged binding is always allowed, so a lapsed license never strands one.
+func (h *PlanHandler) checkPlacement(c *okapi.Context, prev, next models.PlanPlacement) error {
+	if next.Pool != "" && !models.ValidPoolName(next.Pool) {
+		return c.AbortBadRequest(errInvalidPlanPool.Error())
+	}
+	if (len(next.Locations) == 0 && next.Pool == "") || (next.Pool == prev.Pool && slices.Equal(next.Locations, prev.Locations)) {
+		return nil
+	}
+	if err := h.ee.RequireMutable(enterprise.FlagPlacementPolicy); err != nil {
+		return entitlementAbort(c, err)
+	}
+	return nil
 }
 
 // List returns a paginated, searchable plan catalog.
@@ -184,6 +205,9 @@ func (h *PlanHandler) Create(c *okapi.Context, req *CreatePlanRequest) error {
 	if err := h.guardSecurityProfile(body.SecurityProfile); err != nil {
 		return entitlementAbort(c, err)
 	}
+	if a := h.checkPlacement(c, models.PlanPlacement{}, body.Placement); a != nil {
+		return a
+	}
 	if body.IsDefault {
 		_ = h.repo.ClearDefault(nil)
 	}
@@ -203,6 +227,9 @@ func (h *PlanHandler) Update(c *okapi.Context, req *UpdatePlanRequest) error {
 	}
 	if err := h.guardSecurityProfile(req.Body.SecurityProfile); err != nil {
 		return entitlementAbort(c, err)
+	}
+	if a := h.checkPlacement(c, p.Placement, req.Body.Placement); a != nil {
+		return a
 	}
 	if err := systemPlanEdit(p, req.Body.Name, req.Body.IsDefault); err != nil {
 		return c.AbortWithError(409, err)
@@ -332,6 +359,15 @@ func (h *PlanHandler) SetWorkspaceQuota(c *okapi.Context, req *SetWorkspaceQuota
 	if req.Body.SecurityProfile != nil && models.NormalizeSecurityProfile(*req.Body.SecurityProfile) == models.SecurityProfileRestricted {
 		if err := h.ee.RequireMutable(enterprise.FlagSecurityProfile); err != nil {
 			return entitlementAbort(c, err)
+		}
+	}
+	if req.Body.Placement != nil {
+		var prev models.PlanPlacement
+		if o, err := h.overrides.FindByWorkspace(wsID); err == nil && o.Placement != nil {
+			prev = *o.Placement
+		}
+		if a := h.checkPlacement(c, prev, *req.Body.Placement); a != nil {
+			return a
 		}
 	}
 	q := req.Body

--- a/internal/models/plan.go
+++ b/internal/models/plan.go
@@ -3,7 +3,10 @@
 
 package models
 
-import "time"
+import (
+	"regexp"
+	"time"
+)
 
 // Unlimited is the limit value meaning "no cap". Distinct from 0 ("none
 // allowed"), so a plan can forbid a resource entirely.
@@ -35,73 +38,99 @@ func NormalizeSecurityProfile(p string) string {
 	return SecurityProfileDefault
 }
 
+// PoolLabel is the node label naming the pool a node belongs to, mirrored onto its Swarm node.
+const PoolLabel = "miabi.pool"
+
+var poolNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,30}[a-z0-9])?$`)
+
+// ValidPoolName reports whether p is a usable pool name: a short lowercase slug.
+func ValidPoolName(p string) bool { return poolNamePattern.MatchString(p) }
+
+// PoolOf is the pool a node belongs to; empty when it is in none.
+func PoolOf(s *Server) string {
+	if s == nil {
+		return ""
+	}
+	return s.Labels[PoolLabel]
+}
+
+// PlanPlacement binds a plan to locations and a node pool (Enterprise). No locations allows every location;
+// no pool keeps the plan's workloads on nodes that are in no pool.
+type PlanPlacement struct {
+	// Locations are the cluster ids the plan may use; the first is its default location.
+	Locations []uint `json:"locations,omitempty"`
+	Pool      string `json:"pool,omitempty"`
+}
+
 // Plan is an admin-defined per-workspace quota + capability template. Numeric
 // limits use -1 for unlimited and 0 for none; capability booleans gate features.
 type Plan struct {
-	ID                        uint      `json:"id" gorm:"primaryKey"`
-	Name                      string    `json:"name" gorm:"uniqueIndex;not null"`
-	Description               string    `json:"description"`
-	IsDefault                 bool      `json:"is_default" gorm:"not null;default:false"` // applied to workspaces with no plan
-	IsActive                  bool      `json:"is_active" gorm:"not null;default:true"`
-	System                    bool      `json:"system" gorm:"not null;default:false"`
-	MaxApps                   int       `json:"max_apps" gorm:"not null;default:0"`
-	MaxDatabaseInstances      int       `json:"max_database_instances" gorm:"not null;default:0"`
-	MaxCronJobs               int       `json:"max_cron_jobs" gorm:"not null;default:0"`
-	MaxVolumes                int       `json:"max_volumes" gorm:"not null;default:0"`
-	MaxNetworks               int       `json:"max_networks" gorm:"not null;default:0"`
-	MaxAPIKeys                int       `json:"max_api_keys" gorm:"not null;default:0"`
-	MaxMembers                int       `json:"max_members" gorm:"not null;default:0"`
-	MaxDatabasesPerInstance   int       `json:"max_databases_per_instance" gorm:"not null;default:0"`
-	MaxCPUCores               int       `json:"max_cpu_cores" gorm:"not null;default:0"`
-	MaxMemoryMB               int       `json:"max_memory_mb" gorm:"not null;default:0"`
-	MaxDatabaseInstanceSizeMB int       `json:"max_database_instance_size_mb" gorm:"not null;default:0"`
-	MaxStorageMB              int       `json:"max_storage_mb" gorm:"not null;default:0"`
-	MaxRunners                int       `json:"max_runners" gorm:"not null;default:0"`
-	MaxGPUs                   int       `json:"max_gpus" gorm:"not null;default:0"`
-	AllowCustomTLS            bool      `json:"allow_custom_tls" gorm:"not null;default:false"`
-	AllowPrivilegedHostMounts bool      `json:"allow_privileged_host_mounts" gorm:"not null;default:false"`
-	AllowShellExec            bool      `json:"allow_shell_exec" gorm:"not null;default:false"`
-	AllowSharedStorage        bool      `json:"allow_shared_storage" gorm:"not null;default:false"`
-	AllowDNSProviders         bool      `json:"allow_dns_providers" gorm:"not null;default:false"`
-	AllowCustomLabels         bool      `json:"allow_custom_labels" gorm:"not null;default:false"`
-	AllowPlatformRunners      bool      `json:"allow_platform_runners" gorm:"not null;default:false"`
-	AllowCustomBuilder        bool      `json:"allow_custom_builder" gorm:"not null;default:false"`
-	SecurityProfile           string    `json:"security_profile" gorm:"not null;default:'default'"`
-	AllowOfficialImageUser    bool      `json:"allow_official_image_user" gorm:"not null;default:false"`
-	AllowGPU                  bool      `json:"allow_gpu" gorm:"not null;default:false"`
-	CreatedAt                 time.Time `json:"created_at"`
-	UpdatedAt                 time.Time `json:"updated_at"`
+	ID                        uint          `json:"id" gorm:"primaryKey"`
+	Name                      string        `json:"name" gorm:"uniqueIndex;not null"`
+	Description               string        `json:"description"`
+	IsDefault                 bool          `json:"is_default" gorm:"not null;default:false"` // applied to workspaces with no plan
+	IsActive                  bool          `json:"is_active" gorm:"not null;default:true"`
+	System                    bool          `json:"system" gorm:"not null;default:false"`
+	MaxApps                   int           `json:"max_apps" gorm:"not null;default:0"`
+	MaxDatabaseInstances      int           `json:"max_database_instances" gorm:"not null;default:0"`
+	MaxCronJobs               int           `json:"max_cron_jobs" gorm:"not null;default:0"`
+	MaxVolumes                int           `json:"max_volumes" gorm:"not null;default:0"`
+	MaxNetworks               int           `json:"max_networks" gorm:"not null;default:0"`
+	MaxAPIKeys                int           `json:"max_api_keys" gorm:"not null;default:0"`
+	MaxMembers                int           `json:"max_members" gorm:"not null;default:0"`
+	MaxDatabasesPerInstance   int           `json:"max_databases_per_instance" gorm:"not null;default:0"`
+	MaxCPUCores               int           `json:"max_cpu_cores" gorm:"not null;default:0"`
+	MaxMemoryMB               int           `json:"max_memory_mb" gorm:"not null;default:0"`
+	MaxDatabaseInstanceSizeMB int           `json:"max_database_instance_size_mb" gorm:"not null;default:0"`
+	MaxStorageMB              int           `json:"max_storage_mb" gorm:"not null;default:0"`
+	MaxRunners                int           `json:"max_runners" gorm:"not null;default:0"`
+	MaxGPUs                   int           `json:"max_gpus" gorm:"not null;default:0"`
+	AllowCustomTLS            bool          `json:"allow_custom_tls" gorm:"not null;default:false"`
+	AllowPrivilegedHostMounts bool          `json:"allow_privileged_host_mounts" gorm:"not null;default:false"`
+	AllowShellExec            bool          `json:"allow_shell_exec" gorm:"not null;default:false"`
+	AllowSharedStorage        bool          `json:"allow_shared_storage" gorm:"not null;default:false"`
+	AllowDNSProviders         bool          `json:"allow_dns_providers" gorm:"not null;default:false"`
+	AllowCustomLabels         bool          `json:"allow_custom_labels" gorm:"not null;default:false"`
+	AllowPlatformRunners      bool          `json:"allow_platform_runners" gorm:"not null;default:false"`
+	AllowCustomBuilder        bool          `json:"allow_custom_builder" gorm:"not null;default:false"`
+	SecurityProfile           string        `json:"security_profile" gorm:"not null;default:'default'"`
+	AllowOfficialImageUser    bool          `json:"allow_official_image_user" gorm:"not null;default:false"`
+	AllowGPU                  bool          `json:"allow_gpu" gorm:"not null;default:false"`
+	Placement                 PlanPlacement `json:"placement" gorm:"type:text;serializer:json"`
+	CreatedAt                 time.Time     `json:"created_at"`
+	UpdatedAt                 time.Time     `json:"updated_at"`
 }
 
 // WorkspaceQuota holds per-workspace overrides applied on top of the assigned
 // plan. Any non-nil field overrides the plan for that workspace; nil inherits.
 type WorkspaceQuota struct {
-	WorkspaceID               uint    `json:"workspace_id" gorm:"primaryKey"`
-	MaxApps                   *int    `json:"max_apps,omitempty"`
-	MaxDatabaseInstances      *int    `json:"max_database_instances,omitempty"`
-	MaxCronJobs               *int    `json:"max_cron_jobs,omitempty"`
-	MaxVolumes                *int    `json:"max_volumes,omitempty"`
-	MaxNetworks               *int    `json:"max_networks,omitempty"`
-	MaxAPIKeys                *int    `json:"max_api_keys,omitempty"`
-	MaxMembers                *int    `json:"max_members,omitempty"`
-	MaxDatabasesPerInstance   *int    `json:"max_databases_per_instance,omitempty"`
-	MaxCPUCores               *int    `json:"max_cpu_cores,omitempty"`
-	MaxMemoryMB               *int    `json:"max_memory_mb,omitempty"`
-	MaxDatabaseInstanceSizeMB *int    `json:"max_database_instance_size_mb,omitempty"`
-	MaxStorageMB              *int    `json:"max_storage_mb,omitempty"`
-	MaxRunners                *int    `json:"max_runners,omitempty"`
-	MaxGPUs                   *int    `json:"max_gpus,omitempty"`
-	AllowCustomTLS            *bool   `json:"allow_custom_tls,omitempty"`
-	AllowPrivilegedHostMounts *bool   `json:"allow_privileged_host_mounts,omitempty"`
-	AllowShellExec            *bool   `json:"allow_shell_exec,omitempty"`
-	AllowSharedStorage        *bool   `json:"allow_shared_storage,omitempty"`
-	AllowDNSProviders         *bool   `json:"allow_dns_providers,omitempty"`
-	AllowCustomLabels         *bool   `json:"allow_custom_labels,omitempty"`
-	AllowPlatformRunners      *bool   `json:"allow_platform_runners,omitempty"`
-	AllowCustomBuilder        *bool   `json:"allow_custom_builder,omitempty"`
-	AllowGPU                  *bool   `json:"allow_gpu,omitempty"`
-	SecurityProfile           *string `json:"security_profile,omitempty"`          // nil = inherit plan
-	AllowOfficialImageUser    *bool   `json:"allow_official_image_user,omitempty"` // nil = inherit plan
+	WorkspaceID               uint           `json:"workspace_id" gorm:"primaryKey"`
+	MaxApps                   *int           `json:"max_apps,omitempty"`
+	MaxDatabaseInstances      *int           `json:"max_database_instances,omitempty"`
+	MaxCronJobs               *int           `json:"max_cron_jobs,omitempty"`
+	MaxVolumes                *int           `json:"max_volumes,omitempty"`
+	MaxNetworks               *int           `json:"max_networks,omitempty"`
+	MaxAPIKeys                *int           `json:"max_api_keys,omitempty"`
+	MaxMembers                *int           `json:"max_members,omitempty"`
+	MaxDatabasesPerInstance   *int           `json:"max_databases_per_instance,omitempty"`
+	MaxCPUCores               *int           `json:"max_cpu_cores,omitempty"`
+	MaxMemoryMB               *int           `json:"max_memory_mb,omitempty"`
+	MaxDatabaseInstanceSizeMB *int           `json:"max_database_instance_size_mb,omitempty"`
+	MaxStorageMB              *int           `json:"max_storage_mb,omitempty"`
+	MaxRunners                *int           `json:"max_runners,omitempty"`
+	MaxGPUs                   *int           `json:"max_gpus,omitempty"`
+	AllowCustomTLS            *bool          `json:"allow_custom_tls,omitempty"`
+	AllowPrivilegedHostMounts *bool          `json:"allow_privileged_host_mounts,omitempty"`
+	AllowShellExec            *bool          `json:"allow_shell_exec,omitempty"`
+	AllowSharedStorage        *bool          `json:"allow_shared_storage,omitempty"`
+	AllowDNSProviders         *bool          `json:"allow_dns_providers,omitempty"`
+	AllowCustomLabels         *bool          `json:"allow_custom_labels,omitempty"`
+	AllowPlatformRunners      *bool          `json:"allow_platform_runners,omitempty"`
+	AllowCustomBuilder        *bool          `json:"allow_custom_builder,omitempty"`
+	AllowGPU                  *bool          `json:"allow_gpu,omitempty"`
+	SecurityProfile           *string        `json:"security_profile,omitempty"`                           // nil = inherit plan
+	AllowOfficialImageUser    *bool          `json:"allow_official_image_user,omitempty"`                  // nil = inherit plan
+	Placement                 *PlanPlacement `json:"placement,omitempty" gorm:"type:text;serializer:json"` // nil = inherit plan
 
 	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/internal/routes/node_routes.go
+++ b/internal/routes/node_routes.go
@@ -60,6 +60,15 @@ func (r *Router) nodeRoutes() []okapi.RouteDefinition {
 			Request:     &handlers.CreateNodeRequest{},
 		},
 		{
+			Method:      http.MethodPut,
+			Path:        "/{nodeID}/pool",
+			Group:       g,
+			Middlewares: admin,
+			Handler:     okapi.H(r.h.node.SetPool),
+			Summary:     "Put a node in a pool",
+			Request:     &handlers.SetNodePoolRequest{},
+		},
+		{
 			Method:      http.MethodGet,
 			Path:        "/{nodeID}/workloads",
 			Group:       g,

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -692,6 +692,7 @@ func InitRoutes(app *okapi.Okapi, db *gorm.DB, redisClient *redis.Client, cfg *c
 	monitoringService.SetSwarmManager(clusterService)
 	monitoringService.SetServerInfo(nodeService)
 	placementService := placement.NewService(repositories.NewClusterRepository(db), serverRepo, nodeClients.Connected)
+	placementService.SetPolicy(quotaService)
 	placer := handlers.NewPlacer(placementService, userRepo)
 	marketplaceService := marketplace.NewService(appService, databaseService, storageService, stackService, repositories.NewTemplateInstallRepository(db), repositories.NewTemplateRepository(db))
 	marketplaceService.SetPlacer(placementService)
@@ -1349,6 +1350,7 @@ func InitRoutes(app *okapi.Okapi, db *gorm.DB, redisClient *redis.Client, cfg *c
 	// can list/operate containers, but not read another workspace's container logs.
 	r.h.node.SetMembership(workspaceRepo)
 	r.h.cluster.SetConnectivityApplier(r.h.node.ApplyConnectivity)
+	r.h.node.SetPoolLabeler(clusterService.SyncPoolLabel)
 	// Block stop/remove of managed containers from the admin node view unless the
 	// operator has explicitly disabled security enforcement (break-glass).
 	r.h.node.SetSecurityEnforcement(r.cfg.SecurityEnforcement)

--- a/internal/services/cluster/cluster.go
+++ b/internal/services/cluster/cluster.go
@@ -372,6 +372,7 @@ func (s *Service) Refresh(ctx context.Context) {
 			s.AttachGateway(ctx, id)
 		}
 	}
+	s.reassertPoolLabels(ctx)
 
 	if info.NodeID != "" {
 		if id := s.clients.LocalID(); id != 0 {

--- a/internal/services/cluster/pools.go
+++ b/internal/services/cluster/pools.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package cluster
+
+import (
+	"context"
+
+	"github.com/jkaninda/logger"
+	"github.com/miabi-io/miabi/internal/models"
+)
+
+// SyncPoolLabel mirrors a node's pool onto its swarm node, where service placement constraints read it. A no-op
+// for a node outside an active swarm.
+func (s *Service) SyncPoolLabel(ctx context.Context, srv *models.Server) error {
+	if srv == nil || srv.SwarmNodeID == "" || !s.IsSwarm(srv.ClusterID) {
+		return nil
+	}
+	mgr, err := s.Manager(ctx, srv.ClusterID)
+	if err != nil {
+		return err
+	}
+	return mgr.SwarmNodeSetLabel(ctx, srv.SwarmNodeID, models.PoolLabel, models.PoolOf(srv))
+}
+
+// reassertPoolLabels labels every pooled swarm member, covering a node that joined after its pool was set or a
+// pool set while its swarm was unreachable.
+func (s *Service) reassertPoolLabels(ctx context.Context) {
+	servers, err := s.nodes.List(ctx)
+	if err != nil {
+		return
+	}
+	for i := range servers {
+		if models.PoolOf(&servers[i]) == "" {
+			continue
+		}
+		if err := s.SyncPoolLabel(ctx, &servers[i]); err != nil {
+			logger.Warn("failed to label a swarm node with its pool", "node", servers[i].Name, "error", err)
+		}
+	}
+}

--- a/internal/services/node/service.go
+++ b/internal/services/node/service.go
@@ -35,6 +35,7 @@ var (
 	// ErrConnectivityAckRequired is returned when an update changes the node's
 	// reachability settings without the caller acknowledging the impact.
 	ErrConnectivityAckRequired = &connectivityAckError{}
+	ErrInvalidPool             = errors.New("a pool name is lowercase letters, digits and hyphens (max 32), e.g. pro")
 	ErrInvalidConnectivity     = errors.New("a node either runs its own gateway (edge-gateway) or, as a swarm member, is served by its cluster's gateway (cluster)")
 )
 
@@ -534,6 +535,31 @@ func (s *Service) checkConnectivity(srv *models.Server, c models.ServerConnectiv
 		return ErrInvalidConnectivity
 	}
 	return nil
+}
+
+// SetPool puts a node in a pool, or in none for an empty name. A plan bound to a pool places its workspaces'
+// workloads only on that pool's nodes.
+func (s *Service) SetPool(id uint, pool string) (*models.Server, error) {
+	pool = strings.TrimSpace(pool)
+	if pool != "" && !models.ValidPoolName(pool) {
+		return nil, ErrInvalidPool
+	}
+	srv, err := s.repo.FindByID(id)
+	if err != nil {
+		return nil, ErrNodeNotFound
+	}
+	if srv.Labels == nil {
+		srv.Labels = map[string]string{}
+	}
+	if pool == "" {
+		delete(srv.Labels, models.PoolLabel)
+	} else {
+		srv.Labels[models.PoolLabel] = pool
+	}
+	if err := s.repo.Update(srv); err != nil {
+		return nil, err
+	}
+	return srv, nil
 }
 
 // SetConnectivity changes only how a node's apps are served, leaving its other reachability settings alone.

--- a/internal/services/placement/placement.go
+++ b/internal/services/placement/placement.go
@@ -7,6 +7,9 @@ package placement
 
 import (
 	"errors"
+	"fmt"
+	"slices"
+	"sort"
 	"strings"
 
 	"github.com/miabi-io/miabi/internal/models"
@@ -32,10 +35,31 @@ type Service struct {
 	clusters *repositories.ClusterRepository
 	servers  *repositories.ServerRepository
 	online   Online
+	policy   Policy
 }
 
 func NewService(clusters *repositories.ClusterRepository, servers *repositories.ServerRepository, online Online) *Service {
 	return &Service{clusters: clusters, servers: servers, online: online}
+}
+
+// Policy resolves the locations and node pool a workspace's plan binds it to; false means no policy applies.
+// Satisfied by the quota service.
+type Policy interface {
+	EffectivePlacement(workspaceID uint) (models.PlanPlacement, bool)
+}
+
+// SetPolicy wires plan placement (nil-safe; nil binds no workspace to locations or pools).
+func (s *Service) SetPolicy(p Policy) { s.policy = p }
+
+func (s *Service) planPlacement(workspaceID uint) (models.PlanPlacement, bool) {
+	if s.policy == nil {
+		return models.PlanPlacement{}, false
+	}
+	return s.policy.EffectivePlacement(workspaceID)
+}
+
+func permits(p models.PlanPlacement, enforced bool, clusterID uint) bool {
+	return !enforced || len(p.Locations) == 0 || slices.Contains(p.Locations, clusterID)
 }
 
 // Request describes a resource to place.
@@ -73,7 +97,8 @@ func (s *Service) Place(req Request) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
-	serverID, err := s.pickNode(c, req.Service)
+	policy, enforced := s.planPlacement(req.WorkspaceID)
+	serverID, err := s.pickNode(c, req.Service, policy.Pool, enforced)
 	if err != nil {
 		return Result{}, err
 	}
@@ -110,12 +135,16 @@ func allowed(c *models.Cluster, admin bool) bool {
 // resolveCluster picks the named location, else the workspace's default, else the first location the
 // workspace may use (the default cluster comes first).
 func (s *Service) resolveCluster(workspaceID uint, location string, admin bool) (*models.Cluster, error) {
+	policy, enforced := s.planPlacement(workspaceID)
+	usable := func(c *models.Cluster) bool {
+		return allowed(c, admin) && !c.Cordoned && permits(policy, enforced, c.ID)
+	}
 	if name := strings.TrimSpace(location); name != "" {
 		c, err := s.clusters.FindByName(name)
 		if err != nil {
 			return nil, ErrLocationNotFound
 		}
-		if !allowed(c, admin) {
+		if !allowed(c, admin) || !permits(policy, enforced, c.ID) {
 			return nil, ErrLocationNotAllowed
 		}
 		if c.Cordoned {
@@ -123,15 +152,22 @@ func (s *Service) resolveCluster(workspaceID uint, location string, admin bool) 
 		}
 		return c, nil
 	}
-	if def, err := s.clusters.WorkspaceDefault(workspaceID); err == nil && allowed(def, admin) && !def.Cordoned {
+	if def, err := s.clusters.WorkspaceDefault(workspaceID); err == nil && usable(def) {
 		return def, nil
+	}
+	if enforced {
+		for _, id := range policy.Locations {
+			if c, err := s.clusters.FindByID(id); err == nil && usable(c) {
+				return c, nil
+			}
+		}
 	}
 	list, err := s.clusters.List()
 	if err != nil {
 		return nil, err
 	}
 	for i := range list {
-		if allowed(&list[i], admin) && !list[i].Cordoned {
+		if usable(&list[i]) {
 			return &list[i], nil
 		}
 	}
@@ -139,8 +175,20 @@ func (s *Service) resolveCluster(workspaceID uint, location string, admin bool) 
 }
 
 // pickNode chooses the node inside a cluster: its only node when standalone, the manager for a service,
-// and otherwise the online, uncordoned node with the least container memory already placed on it.
-func (s *Service) pickNode(c *models.Cluster, service bool) (uint, error) {
+// and otherwise the online, uncordoned node with the least container memory already placed on it. With a
+// pooled plan only nodes in the plan's pool count, and a cluster with none of them refuses the create.
+func (s *Service) pickNode(c *models.Cluster, service bool, pool string, pooled bool) (uint, error) {
+	if pooled && (c.Mode != models.ClusterModeSwarm || service) {
+		servers, err := s.servers.List()
+		if err != nil {
+			return 0, err
+		}
+		if !slices.ContainsFunc(servers, func(srv models.Server) bool {
+			return srv.ClusterID == c.ID && !srv.Cordoned && models.PoolOf(&srv) == pool
+		}) {
+			return 0, poolUnavailable(pool)
+		}
+	}
 	if c.Mode != models.ClusterModeSwarm || service {
 		if c.IsDefault {
 			local, err := s.servers.FindLocal()
@@ -166,15 +214,55 @@ func (s *Service) pickNode(c *models.Cluster, service bool) (uint, error) {
 		if srv.ClusterID != c.ID || srv.Cordoned || (!srv.IsLocal && (s.online == nil || !s.online(srv.ID))) {
 			continue
 		}
+		if pooled && models.PoolOf(srv) != pool {
+			continue
+		}
 		load := loads[srv.ID]
 		if best == 0 || load.Less(bestLoad) {
 			best, bestLoad = srv.ID, load
 		}
 	}
+	if best == 0 && pooled {
+		return 0, poolUnavailable(pool)
+	}
 	if best == 0 {
 		return 0, ErrNoSchedulableNode
 	}
 	return best, nil
+}
+
+func poolUnavailable(pool string) error {
+	if pool == "" {
+		return fmt.Errorf("%w: every node there is in a pool this workspace's plan does not use", ErrNoSchedulableNode)
+	}
+	return fmt.Errorf("%w: none is in the %q pool this workspace's plan requires", ErrNoSchedulableNode, pool)
+}
+
+// PoolConstraints are the Swarm constraints that keep a workspace's services in its plan's pool: that pool's
+// label, or for a plan without a pool, every pool present in the cluster excluded. Nil when no policy applies.
+func (s *Service) PoolConstraints(workspaceID, clusterID uint) []string {
+	policy, enforced := s.planPlacement(workspaceID)
+	if !enforced {
+		return nil
+	}
+	if policy.Pool != "" {
+		return []string{fmt.Sprintf("node.labels.%s==%s", models.PoolLabel, policy.Pool)}
+	}
+	servers, err := s.servers.List()
+	if err != nil {
+		return nil
+	}
+	clusterID = s.resolveID(clusterID)
+	seen := map[string]bool{}
+	var out []string
+	for i := range servers {
+		if p := models.PoolOf(&servers[i]); p != "" && servers[i].ClusterID == clusterID && !seen[p] {
+			seen[p] = true
+			out = append(out, fmt.Sprintf("node.labels.%s!=%s", models.PoolLabel, p))
+		}
+	}
+	sort.Strings(out)
+	return out
 }
 
 // Location is a cluster as a workspace sees it: no nodes, addresses or capacity.
@@ -194,10 +282,11 @@ func (s *Service) Locations(workspaceID uint, admin bool) ([]Location, error) {
 		return nil, err
 	}
 	fallback, _ := s.resolveCluster(workspaceID, "", admin)
+	policy, enforced := s.planPlacement(workspaceID)
 	out := make([]Location, 0, len(list))
 	for i := range list {
 		c := &list[i]
-		if !allowed(c, admin) || c.Cordoned {
+		if !allowed(c, admin) || c.Cordoned || !permits(policy, enforced, c.ID) {
 			continue
 		}
 		out = append(out, Location{
@@ -222,7 +311,7 @@ func (s *Service) SetDefaultLocation(workspaceID uint, location string, admin bo
 	if err != nil {
 		return ErrLocationNotFound
 	}
-	if !allowed(c, admin) {
+	if policy, enforced := s.planPlacement(workspaceID); !allowed(c, admin) || !permits(policy, enforced, c.ID) {
 		return ErrLocationNotAllowed
 	}
 	return s.clusters.SetWorkspaceDefault(workspaceID, &c.ID)

--- a/internal/services/placement/placement_test.go
+++ b/internal/services/placement/placement_test.go
@@ -5,6 +5,7 @@ package placement
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -42,6 +43,7 @@ type serverTable struct {
 	ClusterID uint
 	IsLocal   bool
 	Cordoned  bool
+	Labels    map[string]string `gorm:"serializer:json"`
 }
 
 func (serverTable) TableName() string { return "servers" }
@@ -92,7 +94,7 @@ func newPlacement(t *testing.T, online map[uint]bool) (*Service, *gorm.DB) {
 		{ID: 1, Name: "manager", ClusterID: 1, IsLocal: true},
 		{ID: 10, Name: "warsaw-1", ClusterID: 2},
 		{ID: 11, Name: "warsaw-2", ClusterID: 2},
-		{ID: 12, Name: "warsaw-3", ClusterID: 2},
+		{ID: 12, Name: "warsaw-3", ClusterID: 2, Labels: map[string]string{models.PoolLabel: "pro"}},
 		{ID: 13, Name: "warsaw-4", ClusterID: 2, Cordoned: true},
 		{ID: 20, Name: "gpu-1", ClusterID: 3},
 	})
@@ -187,6 +189,65 @@ func TestPlacementRefusals(t *testing.T) {
 	}
 	if err := s.SetDefaultLocation(5, "gpu", false); !errors.Is(err, ErrLocationNotAllowed) {
 		t.Errorf("tenant default in a restricted location err = %v", err)
+	}
+}
+
+type fakePolicy struct{ placement models.PlanPlacement }
+
+func (f fakePolicy) EffectivePlacement(uint) (models.PlanPlacement, bool) { return f.placement, true }
+
+// A pooled plan lands only on its pool's nodes, and a plan without a pool never on a pooled one.
+func TestPlacementHonorsThePlanPool(t *testing.T) {
+	s, _ := newPlacement(t, map[uint]bool{10: true, 11: true, 12: true})
+
+	s.SetPolicy(fakePolicy{models.PlanPlacement{Pool: "pro"}})
+	if got, err := s.Place(Request{WorkspaceID: 5, Location: "eu-east"}); err != nil || got.ServerID != 12 {
+		t.Errorf("pro plan placed on node %d (%v), want the pro node 12", got.ServerID, err)
+	}
+	if got := s.PoolConstraints(5, 2); len(got) != 1 || got[0] != "node.labels.miabi.pool==pro" {
+		t.Errorf("pro plan constraints = %v", got)
+	}
+
+	s.SetPolicy(fakePolicy{})
+	if got, err := s.Place(Request{WorkspaceID: 5, Location: "eu-east"}); err != nil || got.ServerID != 11 {
+		t.Errorf("unpooled plan placed on node %d (%v), want the least loaded unpooled node 11", got.ServerID, err)
+	}
+	if got := s.PoolConstraints(5, 2); len(got) != 1 || got[0] != "node.labels.miabi.pool!=pro" {
+		t.Errorf("unpooled plan constraints = %v, want the pro pool excluded", got)
+	}
+	if got := s.PoolConstraints(5, 1); len(got) != 0 {
+		t.Errorf("a cluster without pools needs no constraints, got %v", got)
+	}
+
+	s.SetPolicy(fakePolicy{models.PlanPlacement{Pool: "gpu"}})
+	for _, loc := range []string{"eu-east", "default"} {
+		_, err := s.Place(Request{WorkspaceID: 5, Location: loc})
+		if !errors.Is(err, ErrNoSchedulableNode) || !strings.Contains(err.Error(), `"gpu"`) {
+			t.Errorf("%s with no gpu node: err = %v, want a refusal naming the pool", loc, err)
+		}
+	}
+}
+
+// A plan's locations bound what a workspace sees and where it may create; the first is its default.
+func TestPlacementHonorsThePlanLocations(t *testing.T) {
+	s, _ := newPlacement(t, map[uint]bool{10: true, 11: true})
+	s.SetPolicy(fakePolicy{models.PlanPlacement{Locations: []uint{2}}})
+
+	if got, err := s.Place(Request{WorkspaceID: 5}); err != nil || got.ClusterID != 2 {
+		t.Errorf("placed %+v (%v), want the plan's first location", got, err)
+	}
+	if _, err := s.Place(Request{WorkspaceID: 5, Location: "default"}); !errors.Is(err, ErrLocationNotAllowed) {
+		t.Errorf("a location outside the plan: err = %v", err)
+	}
+	if err := s.SetDefaultLocation(5, "default", false); !errors.Is(err, ErrLocationNotAllowed) {
+		t.Errorf("a default outside the plan: err = %v", err)
+	}
+	locs, err := s.Locations(5, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(locs) != 1 || locs[0].Name != "eu-east" || !locs[0].Default {
+		t.Errorf("locations = %+v, want only eu-east, as the default", locs)
 	}
 }
 

--- a/internal/services/quota/placement_test.go
+++ b/internal/services/quota/placement_test.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package quota
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/miabi-io/miabi/internal/models"
+)
+
+func TestPlacementFrom(t *testing.T) {
+	plan := &models.Plan{Placement: models.PlanPlacement{Locations: []uint{2, 1}, Pool: "pro"}}
+
+	if got := placementFrom(plan, nil); got.Pool != "pro" || !slices.Equal(got.Locations, []uint{2, 1}) {
+		t.Errorf("plan placement = %+v", got)
+	}
+	override := &models.WorkspaceQuota{Placement: &models.PlanPlacement{Pool: "gpu"}}
+	if got := placementFrom(plan, override); got.Pool != "gpu" || len(got.Locations) != 0 {
+		t.Errorf("an override must replace the plan's placement whole, got %+v", got)
+	}
+	if got := placementFrom(plan, &models.WorkspaceQuota{}); got.Pool != "pro" {
+		t.Errorf("an override without placement must inherit the plan, got %+v", got)
+	}
+	if got := placementFrom(nil, nil); got.Pool != "" || len(got.Locations) != 0 {
+		t.Errorf("no plan = no binding, got %+v", got)
+	}
+}
+
+// Without enforcement or the placement_policy entitlement, no workspace is bound to locations or pools.
+func TestEffectivePlacementNeedsEnforcementAndLicense(t *testing.T) {
+	if _, enforced := (&Service{enforce: false, ee: allow{}}).EffectivePlacement(1); enforced {
+		t.Error("placement applied with plan enforcement off")
+	}
+	if _, enforced := (&Service{enforce: true}).EffectivePlacement(1); enforced {
+		t.Error("placement applied without the placement_policy entitlement")
+	}
+}
+
+type allow struct{}
+
+func (allow) Has(string) bool { return true }

--- a/internal/services/quota/quota.go
+++ b/internal/services/quota/quota.go
@@ -244,6 +244,9 @@ type EditionGate interface {
 // package needs no enterprise import.
 const flagSecurityProfile = "security_profile"
 
+// flagPlacementPolicy is a local copy of enterprise.FlagPlacementPolicy.
+const flagPlacementPolicy = "placement_policy"
+
 // Service resolves and enforces effective workspace limits.
 type Service struct {
 	plans     *repositories.PlanRepository
@@ -282,6 +285,30 @@ func (s *Service) effectivePlan(workspaceID uint) *models.Plan {
 		return p
 	}
 	return nil
+}
+
+// EffectivePlacement resolves the locations and node pool a workspace's plan binds it to (override -> plan ->
+// default). The bool is false when no policy applies, because plan enforcement is off or placement_policy is
+// not licensed; the workspace may then use any location and any node.
+func (s *Service) EffectivePlacement(workspaceID uint) (models.PlanPlacement, bool) {
+	if !s.Enabled() || !s.entitled(flagPlacementPolicy) {
+		return models.PlanPlacement{}, false
+	}
+	var o *models.WorkspaceQuota
+	if s.overrides != nil {
+		o, _ = s.overrides.FindByWorkspace(workspaceID)
+	}
+	return placementFrom(s.effectivePlan(workspaceID), o), true
+}
+
+func placementFrom(p *models.Plan, o *models.WorkspaceQuota) models.PlanPlacement {
+	if o != nil && o.Placement != nil {
+		return *o.Placement
+	}
+	if p == nil {
+		return models.PlanPlacement{}
+	}
+	return p.Placement
 }
 
 // EffectivePlanName returns the name of the workspace's resolved plan, or ""

--- a/internal/worker/deploy.go
+++ b/internal/worker/deploy.go
@@ -63,6 +63,7 @@ type DeployHandler struct {
 	logs          *logstore.Store
 	deployLock    DeployLock
 	builderPolicy BuilderPolicy
+	poolPolicy    PoolPolicy
 	clusterSlots  *clusterSlots
 
 	// Runner build dispatch: a git-source app's image is built on a registered
@@ -187,6 +188,21 @@ type BuilderPolicy interface {
 // a builder set while granted stops being honored if the capability is later
 // revoked, e.g. a plan downgrade). Optional; nil honors the app's builder.
 func (h *DeployHandler) SetBuilderPolicy(p BuilderPolicy) { h.builderPolicy = p }
+
+// PoolPolicy resolves the Swarm constraints that keep a workspace's services in its plan's node pool.
+type PoolPolicy interface {
+	PoolConstraints(workspaceID, clusterID uint) []string
+}
+
+// SetPoolPolicy wires plan node pools into service placement (nil adds no pool constraints).
+func (h *DeployHandler) SetPoolPolicy(p PoolPolicy) { h.poolPolicy = p }
+
+func (h *DeployHandler) serviceConstraints(app *models.Application) []string {
+	if h.poolPolicy == nil {
+		return app.PlacementConstraints
+	}
+	return append(append([]string{}, app.PlacementConstraints...), h.poolPolicy.PoolConstraints(app.WorkspaceID, app.ClusterID)...)
+}
 
 // NodeDocker resolves the Docker client for a node id (0 = local).
 type NodeDocker interface {
@@ -795,7 +811,7 @@ func (h *DeployHandler) deployService(ctx context.Context, app *models.Applicati
 		Configs:        svcConfigs,
 		MemoryBytes:    app.MemoryBytes,
 		NanoCPUs:       app.NanoCPUs,
-		Constraints:    app.PlacementConstraints,
+		Constraints:    h.serviceConstraints(app),
 		Healthcheck:    buildHealthcheck(app),
 		User:           sec.User,
 		CapAdd:         sec.CapAdd,

--- a/web/src/api/nodes.ts
+++ b/web/src/api/nodes.ts
@@ -241,6 +241,8 @@ export const nodesApi = {
     api.post<ApiResponse<NodeCreated>>('/admin/nodes', payload),
   update: (id: number, payload: CreateNodePayload) =>
     api.put<ApiResponse<Server>>(`/admin/nodes/${id}`, payload),
+  // An empty pool takes the node out of its pool.
+  setPool: (id: number, pool: string) => api.put<ApiResponse<Server>>(`/admin/nodes/${id}/pool`, { pool }),
   workloads: (id: number) =>
     api.get<ApiResponse<NodeWorkloads>>(`/admin/nodes/${id}/workloads`),
 

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -57,8 +57,15 @@ export interface Plan {
   // Let apps installed from an official marketplace template keep the image's own
   // default user even under the "restricted" security profile.
   allow_official_image_user: boolean
+  // Binds the plan to locations (cluster ids, the first is the default) and a node pool. Enterprise.
+  placement?: PlanPlacement
   created_at?: string
   updated_at?: string
+}
+
+export interface PlanPlacement {
+  locations?: number[]
+  pool?: string
 }
 
 // SecurityProfile hardens how a workspace's app/job containers run. "restricted"
@@ -94,6 +101,7 @@ export interface WorkspaceQuotaOverride {
   allow_gpu: boolean | null
   security_profile: SecurityProfile | null
   allow_official_image_user: boolean | null
+  placement?: PlanPlacement | null
 }
 
 export interface ResourceUsage {

--- a/web/src/views/admin/NodeDetail.vue
+++ b/web/src/views/admin/NodeDetail.vue
@@ -68,6 +68,28 @@ onBeforeUnmount(stopGatewayEvents)
 const connected = computed(() => !!node.value && (node.value.is_local || !!node.value.agent_connected))
 const isEdge = computed(() => node.value?.connectivity === 'edge-gateway')
 
+const pool = computed(() => node.value?.labels?.['miabi.pool'] ?? '')
+const showPool = ref(false)
+const poolForm = ref('')
+const poolSaving = ref(false)
+function openPool() {
+  poolForm.value = pool.value
+  showPool.value = true
+}
+async function savePool() {
+  const name = poolForm.value.trim()
+  poolSaving.value = true
+  try {
+    node.value = (await nodesApi.setPool(id, name)).data.data
+    showPool.value = false
+    notify.success(name ? `Node is now in the ${name} pool` : 'Node removed from its pool')
+  } catch (e) {
+    notify.apiError(e)
+  } finally {
+    poolSaving.value = false
+  }
+}
+
 // Cluster membership (docker node ls) — shown on the manager's page only, since
 // the manager is the swarm's source of truth. Includes unmanaged members.
 const clusterMembers = ref<ClusterMember[]>([])
@@ -887,6 +909,9 @@ const gwBadge = computed(() => {
             <div class="hero-chips">
               <span class="chip"><span class="mdi mdi-shield-account-outline"></span> {{ roleLabel }}</span>
               <span class="chip"><span class="mdi mdi-transit-connection-variant"></span> {{ connectivityLabel() }}</span>
+              <button type="button" class="chip" :title="pool ? 'Change the node pool' : 'Put the node in a pool'" @click="openPool">
+                <span class="mdi mdi-tag-outline"></span> {{ pool ? `pool: ${pool}` : 'no pool' }}
+              </button>
               <span v-if="node.cordoned" class="chip chip-warn"><span class="mdi mdi-cancel"></span> cordoned</span>
               <span v-else class="chip chip-ok"><span class="mdi mdi-check"></span> schedulable</span>
             </div>
@@ -1515,6 +1540,31 @@ const gwBadge = computed(() => {
           <div class="modal-footer">
             <button type="button" class="btn btn-secondary" @click="showEdit = false">Cancel</button>
             <button type="submit" class="btn btn-primary" :disabled="editSaving">{{ editSaving ? 'Saving…' : 'Save changes' }}</button>
+          </div>
+        </form>
+      </AppModal>
+    </Teleport>
+
+    <Teleport to="body">
+      <AppModal v-if="showPool" @close="showPool = false">
+        <div class="modal-header">
+          <h3>Node pool — {{ node?.name }}</h3>
+          <button class="btn-icon btn-icon-muted" aria-label="Close" @click="showPool = false"><span class="mdi mdi-close"></span></button>
+        </div>
+        <form @submit.prevent="savePool">
+          <div class="modal-body">
+            <div class="form-group" style="margin-bottom: 0">
+              <label class="form-label">Pool</label>
+              <input v-model="poolForm" class="form-input mono" placeholder="e.g. pro" autofocus />
+              <p class="form-hint">
+                Workspaces whose plan names this pool run on its nodes, and plans without a pool never land here
+                (Enterprise plan placement). Empty takes the node out of its pool. Running workloads stay where they are.
+              </p>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" @click="showPool = false">Cancel</button>
+            <button type="submit" class="btn btn-primary" :disabled="poolSaving">{{ poolSaving ? 'Saving…' : 'Save' }}</button>
           </div>
         </form>
       </AppModal>

--- a/web/src/views/admin/PlanDetail.vue
+++ b/web/src/views/admin/PlanDetail.vue
@@ -2,7 +2,8 @@
 import { ref, computed, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { adminApi } from '@/api/admin'
-import type { Plan, PlanInput } from '@/api/types'
+import { clustersApi } from '@/api/clusters'
+import type { Cluster, Plan, PlanInput } from '@/api/types'
 import { useNotificationStore } from '@/stores/notification'
 import { useEntitlement } from '@/composables/useEntitlement'
 import ConfirmDialog from '@/components/ConfirmDialog.vue'
@@ -14,6 +15,9 @@ const notify = useNotificationStore()
 // The restricted security profile is an Enterprise-only policy; in Community the
 // profile stays default.
 const securityProfile = useEntitlement('security_profile')
+const placementPolicy = useEntitlement('placement_policy')
+const clusters = ref<Cluster[]>([])
+clustersApi.list().then((r) => { clusters.value = r.data.data ?? [] }).catch(() => { clusters.value = [] })
 
 const planId = computed(() => Number(route.params.id))
 const plan = ref<Plan | null>(null)
@@ -67,6 +71,24 @@ async function load() {
   }
 }
 watch(planId, load, { immediate: true })
+
+const placementLocations = computed(() => form.value?.placement?.locations ?? [])
+const placementPool = computed({
+  get: () => form.value?.placement?.pool ?? '',
+  set: (pool: string) => {
+    if (form.value) form.value.placement = { ...form.value.placement, pool }
+  },
+})
+function setLocations(locations: number[]) {
+  if (form.value) form.value.placement = { ...form.value.placement, locations }
+}
+function toggleLocation(clusterId: number) {
+  const ids = placementLocations.value
+  setLocations(ids.includes(clusterId) ? ids.filter((x) => x !== clusterId) : [...ids, clusterId])
+}
+function makeDefaultLocation(clusterId: number) {
+  setLocations([clusterId, ...placementLocations.value.filter((x) => x !== clusterId)])
+}
 
 async function save() {
   if (!form.value || !plan.value || !form.value.name.trim()) return
@@ -226,6 +248,39 @@ function fmtDate(s?: string): string {
               Exempt official marketplace apps (keep the image's default user)
             </label>
             <p class="form-hint">When Restricted, apps installed from an <strong>official</strong> marketplace template still run as the image's own user, so curated images that need it aren't broken. Only official installs qualify; the user's own apps stay non-root.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="card mt-4">
+        <div class="card-header">
+          <h2>Placement</h2>
+          <span v-if="!placementPolicy.has.value" class="badge badge-neutral" title="Plan placement requires an Enterprise license">
+            <span class="mdi mdi-lock-outline"></span> Enterprise
+          </span>
+        </div>
+        <div class="card-body">
+          <p class="form-hint" style="margin-top: 0">
+            Where this plan's workspaces may run. Enforced only while plan enforcement is on.
+            <template v-if="!placementPolicy.has.value"> Requires an Enterprise license; without one, workspaces may use any location and any node.</template>
+          </p>
+          <label class="form-label" style="margin-top: 12px">Locations</label>
+          <label v-for="c in clusters" :key="c.id" class="checkbox-label">
+            <input type="checkbox" :checked="placementLocations.includes(c.id)" :disabled="!placementPolicy.mutable.value" @change="toggleLocation(c.id)" />
+            {{ c.display_name || c.name }}<span v-if="c.location_code" class="text-muted"> ({{ c.location_code }})</span>
+            <span v-if="placementLocations[0] === c.id" class="badge badge-info" style="margin-left: 6px">default</span>
+            <button
+              v-else-if="placementLocations.includes(c.id) && placementPolicy.mutable.value"
+              type="button"
+              class="btn btn-ghost btn-sm"
+              @click.prevent="makeDefaultLocation(c.id)"
+            >Make default</button>
+          </label>
+          <p class="form-hint">None checked allows every location. The default is where a workspace's resources land when it names no location.</p>
+          <div class="form-group" style="margin-top: 12px; max-width: 360px">
+            <label class="form-label">Node pool</label>
+            <input v-model.trim="placementPool" class="form-input mono" placeholder="e.g. pro" :disabled="!placementPolicy.mutable.value" />
+            <p class="form-hint">Workspaces run only on nodes in this pool. Empty keeps them on nodes that are in no pool.</p>
           </div>
         </div>
       </div>

--- a/web/src/views/admin/WorkspaceDetail.vue
+++ b/web/src/views/admin/WorkspaceDetail.vue
@@ -2,11 +2,12 @@
 import { computed, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { adminApi } from '@/api/admin'
+import { clustersApi } from '@/api/clusters'
 import { useNotificationStore } from '@/stores/notification'
 import { useLicenseStore } from '@/stores/license'
 import { useEntitlement } from '@/composables/useEntitlement'
 import ConfirmDialog from '@/components/ConfirmDialog.vue'
-import type { AdminWorkspaceDetail, AdminEvent, AdminWorkspaceMember, Plan, WorkspaceQuotaOverride } from '@/api/types'
+import type { AdminWorkspaceDetail, AdminEvent, AdminWorkspaceMember, Cluster, Plan, WorkspaceQuotaOverride } from '@/api/types'
 
 const route = useRoute()
 const router = useRouter()
@@ -131,7 +132,27 @@ async function clearOverride() {
   }
 }
 
-watch(wsId, () => { load(); loadOverride(); licenseStore.load() }, { immediate: true })
+const placementPolicy = useEntitlement('placement_policy')
+const clusters = ref<Cluster[]>([])
+async function loadClusters() {
+  try {
+    clusters.value = (await clustersApi.list()).data.data ?? []
+  } catch {
+    clusters.value = []
+  }
+}
+function setPlacementMode(raw: string) {
+  if (!override.value) return
+  override.value.placement = raw === 'override' ? { locations: [], pool: '' } : null
+}
+function toggleOverrideLocation(clusterId: number) {
+  const p = override.value?.placement
+  if (!p) return
+  const ids = p.locations ?? []
+  p.locations = ids.includes(clusterId) ? ids.filter((x) => x !== clusterId) : [...ids, clusterId]
+}
+
+watch(wsId, () => { load(); loadOverride(); loadClusters(); licenseStore.load() }, { immediate: true })
 
 function back() {
   router.push('/admin/workspaces')
@@ -444,6 +465,30 @@ function eventSeverity(e: AdminEvent): string {
               </select>
             </div>
           </div>
+          <div class="form-group" style="margin: 14px 0 0; max-width: 360px">
+            <label class="form-label form-label-sm">
+              Placement
+              <span v-if="!placementPolicy.has.value" class="badge badge-neutral" style="margin-left: 6px" title="Plan placement requires an Enterprise license">
+                <span class="mdi mdi-lock-outline"></span> Enterprise
+              </span>
+            </label>
+            <select class="form-select" :value="override.placement ? 'override' : ''" @change="setPlacementMode(($event.target as HTMLSelectElement).value)">
+              <option value="">Inherit the plan</option>
+              <option value="override" :disabled="!placementPolicy.mutable.value">Override locations and pool</option>
+            </select>
+          </div>
+          <template v-if="override.placement">
+            <label v-for="c in clusters" :key="c.id" class="checkbox-label" style="display: block; margin-top: 8px">
+              <input type="checkbox" :checked="(override.placement.locations ?? []).includes(c.id)" @change="toggleOverrideLocation(c.id)" />
+              {{ c.display_name || c.name }}
+              <span v-if="override.placement.locations?.[0] === c.id" class="badge badge-info" style="margin-left: 6px">default</span>
+            </label>
+            <p class="form-hint">None checked allows every location; the first checked is the default.</p>
+            <div class="form-group" style="margin-bottom: 0; max-width: 360px">
+              <label class="form-label form-label-sm">Node pool</label>
+              <input v-model.trim="override.placement.pool" class="form-input mono" placeholder="empty = nodes in no pool" />
+            </div>
+          </template>
           <div style="display: flex; gap: 10px; margin-top: 20px">
             <button
               class="btn btn-primary"


### PR DESCRIPTION
A plan can now bind its workspaces to locations and a node pool, so a Starter workspace can neither see nor deploy to a Pro-only location, and its workloads stay on Starter hardware. Enforced only with plan enforcement on and the new Enterprise  entitlement (Business tier and up); otherwise placement is unchanged.