### PR TITLE
feat(clusters): per-cluster external access domain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,12 +142,13 @@ MIABI_NETWORK_SUBNET_PREFIX=24
 # Default: 30
 MIABI_DNS_RECONCILE_MINUTES=30
 
-# External access (one-click public URLs). MIABI_EXTERNAL_BASE_DOMAIN is the
-# wildcard base domain apps are published under, e.g. "apps.example.com" (point
-# DNS *.apps.example.com at the gateway). MIABI_EXTERNAL_BASE_PROVIDER is the Goma
-# certManager provider used for those routes' certificates ("" = gateway default).
-# When set, these are authoritative and override the admin Settings UI on boot;
-# leave empty to manage them from the UI instead.
+# External access (one-click public URLs) in the default cluster.
+# MIABI_EXTERNAL_BASE_DOMAIN is the wildcard domain its apps are published under,
+# e.g. "apps.example.com" (point DNS *.apps.example.com at the gateway).
+# MIABI_EXTERNAL_BASE_PROVIDER is the Goma certManager provider for those
+# certificates ("" = gateway default). When set, each pins that field of the
+# default cluster on boot; leave empty to manage it from Clusters → Edit, where
+# every other cluster sets its own domain.
 MIABI_EXTERNAL_BASE_DOMAIN=
 MIABI_EXTERNAL_BASE_PROVIDER=
 
@@ -174,7 +175,7 @@ MIABI_CERT_RENEW_DAYS=30
 # ENABLED, HOST and all STORAGE/S3 values are set HERE ONLY: the admin Settings
 # UI shows them read-only, and a change takes a restart. Any other value here is
 # authoritative on boot (overrides the UI), like MIABI_EXTERNAL_BASE_DOMAIN.
-#   HOST         docker login target; defaults to registry.<EXTERNAL_BASE_DOMAIN>.
+#   HOST         docker login target; defaults to registry.<default cluster's external domain>.
 #   STORAGE      filesystem | s3   (blank = filesystem)
 #   IMAGE        override the registry image (also settable via the image catalog)
 #   AUTH_URL     address the gateway's forwardAuth calls to reach this control

--- a/cmd/miabi/server.go
+++ b/cmd/miabi/server.go
@@ -422,7 +422,7 @@ func runServer(cli *okapicli.CLI) {
 			// platform token) for multi-node pulls; it also resolves the host for runner pushes.
 			registryDistributor := registryserver.NewService(
 				repositories.NewRegistrySettingsRepository(res.db), imageResolver,
-				settings.NewProvider(repositories.NewSettingRepository(res.db), nil),
+				clusterService,
 				nil, repositories.NewWorkspaceRepository(res.db), nil, cfg.ProxyNetwork, cfg.ControlURL, cfg.Registry,
 			)
 

--- a/cmd/miabi/worker.go
+++ b/cmd/miabi/worker.go
@@ -238,7 +238,7 @@ func runWorker() error {
 
 	registryDistributor := registryserver.NewService(
 		repositories.NewRegistrySettingsRepository(db), imageResolver,
-		settings.NewProvider(repositories.NewSettingRepository(db), nil),
+		clusterService,
 		nil, repositories.NewWorkspaceRepository(db), nil, cfg.ProxyNetwork, cfg.ControlURL, cfg.Registry,
 	)
 

--- a/examples/compose/.env.example
+++ b/examples/compose/.env.example
@@ -183,10 +183,10 @@ MIABI_NETWORK_SUBNET_PREFIX=24
 MIABI_DNS_RECONCILE_MINUTES=30
 
 # --- One-click public app URLs (wildcard domain) -----------------------------
-# Apps are published under this base domain — point *.apps.example.com at this
-# host. PROVIDER is the Goma certManager provider used for those certificates
-# ("" = the gateway default). When set, these override the admin Settings UI on
-# boot; leave empty to manage them from the UI instead.
+# Apps in the default cluster are published under this domain — point
+# *.apps.example.com at this host. PROVIDER is the Goma certManager provider used
+# for those certificates ("" = the gateway default). When set, these pin the
+# default cluster's fields on boot; leave empty to manage them from Clusters → Edit.
 MIABI_EXTERNAL_BASE_DOMAIN=apps.example.com
 MIABI_EXTERNAL_BASE_PROVIDER=
 
@@ -213,7 +213,7 @@ MIABI_CERT_RENEW_DAYS=30
 #
 # ENABLED, HOST and all STORAGE/S3 values are set HERE ONLY: the admin Settings
 # UI shows them read-only, and a change takes a restart.
-#   HOST         docker login target; defaults to registry.<EXTERNAL_BASE_DOMAIN>.
+#   HOST         docker login target; defaults to registry.<default cluster's external domain>.
 #   STORAGE      filesystem | s3   (blank = filesystem)
 #   IMAGE        override the registry image (also settable via the image catalog)
 #   AUTH_URL     address the gateway's forwardAuth calls to reach this control

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -209,13 +209,12 @@ type Config struct {
 	RequireEmailVerification string
 	AllowedSignupDomains     string
 
-	// ExternalBaseDomain is the wildcard base domain for one-click external access (e.g.
-	// "apps.example.com", DNS *.apps.example.com). When set it is authoritative for the
-	// `external_base_domain` setting on every boot; leave empty to manage it from the admin UI.
+	// ExternalBaseDomain is the default cluster's wildcard domain for one-click external access (e.g.
+	// "apps.example.com", DNS *.apps.example.com). When set it pins that cluster's external domain on
+	// every boot; leave empty to manage it from the cluster page. Other clusters set their own there.
 	ExternalBaseDomain string
-	// ExternalBaseProvider names the Goma certManager provider used for the generated
-	// external-access routes' certificates ("" = the gateway default). Authoritative for the
-	// `external_base_provider` setting when set, like ExternalBaseDomain.
+	// ExternalBaseProvider names the Goma certManager provider for the default cluster's generated
+	// URLs ("" = the gateway default). When set it pins that field, like ExternalBaseDomain.
 	ExternalBaseProvider string
 	// NodeGatewayImage is the Goma Gateway image deployed on edge-gateway nodes.
 	NodeGatewayImage string

--- a/internal/handlers/admin_setting_reserved_test.go
+++ b/internal/handlers/admin_setting_reserved_test.go
@@ -28,7 +28,7 @@ func TestReservedSettingsAreHiddenFromTheGenericList(t *testing.T) {
 		"repo_pipelines_enabled",
 		"require_email_verification",
 		"allowed_signup_domains",
-		"external_base_domain",
+		"max_memory_mb",
 		"branding_notes",
 		"cluster_names",
 		"imagemagick_enabled",

--- a/internal/handlers/clusters_handler.go
+++ b/internal/handlers/clusters_handler.go
@@ -38,11 +38,12 @@ func (h *ClusterHandler) GetCluster(c *okapi.Context) error {
 	if err != nil {
 		return h.mapClusterErr(c, err)
 	}
+	cl.ExternalApps = h.cluster.ExternalApps(cl.ID)
 	return ok(c, cl)
 }
 
-// UpdateClusterRequest sets a cluster's tenant-facing identity and who may place into it. Omitted fields are
-// left unchanged.
+// UpdateClusterRequest sets a cluster's tenant-facing identity, who may place into it, and where its generated app
+// URLs live. Omitted fields are left unchanged.
 type UpdateClusterRequest struct {
 	Body struct {
 		// DisplayName is the location name tenants see, e.g. "Frankfurt". Empty clears it.
@@ -53,6 +54,11 @@ type UpdateClusterRequest struct {
 		Visibility string `json:"visibility" enum:"all,restricted"`
 		// Cordoned stops new placements in the location; running workloads stay.
 		Cordoned *bool `json:"cordoned"`
+		// ExternalBaseDomain is the wildcard domain for generated app URLs here, e.g. "apps.eu-central.example.com".
+		// Empty turns one-click external access off in the location; a change re-hosts the URLs already generated.
+		ExternalBaseDomain *string `json:"external_base_domain"`
+		// ExternalCertProvider names the gateway's certManager provider for those URLs; empty uses its default.
+		ExternalCertProvider *string `json:"external_cert_provider"`
 	} `json:"body"`
 }
 
@@ -71,10 +77,12 @@ func (h *ClusterHandler) UpdateCluster(c *okapi.Context, req *UpdateClusterReque
 		v := models.ClusterVisibility(req.Body.Visibility)
 		patch.Visibility = &v
 	}
+	patch.ExternalBaseDomain, patch.ExternalCertProvider = req.Body.ExternalBaseDomain, req.Body.ExternalCertProvider
 	cl, err := h.cluster.UpdateCluster(id, patch)
 	if err != nil {
 		return h.mapClusterErr(c, err)
 	}
+	cl.ExternalApps = h.cluster.ExternalApps(cl.ID)
 	h.record(c, "cluster.update", cl.ID)
 	return ok(c, cl)
 }
@@ -176,6 +184,11 @@ func (h *ClusterHandler) mapClusterErr(c *okapi.Context, err error) error {
 		errors.Is(err, cluster.ErrInvalidIngressIP), errors.Is(err, cluster.ErrInvalidIngressHostname),
 		errors.Is(err, node.ErrInvalidConnectivity):
 		return c.AbortBadRequest(err.Error())
+	case errors.Is(err, cluster.ErrInvalidExternalDomain), errors.Is(err, cluster.ErrInvalidCertProvider),
+		errors.Is(err, cluster.ErrExternalAccessPinned):
+		return c.AbortBadRequest(err.Error())
+	case errors.Is(err, cluster.ErrExternalDomainTaken):
+		return c.AbortWithError(409, err)
 	default:
 		return c.AbortInternalServerError("cluster operation failed", err)
 	}

--- a/internal/handlers/route_handler.go
+++ b/internal/handlers/route_handler.go
@@ -12,24 +12,15 @@ import (
 	"github.com/miabi-io/miabi/internal/models"
 	"github.com/miabi-io/miabi/internal/services/audit"
 	"github.com/miabi-io/miabi/internal/services/route"
-	"github.com/miabi-io/miabi/internal/services/settings"
 )
 
 type RouteHandler struct {
-	svc      *route.Service
-	settings *settings.Provider
-	audit    *audit.Logger
+	svc   *route.Service
+	audit *audit.Logger
 }
 
-func NewRouteHandler(svc *route.Service, settingsProvider *settings.Provider, auditLog *audit.Logger) *RouteHandler {
-	return &RouteHandler{svc: svc, settings: settingsProvider, audit: auditLog}
-}
-
-func (h *RouteHandler) externalConfig() route.ExternalConfig {
-	return route.ExternalConfig{
-		BaseDomain: h.settings.String(settings.KeyExternalBaseDomain, ""),
-		Provider:   h.settings.String(settings.KeyExternalBaseProvider, ""),
-	}
+func NewRouteHandler(svc *route.Service, auditLog *audit.Logger) *RouteHandler {
+	return &RouteHandler{svc: svc, audit: auditLog}
 }
 
 type CreateRouteRequest struct {
@@ -331,7 +322,7 @@ func (h *RouteHandler) ExternalAccess(c *okapi.Context) error {
 	if err != nil {
 		return c.AbortBadRequest("invalid application id")
 	}
-	out, err := h.svc.GetExternalAccess(middlewares.WorkspaceID(c), appID, h.externalConfig())
+	out, err := h.svc.GetExternalAccess(middlewares.WorkspaceID(c), appID)
 	if err != nil {
 		return h.mapErr(c, err)
 	}
@@ -353,7 +344,7 @@ func (h *RouteHandler) SetExternalAccess(c *okapi.Context, req *SetExternalAcces
 		return c.AbortBadRequest("invalid application id")
 	}
 	wsID := middlewares.WorkspaceID(c)
-	out, err := h.svc.SetExternalAccess(c.Request().Context(), wsID, appID, req.Body.Ports, h.externalConfig())
+	out, err := h.svc.SetExternalAccess(c.Request().Context(), wsID, appID, req.Body.Ports)
 	if err != nil {
 		return h.mapErr(c, err)
 	}

--- a/internal/models/cluster.go
+++ b/internal/models/cluster.go
@@ -56,6 +56,14 @@ type Cluster struct {
 	IngressHostname string            `json:"ingress_hostname,omitempty"`
 	Visibility      ClusterVisibility `json:"visibility" gorm:"not null;default:all"`
 	Cordoned        bool              `json:"cordoned" gorm:"not null;default:false"`
+	// ExternalBaseDomain is the wildcard domain generated app URLs in this cluster live under, empty when one-click
+	// external access is off here; ExternalCertProvider is the gateway's certManager provider for them.
+	ExternalBaseDomain   string `json:"external_base_domain,omitempty"`
+	ExternalCertProvider string `json:"external_cert_provider,omitempty"`
+	// The environment pins the default cluster's external access fields. ExternalApps counts apps with generated URLs.
+	ExternalDomainPinned   bool  `json:"external_domain_pinned,omitempty" gorm:"-"`
+	ExternalProviderPinned bool  `json:"external_provider_pinned,omitempty" gorm:"-"`
+	ExternalApps           int64 `json:"external_apps,omitempty" gorm:"-"`
 	// LegacyIngress marks a cluster whose port-forward node became an edge gateway at upgrade, until an
 	// admin confirms that gateway or joins the node to a swarm.
 	LegacyIngress bool      `json:"legacy_ingress" gorm:"not null;default:false"`

--- a/internal/models/registry_settings.go
+++ b/internal/models/registry_settings.go
@@ -21,9 +21,9 @@ type RegistrySettings struct {
 	// Read-only: MIABI_REGISTRY_ENABLED. Default false → a no-op so single-node
 	// installs are unchanged.
 	Enabled bool `json:"enabled"`
-	// Host is the public registry hostname (e.g. registry.<external-base-domain>),
+	// Host is the public registry hostname (e.g. registry.<external-domain>),
 	// the docker login target. Read-only: MIABI_REGISTRY_HOST, else derived from
-	// the external base domain.
+	// the default cluster's external domain.
 	Host string `json:"host,omitempty"`
 
 	// StorageType is "filesystem" (a managed volume) or "s3" (S3/MinIO).

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -239,8 +239,6 @@ func InitRoutes(app *okapi.Okapi, db *gorm.DB, redisClient *redis.Client, cfg *c
 	recoveryRepo := repositories.NewTwoFactorRecoveryRepository(db)
 	authService := auth.NewService(userRepo, resetRepo, recoveryRepo, sessionStore, cfg.JWTSecret)
 	settingsProvider := settings.NewProvider(settingRepo, map[string]string{
-		settings.KeyExternalBaseDomain:       cfg.ExternalBaseDomain,
-		settings.KeyExternalBaseProvider:     cfg.ExternalBaseProvider,
 		settings.KeyRequireEmailVerification: cfg.RequireEmailVerification,
 		settings.KeyAllowedSignupDomains:     cfg.AllowedSignupDomains,
 	})
@@ -447,6 +445,7 @@ func InitRoutes(app *okapi.Okapi, db *gorm.DB, redisClient *redis.Client, cfg *c
 	clusterService.SetIngressReconciler(proxyReconciler.ReconcileIngressGateway)
 	// A swarm outside the default cluster is served by its own ingress node's gateway.
 	routeService.SetCluster(clusterService)
+	routeService.SetExternalDomains(clusterService)
 	clusterService.SetGatewayListener(routeService.SyncCluster)
 	proxyReconciler.SetCluster(clusterService)
 	go func() { _ = proxyReconciler.ReconcileIngressGateway(context.Background()) }()
@@ -733,7 +732,7 @@ func InitRoutes(app *okapi.Okapi, db *gorm.DB, redisClient *redis.Client, cfg *c
 	// Built-in Docker registry (distinct from the external-creds registryService).
 	registryServerService := registryserver.NewService(
 		repositories.NewRegistrySettingsRepository(db),
-		imageResolver, settingsProvider, apiKeyService, workspaceRepo,
+		imageResolver, clusterService, apiKeyService, workspaceRepo,
 		proxyMgr, cfg.ProxyNetwork, cfg.ControlURL, cfg.Registry,
 	)
 	// S3 storage is an Enterprise entitlement, and the environment is now its only
@@ -855,13 +854,20 @@ func InitRoutes(app *okapi.Okapi, db *gorm.DB, redisClient *redis.Client, cfg *c
 	applyService.SetPlacer(placementService)
 	applyService.SetCertificates(certificateService)
 	// Declarative Application port exposure: externalAccess (reverse-proxy URLs,
-	// over the platform base domain) and publish/hostPort (host-port bindings).
-	applyService.SetPortExposure(func() route.ExternalConfig {
-		return route.ExternalConfig{
-			BaseDomain: settingsProvider.String(settings.KeyExternalBaseDomain, ""),
-			Provider:   settingsProvider.String(settings.KeyExternalBaseProvider, ""),
+	// over the app's cluster domain) and publish/hostPort (host-port bindings).
+	applyService.SetPortExposure(portBindingService)
+	// Wired once every route service dependency is, since a pinned domain that changed re-hosts routes right away.
+	clusterService.SetExternalAccessListener(func(ctx context.Context, clusterID uint) {
+		routeService.RehostCluster(ctx, clusterID)
+		if c, err := clusterService.Cluster(clusterID); err == nil && c.IsDefault {
+			if err := registryServerService.SyncGateway(ctx); err != nil {
+				logger.Warn("registry: re-publishing the gateway route failed", "error", err)
+			}
 		}
-	}, portBindingService)
+	})
+	if err := clusterService.PinExternalAccess(cfg.ExternalBaseDomain, cfg.ExternalBaseProvider); err != nil {
+		logger.Error("external access from the environment was not applied", "error", err)
+	}
 	// GitOps: reconcile a repo of miabi.io/v1 manifests via the apply engine.
 	gitopsService := gitops.NewService(repositories.NewGitSourceRepository(db), gitRepoRepo, applyService)
 	gitopsService.SetSecrets(secretService) // resolve a vault-backed Git credential when fetching
@@ -1067,7 +1073,7 @@ func InitRoutes(app *okapi.Okapi, db *gorm.DB, redisClient *redis.Client, cfg *c
 			app:             handlers.NewApplicationHandler(appService, bus, auditLogger, ee),
 			network:         handlers.NewNetworkHandler(networkService, auditLogger),
 			stack:           handlers.NewStackHandler(stackService, auditLogger),
-			route:           handlers.NewRouteHandler(routeService, settingsProvider, auditLogger),
+			route:           handlers.NewRouteHandler(routeService, auditLogger),
 			domain:          handlers.NewDomainHandler(domainService, routeRepo, auditLogger),
 			dnsProvider:     handlers.NewDNSProviderHandler(dnsProviderService, auditLogger),
 			middleware:      handlers.NewMiddlewareHandler(middlewareService, auditLogger),

--- a/internal/services/apply/apply.go
+++ b/internal/services/apply/apply.go
@@ -69,10 +69,10 @@ type Service struct {
 	domains    *domain.Service
 	registries *registry.Service
 
-	// Port-exposure reconcilers (optional; wired via SetPortExposure). extConfig
-	// resolves the platform external-access base domain at apply time; bindings
+	// Port-exposure reconcilers (optional; wired via SetPortExposure). extAccess
+	// reconciles externalAccess ports under the app's cluster domain; bindings
 	// manages host-port bindings.
-	extConfig func() route.ExternalConfig
+	extAccess bool
 	bindings  *portbinding.Service
 
 	// configs converges kind: Config; nil leaves a manifest declaring one
@@ -306,8 +306,8 @@ func NewService(apps *application.Service, storage *storage.Service, dbs *databa
 // SetPortExposure wires the reconcilers for an Application's per-port exposure:
 // externalAccess (reverse-proxy URLs) and publish/hostPort (host-port bindings).
 // Nil-safe: when unset, those manifest fields are ignored.
-func (s *Service) SetPortExposure(extConfig func() route.ExternalConfig, bindings *portbinding.Service) {
-	s.extConfig, s.bindings = extConfig, bindings
+func (s *Service) SetPortExposure(bindings *portbinding.Service) {
+	s.extAccess, s.bindings = true, bindings
 }
 
 // Options tunes a plan/apply.
@@ -2447,14 +2447,14 @@ func (s *Service) reconcileExposure(ctx context.Context, workspaceID uint, app *
 	}
 	// Reverse-proxy external access: the set of ports flagged externalAccess.
 	// SetExternalAccess is idempotent and also tears down ports no longer flagged.
-	if s.extConfig != nil {
+	if s.extAccess {
 		var ext []int
 		for _, p := range spec.Ports {
 			if p.ExternalAccess {
 				ext = append(ext, p.Container)
 			}
 		}
-		if _, err := s.routes.SetExternalAccess(ctx, workspaceID, app.ID, ext, s.extConfig()); err != nil {
+		if _, err := s.routes.SetExternalAccess(ctx, workspaceID, app.ID, ext); err != nil {
 			return fmt.Errorf("external access: %w", err)
 		}
 	}

--- a/internal/services/cluster/cluster.go
+++ b/internal/services/cluster/cluster.go
@@ -75,6 +75,7 @@ type Store interface {
 	IDByUID(uid string) (uint, error)
 	UpdateColumns(id uint, cols map[string]any) error
 	CountWorkloads(clusterID uint) (int64, error)
+	CountExternalApps(clusterID uint) (int64, error)
 	CountServerWorkloadsByKind(serverID uint) (apps, databases, volumes int64, err error)
 	CreateStandalone(srv *models.Server, name string) (*models.Cluster, error)
 	AssignServer(serverID, clusterID uint) error
@@ -106,6 +107,10 @@ type Service struct {
 	// so a gateway recreate can't leave clustered apps dark for longer than a refresh interval.
 	ingressReconciler func(context.Context) error
 	gatewayListener   func(context.Context, uint)
+	externalListener  func(context.Context, uint)
+	// externalDomainEnv and externalProviderEnv pin the default cluster's external access from the environment.
+	externalDomainEnv   string
+	externalProviderEnv string
 
 	// networkMigrator converts the default cluster's workspace bridges into overlays when Swarm is enabled,
 	// networkRollback reverses it before leaving, and networkPending counts bridges still left.

--- a/internal/services/cluster/clusters.go
+++ b/internal/services/cluster/clusters.go
@@ -5,6 +5,7 @@ package cluster
 
 import (
 	"errors"
+	"maps"
 	"regexp"
 	"strings"
 
@@ -25,6 +26,9 @@ type ClusterPatch struct {
 	LocationCode *string
 	Visibility   *models.ClusterVisibility
 	Cordoned     *bool
+	// ExternalBaseDomain and ExternalCertProvider set where generated app URLs live; a change re-hosts them.
+	ExternalBaseDomain   *string
+	ExternalCertProvider *string
 }
 
 // Clusters lists every cluster, the default first, with its node count.
@@ -32,7 +36,12 @@ func (s *Service) Clusters() ([]models.Cluster, error) {
 	if s.store == nil {
 		return []models.Cluster{}, nil
 	}
-	return s.store.List()
+	list, err := s.store.List()
+	if err != nil {
+		return nil, err
+	}
+	s.markExternalPins(list)
+	return list, nil
 }
 
 // Cluster returns one cluster with its node count; id 0 is the default cluster.
@@ -57,7 +66,7 @@ func (s *Service) ClusterIDByUID(uid string) (uint, error) {
 	return s.store.IDByUID(uid)
 }
 
-// UpdateCluster renames a cluster, changes its location code, or changes who may place into it.
+// UpdateCluster renames a cluster, changes its location code, who may place into it, or its external access.
 func (s *Service) UpdateCluster(id uint, p ClusterPatch) (*models.Cluster, error) {
 	c, err := s.Cluster(id)
 	if err != nil {
@@ -87,10 +96,18 @@ func (s *Service) UpdateCluster(id uint, p ClusterPatch) (*models.Cluster, error
 	if p.Cordoned != nil {
 		cols["cordoned"] = *p.Cordoned
 	}
+	external, err := s.externalColumns(c, p)
+	if err != nil {
+		return nil, err
+	}
+	maps.Copy(cols, external)
 	if len(cols) > 0 {
 		if err := s.store.UpdateColumns(c.ID, cols); err != nil {
 			return nil, err
 		}
+	}
+	if len(external) > 0 {
+		s.externalChanged(c.ID)
 	}
 	return s.Cluster(c.ID)
 }

--- a/internal/services/cluster/external.go
+++ b/internal/services/cluster/external.go
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package cluster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/jkaninda/logger"
+	"github.com/miabi-io/miabi/internal/models"
+)
+
+var (
+	// ErrInvalidExternalDomain is returned for an external domain that is not a DNS name.
+	ErrInvalidExternalDomain = errors.New("the external domain must be a DNS name such as apps.eu-central.example.com")
+	// ErrExternalDomainTaken is returned when another cluster already generates URLs under the domain.
+	ErrExternalDomainTaken = errors.New("another cluster already uses this external domain")
+	// ErrInvalidCertProvider is returned for a certificate provider that is not a plain provider name.
+	ErrInvalidCertProvider = errors.New("the certificate provider must be a provider name from the gateway configuration, e.g. letsencrypt")
+	// ErrExternalAccessPinned is returned for a change to a field the environment sets.
+	ErrExternalAccessPinned = errors.New("set by MIABI_EXTERNAL_BASE_DOMAIN or MIABI_EXTERNAL_BASE_PROVIDER; change it in the environment")
+)
+
+var certProviderPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]{0,62}$`)
+
+// ExternalAccess returns the wildcard domain and certificate provider for generated app URLs in a cluster; id 0 is
+// the default cluster. An empty domain means one-click external access is off there.
+func (s *Service) ExternalAccess(clusterID uint) (domain, provider string) {
+	if s.store == nil {
+		return "", ""
+	}
+	c, err := s.store.FindByID(clusterID)
+	if err != nil {
+		return "", ""
+	}
+	return c.ExternalBaseDomain, c.ExternalCertProvider
+}
+
+// ExternalApps counts the apps in a cluster holding generated URLs, which a domain change re-hosts.
+func (s *Service) ExternalApps(clusterID uint) int64 {
+	if s.store == nil {
+		return 0
+	}
+	n, err := s.store.CountExternalApps(clusterID)
+	if err != nil {
+		logger.Warn("count apps with generated URLs failed", "cluster", clusterID, "error", err)
+		return 0
+	}
+	return n
+}
+
+// SetExternalAccessListener is told when a cluster's external domain or certificate provider changed, so the
+// generated app URLs follow.
+func (s *Service) SetExternalAccessListener(fn func(ctx context.Context, clusterID uint)) {
+	s.externalListener = fn
+}
+
+// PinExternalAccess applies MIABI_EXTERNAL_BASE_DOMAIN and MIABI_EXTERNAL_BASE_PROVIDER to the default cluster. A
+// set variable wins on every boot and locks its field; an empty one leaves the field to the console.
+func (s *Service) PinExternalAccess(domain, provider string) error {
+	s.externalDomainEnv = normalizeExternalDomain(domain)
+	s.externalProviderEnv = strings.TrimSpace(provider)
+	if s.store == nil || (s.externalDomainEnv == "" && s.externalProviderEnv == "") {
+		return nil
+	}
+	def, err := s.store.FindDefault()
+	if err != nil {
+		return err
+	}
+	cols := map[string]any{}
+	if d := s.externalDomainEnv; d != "" && d != def.ExternalBaseDomain {
+		if err := s.checkExternalDomain(def.ID, d); err != nil {
+			return fmt.Errorf("MIABI_EXTERNAL_BASE_DOMAIN: %w", err)
+		}
+		cols["external_base_domain"] = d
+	}
+	if p := s.externalProviderEnv; p != "" && p != def.ExternalCertProvider {
+		if !certProviderPattern.MatchString(p) {
+			return fmt.Errorf("MIABI_EXTERNAL_BASE_PROVIDER: %w", ErrInvalidCertProvider)
+		}
+		cols["external_cert_provider"] = p
+	}
+	if len(cols) == 0 {
+		return nil
+	}
+	if err := s.store.UpdateColumns(def.ID, cols); err != nil {
+		return err
+	}
+	s.externalChanged(def.ID)
+	return nil
+}
+
+// externalColumns validates a patch's external access fields, returning only the columns that change.
+func (s *Service) externalColumns(c *models.Cluster, p ClusterPatch) (map[string]any, error) {
+	cols := map[string]any{}
+	if p.ExternalBaseDomain != nil {
+		if d := normalizeExternalDomain(*p.ExternalBaseDomain); d != c.ExternalBaseDomain {
+			if c.IsDefault && s.externalDomainEnv != "" {
+				return nil, ErrExternalAccessPinned
+			}
+			if err := s.checkExternalDomain(c.ID, d); err != nil {
+				return nil, err
+			}
+			cols["external_base_domain"] = d
+		}
+	}
+	if p.ExternalCertProvider != nil {
+		if prov := strings.TrimSpace(*p.ExternalCertProvider); prov != c.ExternalCertProvider {
+			if c.IsDefault && s.externalProviderEnv != "" {
+				return nil, ErrExternalAccessPinned
+			}
+			if prov != "" && !certProviderPattern.MatchString(prov) {
+				return nil, ErrInvalidCertProvider
+			}
+			cols["external_cert_provider"] = prov
+		}
+	}
+	return cols, nil
+}
+
+// checkExternalDomain refuses a malformed domain, and one another cluster already uses: both would generate the
+// same hostnames.
+func (s *Service) checkExternalDomain(clusterID uint, domain string) error {
+	if domain == "" {
+		return nil
+	}
+	if len(domain) > 253 || !hostnamePattern.MatchString(domain) {
+		return ErrInvalidExternalDomain
+	}
+	list, err := s.store.List()
+	if err != nil {
+		return err
+	}
+	for _, other := range list {
+		if other.ID != clusterID && other.ExternalBaseDomain == domain {
+			return ErrExternalDomainTaken
+		}
+	}
+	return nil
+}
+
+func (s *Service) externalChanged(clusterID uint) {
+	if s.externalListener != nil {
+		go s.externalListener(context.Background(), clusterID)
+	}
+}
+
+func (s *Service) markExternalPins(list []models.Cluster) {
+	for i := range list {
+		if list[i].IsDefault {
+			list[i].ExternalDomainPinned = s.externalDomainEnv != ""
+			list[i].ExternalProviderPinned = s.externalProviderEnv != ""
+		}
+	}
+}
+
+// normalizeExternalDomain accepts "*.apps.example.com" and "apps.example.com." for "apps.example.com".
+func normalizeExternalDomain(raw string) string {
+	d := strings.ToLower(strings.TrimSpace(raw))
+	d = strings.TrimPrefix(d, "*.")
+	return strings.TrimSuffix(strings.TrimPrefix(d, "."), ".")
+}

--- a/internal/services/cluster/external_test.go
+++ b/internal/services/cluster/external_test.go
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package cluster
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/miabi-io/miabi/internal/models"
+)
+
+func rehosted(s *Service) <-chan uint {
+	changed := make(chan uint, 4)
+	s.SetExternalAccessListener(func(_ context.Context, id uint) { changed <- id })
+	return changed
+}
+
+func expectRehost(t *testing.T, changed <-chan uint, want uint) {
+	t.Helper()
+	select {
+	case id := <-changed:
+		if id != want {
+			t.Errorf("re-hosted cluster %d, want %d", id, want)
+		}
+	case <-time.After(time.Second):
+		t.Errorf("cluster %d was not re-hosted", want)
+	}
+}
+
+func TestUpdateClusterSetsTheExternalDomain(t *testing.T) {
+	store := &memStore{
+		def:    models.Cluster{ID: 1, IsDefault: true, Name: "default"},
+		others: map[uint]models.Cluster{2: {ID: 2, Name: "paris", ExternalBaseDomain: "apps.eu.example.com"}},
+	}
+	s := &Service{store: store}
+	changed := rehosted(s)
+
+	domain, provider := " *.Apps.Example.com. ", "letsencrypt"
+	c, err := s.UpdateCluster(1, ClusterPatch{ExternalBaseDomain: &domain, ExternalCertProvider: &provider})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if c.ExternalBaseDomain != "apps.example.com" || c.ExternalCertProvider != "letsencrypt" {
+		t.Errorf("cluster = %+v, want apps.example.com with letsencrypt", c)
+	}
+	expectRehost(t, changed, 1)
+
+	if _, err := s.UpdateCluster(1, ClusterPatch{ExternalBaseDomain: &domain}); err != nil {
+		t.Fatalf("saving the same domain: %v", err)
+	}
+	select {
+	case id := <-changed:
+		t.Errorf("cluster %d re-hosted although its domain did not change", id)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	for raw, want := range map[string]error{
+		"not a domain":        ErrInvalidExternalDomain,
+		"localhost":           ErrInvalidExternalDomain,
+		"apps.eu.example.com": ErrExternalDomainTaken,
+	} {
+		if _, err := s.UpdateCluster(1, ClusterPatch{ExternalBaseDomain: &raw}); !errors.Is(err, want) {
+			t.Errorf("domain %q: err = %v, want %v", raw, err, want)
+		}
+	}
+	bad := "lets encrypt"
+	if _, err := s.UpdateCluster(1, ClusterPatch{ExternalCertProvider: &bad}); !errors.Is(err, ErrInvalidCertProvider) {
+		t.Errorf("provider %q: err = %v, want ErrInvalidCertProvider", bad, err)
+	}
+	if got, _ := s.ExternalAccess(models.DefaultClusterID); got != "apps.example.com" {
+		t.Errorf("ExternalAccess(default) = %q, want apps.example.com", got)
+	}
+
+	cleared := ""
+	if c, err := s.UpdateCluster(2, ClusterPatch{ExternalBaseDomain: &cleared}); err != nil || c.ExternalBaseDomain != "" {
+		t.Fatalf("clearing = %+v, %v; want external access off", c, err)
+	}
+	expectRehost(t, changed, 2)
+}
+
+func TestTheEnvironmentPinsTheDefaultClusterExternalAccess(t *testing.T) {
+	store := &memStore{
+		def:    models.Cluster{ID: 1, IsDefault: true, Name: "default", ExternalBaseDomain: "old.example.com"},
+		others: map[uint]models.Cluster{2: {ID: 2, Name: "paris"}},
+	}
+	s := &Service{store: store}
+	changed := rehosted(s)
+
+	if err := s.PinExternalAccess("*.apps.example.com", ""); err != nil {
+		t.Fatalf("pin: %v", err)
+	}
+	if store.def.ExternalBaseDomain != "apps.example.com" {
+		t.Errorf("default domain = %q, want the environment's", store.def.ExternalBaseDomain)
+	}
+	expectRehost(t, changed, 1)
+
+	other := "apps.example.net"
+	if _, err := s.UpdateCluster(1, ClusterPatch{ExternalBaseDomain: &other}); !errors.Is(err, ErrExternalAccessPinned) {
+		t.Errorf("editing a pinned domain err = %v, want ErrExternalAccessPinned", err)
+	}
+	same, provider := "apps.example.com", "zerossl"
+	c, err := s.UpdateCluster(1, ClusterPatch{ExternalBaseDomain: &same, ExternalCertProvider: &provider})
+	if err != nil || c.ExternalCertProvider != "zerossl" {
+		t.Errorf("unchanged pinned domain with a provider edit = %+v, %v; want the provider saved", c, err)
+	}
+	expectRehost(t, changed, 1)
+	if _, err := s.UpdateCluster(2, ClusterPatch{ExternalBaseDomain: &same}); !errors.Is(err, ErrExternalDomainTaken) {
+		t.Errorf("another cluster taking the pinned domain err = %v, want ErrExternalDomainTaken", err)
+	}
+
+	list, err := s.Clusters()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range list {
+		if c.ExternalDomainPinned != c.IsDefault || c.ExternalProviderPinned {
+			t.Errorf("%s: domain pinned %v, provider pinned %v; want only the default cluster's domain pinned",
+				c.Name, c.ExternalDomainPinned, c.ExternalProviderPinned)
+		}
+	}
+}

--- a/internal/services/cluster/store_test.go
+++ b/internal/services/cluster/store_test.go
@@ -91,6 +91,10 @@ func (m *memStore) UpdateColumns(id uint, cols map[string]any) error {
 			c.Visibility = v.(models.ClusterVisibility)
 		case "cordoned":
 			c.Cordoned = v.(bool)
+		case "external_base_domain":
+			c.ExternalBaseDomain = v.(string)
+		case "external_cert_provider":
+			c.ExternalCertProvider = v.(string)
 		}
 	}
 	if c.ID == m.def.ID {
@@ -100,6 +104,8 @@ func (m *memStore) UpdateColumns(id uint, cols map[string]any) error {
 	}
 	return nil
 }
+
+func (m *memStore) CountExternalApps(uint) (int64, error) { return 0, nil }
 
 func (m *memStore) CountWorkloads(clusterID uint) (int64, error) {
 	var n int64

--- a/internal/services/registryserver/distribute.go
+++ b/internal/services/registryserver/distribute.go
@@ -40,7 +40,7 @@ func (s *Service) DistributionUnavailableReason() string {
 	// The platform token is derived from the master key, so it is always present
 	// (no operator action needed); only enablement and a resolvable host remain.
 	if s.HostFor(st) == "" {
-		return "the registry host cannot be resolved (set MIABI_REGISTRY_HOST, or configure the external base domain so it defaults to registry.<domain>)"
+		return "the registry host cannot be resolved (set MIABI_REGISTRY_HOST, or set the default cluster's external domain so it defaults to registry.<domain>)"
 	}
 	return ""
 }

--- a/internal/services/registryserver/hostlock_test.go
+++ b/internal/services/registryserver/hostlock_test.go
@@ -12,12 +12,7 @@ import (
 
 type baseDomain string
 
-func (b baseDomain) String(_, def string) string {
-	if b == "" {
-		return def
-	}
-	return string(b)
-}
+func (b baseDomain) ExternalAccess(uint) (string, string) { return string(b), "" }
 
 // MIABI_REGISTRY_ENABLED pins enablement when it is set, and only then. An absent variable leaves the
 // switch to the stored row — i.e. to the admin UI — so an install that configures nothing in the
@@ -77,7 +72,7 @@ func TestHostResolution(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			svc := &Service{cfg: config.RegistryConfig{Host: tc.envHost}, settings: baseDomain(tc.base)}
+			svc := &Service{cfg: config.RegistryConfig{Host: tc.envHost}, external: baseDomain(tc.base)}
 			st := &models.RegistrySettings{Host: tc.storedHost}
 			svc.applyEnvConfig(st)
 			if got := svc.HostFor(st); got != tc.wantHost {
@@ -96,7 +91,7 @@ func TestHostResolution(t *testing.T) {
 func TestEnvPinnedFieldsBeatStoredValues(t *testing.T) {
 	svc := &Service{
 		cfg:      config.RegistryConfig{Enabled: false, EnabledSet: true, Host: "registry.env.test", StorageType: "filesystem"},
-		settings: baseDomain(""),
+		external: baseDomain(""),
 	}
 	st := &models.RegistrySettings{Enabled: true, Host: "registry.stale.test", StorageType: models.RegistryStorageS3}
 	svc.applyEnvConfig(st)
@@ -118,7 +113,7 @@ func TestEnvPinnedFieldsBeatStoredValues(t *testing.T) {
 
 // With nothing in the environment, every field is the console's to set.
 func TestNothingIsLockedWithoutEnv(t *testing.T) {
-	svc := &Service{cfg: config.RegistryConfig{}, settings: baseDomain("")}
+	svc := &Service{cfg: config.RegistryConfig{}, external: baseDomain("")}
 	if locks := svc.Locks(); locks.Any() {
 		t.Errorf("Locks = %+v, want nothing pinned", locks)
 	}

--- a/internal/services/registryserver/ref_test.go
+++ b/internal/services/registryserver/ref_test.go
@@ -88,16 +88,12 @@ func TestResolveImageRefFailsClosedWithoutWorkspaceFinder(t *testing.T) {
 // With no registry host there is no internal registry to cross into, so every
 // reference is external and passes through.
 func TestResolveImageRefWithoutHost(t *testing.T) {
-	svc := &Service{cfg: config.RegistryConfig{}, ws: wsFixture(), settings: noSettings{}}
+	svc := &Service{cfg: config.RegistryConfig{}, ws: wsFixture()}
 	got, err := svc.ResolveImageRef(7, "registry.example.com/ws_8/api:1")
 	if err != nil || got != "registry.example.com/ws_8/api:1" {
 		t.Fatalf("ref = (%q,%v), want the input unchanged", got, err)
 	}
 }
-
-type noSettings struct{}
-
-func (noSettings) String(_, def string) string { return def }
 
 func TestValidateImageRef(t *testing.T) {
 	svc := refService("registry.example.com")

--- a/internal/services/registryserver/registryserver.go
+++ b/internal/services/registryserver/registryserver.go
@@ -21,7 +21,6 @@ import (
 	"github.com/miabi-io/miabi/internal/proxy"
 	"github.com/miabi-io/miabi/internal/services/crypto"
 	"github.com/miabi-io/miabi/internal/services/platformimage"
-	"github.com/miabi-io/miabi/internal/services/settings"
 	"github.com/miabi-io/miabi/internal/storage/repositories"
 	"gorm.io/gorm"
 )
@@ -37,7 +36,11 @@ const (
 
 type imageResolver interface{ Ref(key string) string }
 
-type settingsReader interface{ String(key, def string) string }
+// externalAccessReader resolves a cluster's external domain and certificate provider (satisfied by services/cluster).
+// The registry is published under the default cluster's.
+type externalAccessReader interface {
+	ExternalAccess(clusterID uint) (domain, provider string)
+}
 
 type keyVerifier interface {
 	Verify(plaintext string) (*models.APIKey, error)
@@ -59,7 +62,7 @@ type workspaceFinder interface {
 type Service struct {
 	repo     *repositories.RegistrySettingsRepository
 	images   imageResolver
-	settings settingsReader
+	external externalAccessReader
 	keys     keyVerifier
 	ws       workspaceFinder
 	proxy    proxy.Manager
@@ -103,7 +106,7 @@ func (s *Service) platformToken() string {
 func NewService(
 	repo *repositories.RegistrySettingsRepository,
 	images imageResolver,
-	settingsReader settingsReader,
+	external externalAccessReader,
 	keys keyVerifier,
 	ws workspaceFinder,
 	proxyMgr proxy.Manager,
@@ -112,7 +115,7 @@ func NewService(
 	cfg config.RegistryConfig,
 ) *Service {
 	return &Service{
-		repo: repo, images: images, settings: settingsReader, keys: keys, ws: ws,
+		repo: repo, images: images, external: external, keys: keys, ws: ws,
 		proxy: proxyMgr, reg: NewClient(fmt.Sprintf("http://%s:%d", Alias, Port)),
 		usage:   newUsageCache(),
 		network: network, controlURL: controlURL, cfg: cfg,
@@ -371,8 +374,8 @@ func (s *Service) StorageUnavailableReason(st *models.RegistrySettings) string {
 	return ""
 }
 
-// HostFor returns the effective registry hostname: MIABI_REGISTRY_HOST, else registry.<external-base-domain>,
-// else empty. Both candidates are validated — an unusable host resolves to "", so distribution reports
+// HostFor returns the effective registry hostname: MIABI_REGISTRY_HOST, else registry.<default cluster's external
+// domain>, else empty. Both candidates are validated — an unusable host resolves to "", so distribution reports
 // itself unavailable with a reason rather than silently failing to match any image reference.
 func (s *Service) HostFor(st *models.RegistrySettings) string {
 	if host := s.envHost(); host != "" {
@@ -384,16 +387,16 @@ func (s *Service) HostFor(st *models.RegistrySettings) string {
 	if host, err := NormalizeHost(st.Host); err == nil && host != "" {
 		return host
 	}
-	if s.settings == nil {
+	if s.external == nil {
 		return ""
 	}
-	base := strings.TrimSpace(s.settings.String(settings.KeyExternalBaseDomain, ""))
-	if base == "" {
+	base, _ := s.external.ExternalAccess(models.DefaultClusterID)
+	if base = strings.TrimSpace(base); base == "" {
 		return ""
 	}
 	host, err := NormalizeHost("registry." + base)
 	if err != nil {
-		logger.Error("registry: external base domain does not yield a usable registry host", "base_domain", base, "error", err)
+		logger.Error("registry: the default cluster's external domain does not yield a usable registry host", "base_domain", base, "error", err)
 		return ""
 	}
 	return host
@@ -502,7 +505,7 @@ func (s *Service) Ensure(ctx context.Context, dc docker.Client) error {
 		// The container can run, but nothing can reach it: the gateway route below
 		// is what terminates TLS and enforces forwardAuth, and it needs a hostname.
 		// Say so plainly — otherwise the only symptom is pulls failing on nodes.
-		logger.Error("internal registry is enabled but has no usable hostname — set MIABI_REGISTRY_HOST or an external base domain and restart; no gateway route will be published")
+		logger.Error("internal registry is enabled but has no usable hostname — set MIABI_REGISTRY_HOST or the default cluster's external domain; no gateway route is published until then")
 	}
 	if err := s.startContainer(ctx, dc, st, false); err != nil {
 		return err
@@ -679,13 +682,37 @@ func (s *Service) authURL() string {
 	return base + "/internal/registry/auth"
 }
 
+// SyncGateway re-publishes the registry's gateway route, so a change to the default cluster's external domain or
+// certificate provider takes effect without a restart.
+func (s *Service) SyncGateway(ctx context.Context) error {
+	if s.proxy == nil {
+		return nil
+	}
+	st, err := s.Get()
+	if err != nil {
+		return err
+	}
+	if !st.Enabled || s.StorageUnavailableReason(st) != "" {
+		return nil
+	}
+	return s.proxy.SyncRegistry(ctx, s.proxyConfig(st, true))
+}
+
+func (s *Service) certProvider() string {
+	if s.external == nil {
+		return ""
+	}
+	_, provider := s.external.ExternalAccess(models.DefaultClusterID)
+	return provider
+}
+
 func (s *Service) proxyConfig(st *models.RegistrySettings, enabled bool) proxy.RegistryProxy {
 	return proxy.RegistryProxy{
 		Enabled:     enabled,
 		Host:        s.HostFor(st),
 		Upstream:    fmt.Sprintf("http://%s:%d", Alias, Port),
 		AuthURL:     s.authURL(),
-		TLSProvider: s.settings.String(settings.KeyExternalBaseProvider, ""),
+		TLSProvider: s.certProvider(),
 		// Off only for an install behind a TLS terminator with no trusted proxies
 		// configured on the gateway, where the redirect would loop.
 		HTTPSRedirect: s.cfg.HTTPSRedirect,

--- a/internal/services/registryserver/storagelock_test.go
+++ b/internal/services/registryserver/storagelock_test.go
@@ -185,7 +185,7 @@ func TestDistributionReportsUnlicensedStorage(t *testing.T) {
 	svc := &Service{
 		ee:       unlicensed(),
 		cfg:      config.RegistryConfig{Enabled: true, EnabledSet: true, Host: "registry.example.com", StorageType: "s3", S3Bucket: "b"},
-		settings: baseDomain(""),
+		external: baseDomain(""),
 	}
 	reason := svc.DistributionUnavailableReason()
 	if !strings.Contains(reason, "Enterprise license") {

--- a/internal/services/route/external_access.go
+++ b/internal/services/route/external_access.go
@@ -10,19 +10,30 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/jkaninda/logger"
 	"github.com/miabi-io/miabi/internal/models"
 	"github.com/miabi-io/miabi/internal/slug"
 )
 
 // ErrExternalAccessDisabled is returned when one-click external access is used
-// before an admin configures the wildcard base domain.
-var ErrExternalAccessDisabled = errors.New("external access is not configured (an admin must set the base domain in platform settings)")
+// in a cluster that has no external domain.
+var ErrExternalAccessDisabled = errors.New("external access is off in this app's location (a platform admin sets the cluster's external domain)")
 
-// ExternalConfig is the platform-level external-access config (from settings):
-// the wildcard base domain and the certManager provider for generated routes.
-type ExternalConfig struct {
-	BaseDomain string
-	Provider   string
+// ExternalDomains resolves the wildcard domain and certManager provider for generated routes in a cluster.
+// Implemented by services/cluster.
+type ExternalDomains interface {
+	ExternalAccess(clusterID uint) (domain, provider string)
+}
+
+// SetExternalDomains wires per-cluster external access; unset, external access is off everywhere.
+func (s *Service) SetExternalDomains(d ExternalDomains) { s.external = d }
+
+func (s *Service) externalConfig(app *models.Application) (base, provider string) {
+	if s.external == nil {
+		return "", ""
+	}
+	base, provider = s.external.ExternalAccess(app.ClusterID)
+	return sanitizeBase(base), provider
 }
 
 // ExternalPort is one exposed container port and its generated public URL.
@@ -34,21 +45,21 @@ type ExternalPort struct {
 
 // ExternalAccess is an app's external-access state for the UI.
 type ExternalAccess struct {
-	Enabled    bool           `json:"enabled"` // base domain configured platform-wide
+	Enabled    bool           `json:"enabled"` // the app's cluster has an external domain
 	BaseDomain string         `json:"base_domain"`
 	Label      string         `json:"label"`
 	Ports      []ExternalPort `json:"ports"` // currently exposed ports
 }
 
-// GetExternalAccess reports an app's external-access state: whether the feature
-// is enabled, its subdomain label, and the ports currently exposed (derived from
-// the app's generated routes).
-func (s *Service) GetExternalAccess(workspaceID, appID uint, cfg ExternalConfig) (*ExternalAccess, error) {
+// GetExternalAccess reports an app's external-access state: whether its cluster
+// has an external domain, its subdomain label, and the ports currently exposed
+// (derived from the app's generated routes).
+func (s *Service) GetExternalAccess(workspaceID, appID uint) (*ExternalAccess, error) {
 	app, err := s.apps.FindInWorkspace(workspaceID, appID)
 	if err != nil {
 		return nil, ErrAppRequired
 	}
-	base := sanitizeBase(cfg.BaseDomain)
+	base, _ := s.externalConfig(app)
 	// Non-nil so the JSON is [] (not null) when no ports are exposed.
 	out := &ExternalAccess{Enabled: base != "", BaseDomain: base, Label: app.ExternalLabel, Ports: []ExternalPort{}}
 	if out.Label == "" {
@@ -74,9 +85,10 @@ func (s *Service) GetExternalAccess(workspaceID, appID uint, cfg ExternalConfig)
 }
 
 // SetExternalAccess reconciles the app's exposed ports: it generates a managed Route per selected port
-// (host `<label>[-<port>].<base>`, HTTPS via the configured certManager provider) and removes generated
-// routes for ports no longer selected. The primary port gets the bare `<label>.<base>` host. Idempotent.
-func (s *Service) SetExternalAccess(ctx context.Context, workspaceID, appID uint, ports []int, cfg ExternalConfig) (*ExternalAccess, error) {
+// (host `<label>[-<port>].<base>` under the app's cluster domain, HTTPS via the cluster's certManager provider) and
+// removes generated routes for ports no longer selected. The primary port gets the bare `<label>.<base>` host.
+// Idempotent.
+func (s *Service) SetExternalAccess(ctx context.Context, workspaceID, appID uint, ports []int) (*ExternalAccess, error) {
 	app, err := s.apps.FindInWorkspace(workspaceID, appID)
 	if err != nil {
 		return nil, ErrAppRequired
@@ -87,7 +99,7 @@ func (s *Service) SetExternalAccess(ctx context.Context, workspaceID, appID uint
 			want[p] = true
 		}
 	}
-	base := sanitizeBase(cfg.BaseDomain)
+	base, provider := s.externalConfig(app)
 	// Exposing requires a base domain; disabling (no ports) must always proceed so the generated
 	// routes can be cleaned up even if the base domain was later cleared.
 	if len(want) > 0 {
@@ -124,7 +136,7 @@ func (s *Service) SetExternalAccess(ctx context.Context, workspaceID, appID uint
 		if rt, ok := existing[p]; ok {
 			rt.Hosts = []string{host}
 			rt.TLSMode = models.RouteTLSACME
-			rt.TLSProvider = cfg.Provider
+			rt.TLSProvider = provider
 			rt.Generated = true
 			rt.Enabled = true
 			if err := s.routes.Update(rt); err != nil {
@@ -136,7 +148,7 @@ func (s *Service) SetExternalAccess(ctx context.Context, workspaceID, appID uint
 			WorkspaceID: workspaceID, ApplicationID: appID,
 			Name: fmt.Sprintf("mb-ext-%d-%d", appID, p), Path: "/",
 			Hosts: []string{host}, TargetPort: p,
-			TLSMode: models.RouteTLSACME, TLSProvider: cfg.Provider,
+			TLSMode: models.RouteTLSACME, TLSProvider: provider,
 			Generated: true, Enabled: true,
 		}
 		if err := s.routes.Create(rt); err != nil {
@@ -152,7 +164,40 @@ func (s *Service) SetExternalAccess(ctx context.Context, workspaceID, appID uint
 	// SyncRoute re-renders the workspace file from the current DB state, so deleted
 	// generated routes drop out and newly-created ones appear together.
 	_ = s.SyncRoute(ctx, appID)
-	return s.GetExternalAccess(workspaceID, appID, cfg)
+	return s.GetExternalAccess(workspaceID, appID)
+}
+
+// RehostCluster moves the generated URLs of every app in a cluster onto the cluster's current external domain and
+// certificate provider, or removes them when the cluster no longer has a domain. Other routes are left alone.
+func (s *Service) RehostCluster(ctx context.Context, clusterID uint) {
+	apps, err := s.apps.ListByCluster(clusterID)
+	if err != nil {
+		logger.Error("re-host generated URLs: listing the cluster's apps failed", "cluster", clusterID, "error", err)
+		return
+	}
+	for i := range apps {
+		app := &apps[i]
+		routes, err := s.routes.ListByApp(app.ID)
+		if err != nil {
+			logger.Warn("re-host generated URLs: listing routes failed", "app", app.ID, "error", err)
+			continue
+		}
+		var ports []int
+		for _, rt := range routes {
+			if rt.Generated {
+				ports = append(ports, rt.TargetPort)
+			}
+		}
+		if len(ports) == 0 {
+			continue
+		}
+		if base, _ := s.externalConfig(app); base == "" {
+			ports = nil
+		}
+		if _, err := s.SetExternalAccess(ctx, app.WorkspaceID, app.ID, ports); err != nil {
+			logger.Warn("re-host generated URLs failed", "app", app.ID, "error", err)
+		}
+	}
 }
 
 // defaultExternalLabel derives a stable, DNS-safe subdomain label for an app:

--- a/internal/services/route/route.go
+++ b/internal/services/route/route.go
@@ -98,6 +98,7 @@ type Service struct {
 	dnsAddr     DNSAddresser
 	reloader    EdgeReloader
 	cluster     ClusterCap
+	external    ExternalDomains
 }
 
 // ClusterCap reports whether a gateway of its own serves a cluster. Implemented by services/cluster.

--- a/internal/services/settings/provider.go
+++ b/internal/services/settings/provider.go
@@ -42,12 +42,6 @@ const (
 	KeyMaxCPUCores = "max_cpu_cores"
 	KeyMaxMemoryMB = "max_memory_mb"
 
-	// KeyExternalBaseDomain is the wildcard base domain for one-click external access (e.g. "apps.example.com",
-	// DNS *.apps.example.com); empty means off. KeyExternalBaseProvider names the Goma certManager provider used
-	// for the generated routes, with "" meaning the gateway's default provider.
-	KeyExternalBaseDomain   = "external_base_domain"
-	KeyExternalBaseProvider = "external_base_provider"
-
 	// KeyCustomLabelsEnabled is the fleet-wide kill-switch for user-defined Docker labels on app containers. When
 	// false, custom labels are disabled everywhere regardless of any plan capability; when true, the per-plan
 	// AllowCustomLabels capability decides. Default true.
@@ -71,8 +65,6 @@ var defaults = []models.Setting{
 	{Key: KeyAuditLogRetentionDays, Value: "90", Type: models.SettingTypeInt},
 	{Key: KeyMaxCPUCores, Value: "0", Type: models.SettingTypeInt},
 	{Key: KeyMaxMemoryMB, Value: "0", Type: models.SettingTypeInt},
-	{Key: KeyExternalBaseDomain, Value: "", Type: models.SettingTypeString},
-	{Key: KeyExternalBaseProvider, Value: "", Type: models.SettingTypeString},
 	{Key: KeyCustomLabelsEnabled, Value: "true", Type: models.SettingTypeBool},
 	{Key: KeyRepoPipelinesEnabled, Value: "true", Type: models.SettingTypeBool},
 }
@@ -117,7 +109,7 @@ func (p *Provider) seed(envOverrides map[string]string) {
 		}
 	}
 	// Env-provided values win: force them on every boot so a key like
-	// external_base_domain can be set from the environment (12-factor) rather than
+	// allowed_signup_domains can be set from the environment (12-factor) rather than
 	// only the admin UI. Empty values are ignored (the key stays admin-managed).
 	var forced []models.Setting
 	for key, val := range envOverrides {

--- a/internal/storage/migration/upgrade/steps_2026_09_12_external_access.go
+++ b/internal/storage/migration/upgrade/steps_2026_09_12_external_access.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package upgrade
+
+import (
+	"context"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+var externalAccessSettingKeys = map[string]string{
+	"external_base_domain":   "external_base_domain",
+	"external_base_provider": "external_cert_provider",
+}
+
+// externalAccessStep moves one-click external access from platform settings onto the default cluster, now that
+// every cluster keeps its own domain. Generated URLs keep their hosts. A field the cluster already has is kept, so
+// the step is safe to re-run.
+func externalAccessStep(ctx context.Context, db *gorm.DB) error {
+	if !db.Migrator().HasTable("clusters") || !db.Migrator().HasColumn("clusters", "external_base_domain") {
+		return nil
+	}
+	keys := make([]string, 0, len(externalAccessSettingKeys))
+	for key := range externalAccessSettingKeys {
+		keys = append(keys, key)
+	}
+	return db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var rows []struct {
+			Key   string
+			Value string
+		}
+		if err := tx.Table("settings").Select("key, value").Where("key IN ?", keys).Find(&rows).Error; err != nil {
+			return err
+		}
+		for _, row := range rows {
+			value := strings.TrimSpace(row.Value)
+			if value == "" {
+				continue
+			}
+			if row.Key == "external_base_domain" {
+				value = strings.ToLower(strings.TrimPrefix(strings.TrimPrefix(value, "*."), "."))
+			}
+			def, err := ensureDefaultCluster(tx)
+			if err != nil {
+				return err
+			}
+			col := externalAccessSettingKeys[row.Key]
+			err = tx.Table("clusters").Where("id = ? AND ("+col+" IS NULL OR "+col+" = '')", def.ID).Update(col, value).Error
+			if err != nil {
+				return err
+			}
+		}
+		return tx.Exec(`DELETE FROM settings WHERE key IN ?`, keys).Error
+	})
+}
+
+func init() {
+	steps = append(steps, Step{
+		Name:    "external_access_per_cluster",
+		Version: "1.10.0",
+		Run:     externalAccessStep,
+	})
+}

--- a/internal/storage/migration/upgrade/steps_2026_09_12_external_access_test.go
+++ b/internal/storage/migration/upgrade/steps_2026_09_12_external_access_test.go
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package upgrade
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type externalClusterFixture struct {
+	ID                   uint `gorm:"primaryKey"`
+	Name                 string
+	IsDefault            bool
+	Mode                 string
+	Visibility           string
+	ExternalBaseDomain   string
+	ExternalCertProvider string
+}
+
+func (externalClusterFixture) TableName() string { return "clusters" }
+
+func newExternalAccessDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&clusterRow{}, &externalClusterFixture{}, &serverFixture{}, &clusterSettingFixture{}); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func TestExternalAccessMovesOntoTheDefaultCluster(t *testing.T) {
+	db := newExternalAccessDB(t)
+	for _, row := range []any{
+		&externalClusterFixture{ID: 1, Name: "default", IsDefault: true, Mode: "standalone", Visibility: "all"},
+		&externalClusterFixture{ID: 2, Name: "paris", Mode: "standalone", Visibility: "all"},
+		&clusterSettingFixture{Key: "external_base_domain", Value: " *.Apps.Example.com "},
+		&clusterSettingFixture{Key: "external_base_provider", Value: "letsencrypt"},
+		&clusterSettingFixture{Key: "maintenance_mode", Value: "false"},
+	} {
+		if err := db.Create(row).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := externalAccessStep(context.Background(), db); err != nil {
+		t.Fatalf("step: %v", err)
+	}
+
+	var clusters []externalClusterFixture
+	if err := db.Order("id").Find(&clusters).Error; err != nil {
+		t.Fatal(err)
+	}
+	if def := clusters[0]; def.ExternalBaseDomain != "apps.example.com" || def.ExternalCertProvider != "letsencrypt" {
+		t.Errorf("default cluster = %+v, want apps.example.com with letsencrypt", def)
+	}
+	if other := clusters[1]; other.ExternalBaseDomain != "" || other.ExternalCertProvider != "" {
+		t.Errorf("another cluster took the platform domain: %+v", other)
+	}
+	var keys []string
+	if err := db.Model(&clusterSettingFixture{}).Pluck("key", &keys).Error; err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(keys, []string{"maintenance_mode"}) {
+		t.Errorf("settings left = %v, want only maintenance_mode", keys)
+	}
+
+	if err := db.Create(&clusterSettingFixture{Key: "external_base_domain", Value: "other.example.com"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := externalAccessStep(context.Background(), db); err != nil {
+		t.Fatalf("re-run: %v", err)
+	}
+	var def externalClusterFixture
+	if err := db.First(&def, 1).Error; err != nil {
+		t.Fatal(err)
+	}
+	if def.ExternalBaseDomain != "apps.example.com" {
+		t.Errorf("re-run replaced the cluster's domain with %q", def.ExternalBaseDomain)
+	}
+}
+
+func TestExternalAccessStepWithNothingConfigured(t *testing.T) {
+	db := newExternalAccessDB(t)
+	if err := db.Create(&clusterSettingFixture{Key: "external_base_domain", Value: ""}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := externalAccessStep(context.Background(), db); err != nil {
+		t.Fatalf("step: %v", err)
+	}
+	var clusters, settings int64
+	db.Model(&externalClusterFixture{}).Count(&clusters)
+	db.Model(&clusterSettingFixture{}).Count(&settings)
+	if clusters != 0 || settings != 0 {
+		t.Errorf("clusters = %d, settings = %d; want no cluster created and the empty setting removed", clusters, settings)
+	}
+}

--- a/internal/storage/repositories/cluster_repo.go
+++ b/internal/storage/repositories/cluster_repo.go
@@ -87,6 +87,16 @@ func (r *ClusterRepository) CountWorkloads(clusterID uint) (int64, error) {
 	return r.countPlaced("cluster_id", clusterID)
 }
 
+// CountExternalApps counts the apps in a cluster holding generated external-access routes.
+func (r *ClusterRepository) CountExternalApps(clusterID uint) (int64, error) {
+	var n int64
+	err := r.db.Model(&models.Route{}).
+		Joins("JOIN applications ON applications.id = routes.application_id").
+		Where("routes.generated = ? AND applications.cluster_id = ?", true, clusterID).
+		Distinct("routes.application_id").Count(&n).Error
+	return n, err
+}
+
 // CountServerWorkloadsByKind counts the apps, database instances and volumes placed on a node, each on its own.
 func (r *ClusterRepository) CountServerWorkloadsByKind(serverID uint) (apps, databases, volumes int64, err error) {
 	var counts [3]int64

--- a/internal/storage/repositories/cluster_repo_test.go
+++ b/internal/storage/repositories/cluster_repo_test.go
@@ -31,9 +31,20 @@ type clusterTable struct {
 	LegacyIngress   bool
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
+
+	ExternalBaseDomain   string
+	ExternalCertProvider string
 }
 
 func (clusterTable) TableName() string { return "clusters" }
+
+type clusterRouteTable struct {
+	ID            uint `gorm:"primaryKey"`
+	ApplicationID uint
+	Generated     bool
+}
+
+func (clusterRouteTable) TableName() string { return "routes" }
 
 type clusterServerTable struct {
 	ID        uint `gorm:"primaryKey"`
@@ -66,6 +77,32 @@ func newClusterRepo(t *testing.T) (*ClusterRepository, *gorm.DB) {
 		}
 	}
 	return NewClusterRepository(db), db
+}
+
+// The count drives the confirmation before a domain change, so an app is counted once however many URLs it has.
+func TestCountExternalAppsCountsAppsWithGeneratedRoutes(t *testing.T) {
+	repo, db := newClusterRepo(t)
+	if err := db.AutoMigrate(&clusterRouteTable{}); err != nil {
+		t.Fatal(err)
+	}
+	for _, app := range []clusterPlacedTable{{ID: 1, ClusterID: 3}, {ID: 2, ClusterID: 3}, {ID: 3, ClusterID: 4}} {
+		if err := db.Table("applications").Create(&app).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, rt := range []clusterRouteTable{
+		{ID: 1, ApplicationID: 1, Generated: true},
+		{ID: 2, ApplicationID: 1, Generated: true},
+		{ID: 3, ApplicationID: 2},
+		{ID: 4, ApplicationID: 3, Generated: true},
+	} {
+		if err := db.Create(&rt).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	if n, err := repo.CountExternalApps(3); err != nil || n != 1 {
+		t.Errorf("cluster 3 = %d, %v; want 1 (one app with two generated URLs, one with only a custom route)", n, err)
+	}
 }
 
 func TestJoiningTheDefaultClusterMovesANodeAndItsWorkloads(t *testing.T) {

--- a/web/src/api/clusters.ts
+++ b/web/src/api/clusters.ts
@@ -6,6 +6,8 @@ export interface ClusterUpdate {
   location_code?: string
   visibility?: Cluster['visibility']
   cordoned?: boolean
+  external_base_domain?: string
+  external_cert_provider?: string
 }
 
 export interface ConvertIngressInput {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -1943,6 +1943,11 @@ export interface Cluster {
   visibility: 'all' | 'restricted'
   cordoned: boolean
   legacy_ingress: boolean
+  external_base_domain?: string
+  external_cert_provider?: string
+  external_domain_pinned?: boolean
+  external_provider_pinned?: boolean
+  external_apps?: number
   node_count: number
   created_at?: string
   updated_at?: string

--- a/web/src/views/admin/ClusterDetail.vue
+++ b/web/src/views/admin/ClusterDetail.vue
@@ -51,18 +51,52 @@ onMounted(load)
 
 const showEdit = ref(false)
 const saving = ref(false)
-const editForm = ref({ display_name: '', location_code: '', visibility: 'all' as Cluster['visibility'], cordoned: false })
+const editForm = ref({
+  display_name: '', location_code: '', visibility: 'all' as Cluster['visibility'], cordoned: false,
+  external_base_domain: '', external_cert_provider: '',
+})
 function openEdit() {
   editForm.value = {
     display_name: cluster.value?.display_name ?? '',
     location_code: cluster.value?.location_code ?? '',
     visibility: cluster.value?.visibility ?? 'all',
     cordoned: cluster.value?.cordoned ?? false,
+    external_base_domain: cluster.value?.external_base_domain ?? '',
+    external_cert_provider: cluster.value?.external_cert_provider ?? '',
   }
   showEdit.value = true
 }
-async function saveEdit() {
+
+function normalizeDomain(domain: string) {
+  return domain.trim().toLowerCase().replace(/^\*\./, '').replace(/^\.|\.$/g, '')
+}
+const editDomain = computed(() => normalizeDomain(editForm.value.external_base_domain))
+const dnsTarget = computed(() =>
+  cluster.value?.ingress_hostname || cluster.value?.ingress_ip || ingressNode.value?.public_hostname || ingressNode.value?.public_ip || '',
+)
+// Moving or clearing the domain changes URLs people already use, so it is confirmed with the number of apps affected.
+const confirmRehost = ref(false)
+const rehostMessage = computed(() => {
+  const n = cluster.value?.external_apps ?? 0
+  const apps = n === 1 ? '1 app has' : `${n} apps have`
+  const from = `*.${cluster.value?.external_base_domain}`
+  return editDomain.value
+    ? `${apps} generated URLs under ${from}. They move to *.${editDomain.value}, and the old URLs stop working. Custom domains are not affected.`
+    : `${apps} generated URLs under ${from}. They are removed, and those apps stop answering on them. Custom domains are not affected.`
+})
+
+function saveEdit() {
+  const c = cluster.value
+  if (!c) return
+  if ((c.external_apps ?? 0) > 0 && editDomain.value !== (c.external_base_domain ?? '')) {
+    confirmRehost.value = true
+    return
+  }
+  void persistEdit()
+}
+async function persistEdit() {
   if (!cluster.value) return
+  confirmRehost.value = false
   saving.value = true
   try {
     cluster.value = (await clustersApi.update(cluster.value.id, {
@@ -70,6 +104,8 @@ async function saveEdit() {
       location_code: editForm.value.location_code.trim(),
       visibility: editForm.value.visibility,
       cordoned: editForm.value.cordoned,
+      external_base_domain: editForm.value.external_base_domain.trim(),
+      external_cert_provider: editForm.value.external_cert_provider.trim(),
     })).data.data
     showEdit.value = false
     notify.success('Cluster updated')
@@ -450,6 +486,12 @@ function swarmClass(n: Server): string {
             {{ cluster.visibility === 'restricted' ? 'Platform admins only' : 'All workspaces' }}
             <span v-if="cluster.cordoned" class="badge badge-warning">cordoned</span>
           </dd>
+          <dt>External access</dt>
+          <dd>
+            <span v-if="cluster.external_base_domain" class="mono">*.{{ cluster.external_base_domain }}</span>
+            <span v-else class="text-muted">Off</span>
+            <span v-if="cluster.external_domain_pinned" class="badge badge-muted">set by environment</span>
+          </dd>
         </dl>
         <div v-if="needsIngress" class="pending-hint">
           <span class="mdi mdi-alert-outline"></span>
@@ -632,9 +674,38 @@ function swarmClass(n: Server): string {
                 <option value="restricted">Platform admins only</option>
               </select>
             </div>
-            <div class="form-group" style="margin-bottom: 0">
+            <div class="form-group">
               <label class="form-label"><input v-model="editForm.cordoned" type="checkbox" /> Cordoned</label>
               <p class="form-hint">No new apps, databases or volumes land here; running ones stay.</p>
+            </div>
+            <div class="form-group">
+              <label class="form-label">External domain</label>
+              <input
+                v-model="editForm.external_base_domain"
+                class="form-input mono"
+                placeholder="e.g. apps.eu-central.example.com"
+                :disabled="cluster?.external_domain_pinned"
+              />
+              <p v-if="editDomain" class="form-hint">
+                Point <code>*.{{ editDomain }}</code> at <code v-if="dnsTarget">{{ dnsTarget }}</code><template v-else>this cluster's gateway</template>.
+                Apps here get one-click URLs under it.
+              </p>
+              <p v-else class="form-hint">Empty turns one-click external access off in this location. Custom domains still work.</p>
+              <p v-if="cluster?.external_domain_pinned" class="form-hint">Set by environment (MIABI_EXTERNAL_BASE_DOMAIN).</p>
+            </div>
+            <div class="form-group" style="margin-bottom: 0">
+              <label class="form-label">Certificate provider</label>
+              <input
+                v-model="editForm.external_cert_provider"
+                class="form-input mono"
+                placeholder="Gateway default"
+                :disabled="cluster?.external_provider_pinned"
+              />
+              <p class="form-hint">
+                {{ cluster?.external_provider_pinned
+                  ? 'Set by environment (MIABI_EXTERNAL_BASE_PROVIDER).'
+                  : 'The gateway certManager provider for generated URLs. Empty uses its default.' }}
+              </p>
             </div>
           </div>
           <div class="modal-footer">
@@ -903,6 +974,17 @@ function swarmClass(n: Server): string {
         </form>
       </AppModal>
     </Teleport>
+
+    <ConfirmDialog
+      :open="confirmRehost"
+      :title="editDomain ? 'Move generated URLs?' : 'Remove generated URLs?'"
+      :message="rehostMessage"
+      :confirm-label="editDomain ? 'Move URLs' : 'Remove URLs'"
+      variant="danger"
+      :busy="saving"
+      @confirm="persistEdit"
+      @cancel="confirmRehost = false"
+    />
 
     <ConfirmDialog
       :open="showRemoveAgents"

--- a/web/src/views/admin/Registry.vue
+++ b/web/src/views/admin/Registry.vue
@@ -60,9 +60,9 @@ const envManaged = computed(() => Object.values(locks.value).some(Boolean))
 const hostOrigin = computed(() => {
   switch (hostSource.value) {
     case 'env': return 'Pinned by MIABI_REGISTRY_HOST.'
-    case 'base_domain': return 'Derived from the external base domain (registry.<domain>) — set a host here to override it.'
+    case 'base_domain': return 'Derived from the external domain of the default cluster (registry.<domain>) — set a host here to override it.'
     case 'stored': return 'Set here.'
-    default: return 'No usable hostname yet — set one here, or configure an external base domain.'
+    default: return 'No usable hostname yet — set one here, or set an external domain on the default cluster.'
   }
 })
 

--- a/web/src/views/admin/Settings.vue
+++ b/web/src/views/admin/Settings.vue
@@ -137,15 +137,6 @@ const SECTIONS: SectionDef[] = [
       max_memory_mb: 'Max memory per app, MB (0 = unlimited)',
     },
   },
-  {
-    id: 'external-access',
-    title: 'External access',
-    keys: ['external_base_domain', 'external_base_provider'],
-    labels: {
-      external_base_domain: 'External base domain (wildcard, e.g. apps.example.com — point *.<domain> at the gateway)',
-      external_base_provider: 'Cert provider for generated routes (blank = gateway default)',
-    },
-  },
 ]
 
 // System-managed keys: shown read-only, never editable, and excluded from saves.

--- a/web/src/views/apps/AppDetail.vue
+++ b/web/src/views/apps/AppDetail.vue
@@ -2249,8 +2249,8 @@ async function detachDatabase(d: AppDatabase) {
         <div class="card-body">
           <template v-if="extAccess && !extAccess.enabled">
             <p class="text-muted text-sm" style="margin-top: 0">
-              Expose this app on the internet with an auto-generated URL. An admin must first set the
-              <strong>external base domain</strong> in platform settings.
+              Expose this app on the internet with an auto-generated URL. External access is off in this app's
+              location: a platform admin must first set the location's <strong>external domain</strong> on its cluster.
             </p>
           </template>
           <template v-else-if="extAccess">


### PR DESCRIPTION
One-click external access is now set per cluster instead of platform-wide. Each cluster has its own external domain and certificate provider, edited in its Edit dialog. An app's generated URL uses its own cluster's domain, from the console and from manifest externalAccess alike. A cluster without a domain has external access off.